### PR TITLE
Refine project plan with lightweight guidance

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4,17 +4,21 @@ This is a mobile-first, Codex-driven workflow for a 2D space shooter built using
 
 _Note: This is a small, single-person project. Keep the scope lean and treat advanced topics like multiplayer or backend sync as long-term goals._
 
+Keep this plan lightweight and revisit it as progress is made. Check off tasks when they are done and trim or defer anything that feels unnecessary for a solo developer.
+
 ## 📋 Goals & Non-Goals
 
 **Goals**
 - Build a simple offline 2D space shooter with Flutter and Flame.
 - Support PWA install and touch controls.
 - Keep the codebase easy to read for one developer.
+- Ship a playable prototype quickly and iterate.
 
 **Non-Goals**
 - No analytics, accounts, or complex backend.
 - Multiplayer and native builds are future ideas only.
 - Avoid heavy tooling or project management overhead.
+- No elaborate asset pipeline; placeholder art and sounds are fine early on.
 
 ---
 
@@ -32,6 +36,7 @@ _Note: This is a small, single-person project. Keep the scope lean and treat adv
 - [ ] Optional: Use GitHub Mobile + Replit or Termux for light editing
 - [x] Add `LICENSE` file (MIT)
 - [ ] Run `flutter create .` once the Flutter SDK is installed
+- [ ] Verify the generated app runs: `flutter run -d chrome`
 
 ---
 ### 🔢 2. Tooling & Versions
@@ -64,6 +69,11 @@ A fun, light-hearted space shooter with cute cartoony style. Casual tone, access
 - `SpaceGame` (`lib/space_game.dart`) extends `FlameGame`
 - Core components live in `lib/components/` (e.g., `player.dart`, `enemy.dart`, `asteroid.dart`, `bullet.dart`)
 - Keep classes small and state serializable to ease future multiplayer features
+
+#### 🔄 Game Flow
+
+- Simple loop: Main menu → gameplay → game over screen
+- Allow quick restart to encourage short play sessions
 
 ### 🎯 MVP Scope
 


### PR DESCRIPTION
## Summary
- clarify that the plan should stay lightweight and iterative for a solo developer
- note that placeholder assets are acceptable and add a step to verify the default Flutter app runs
- outline a simple menu → gameplay → game-over loop for the MVP

## Testing
- `dart format PLAN.md` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689591bd932c8330b1f26bdc713de645