### PR TITLE
Clarify project scope and workflow in PLAN

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4,6 +4,18 @@ This is a mobile-first, Codex-driven workflow for a 2D space shooter built using
 
 _Note: This is a small, single-person project. Keep the scope lean and treat advanced topics like multiplayer or backend sync as long-term goals._
 
+## 📋 Goals & Non-Goals
+
+**Goals**
+- Build a simple offline 2D space shooter with Flutter and Flame.
+- Support PWA install and touch controls.
+- Keep the codebase easy to read for one developer.
+
+**Non-Goals**
+- No analytics, accounts, or complex backend.
+- Multiplayer and native builds are future ideas only.
+- Avoid heavy tooling or project management overhead.
+
 ---
 
 ## ✅ Master Checklist
@@ -174,7 +186,7 @@ Choose one:
 
 ### 🛠 12. Game Features – Dev Plan
 
-Break into Codex prompts and commits:
+Break into Codex prompts and commits. Tackle one feature at a time and test manually after each change:
 
 - [ ] Ship movement with rotation + thrust
 - [ ] Touch or joystick controls


### PR DESCRIPTION
## Summary
- add explicit Goals & Non-Goals to keep project scope lean
- note to tackle features one at a time and test manually

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68958fe4b1f88330bfc89987d9d2913d