### PR TITLE
docs: refine plan and design

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -21,19 +21,23 @@ Target is an offline PWA that a solo developer can iterate on quickly.
 - Keep the entire project understandable by one person
 - Prefer built‑in Flame and Flutter features over custom frameworks
 - Optimize for quick iteration and avoid unnecessary abstraction
+- Keep dependencies minimal—stick to core Flutter, Flame, and a few small plugins
 
 ## 🛠️ Setup
 
 ### Repository
 
 - Public GitHub repo `space-game`
-- Contains `README.md`, `.gitignore`, `LICENSE`, `AGENTS.md`,
-  `pubspec.yaml`, `.analysis_options.yaml`, `fvm_config.json`
+- Contains `README.md`, `.gitignore`, `LICENSE`, `AGENTS.md`, `fvm_config.json`,
+  `.analysis_options.yaml`
+- `pubspec.yaml` and Flutter source folders are generated after running
+  `fvm flutter create .`
 - `AGENTS.md` captures coding and architecture guidelines
 
 ### Flutter & FVM
 
 - `fvm install` then `fvm use` to fetch and activate the pinned Flutter SDK
+- `fvm flutter create .` once to scaffold the Flutter project
 - Flutter version is defined in `fvm_config.json` (currently `3.32.8`)
 - `fvm flutter doctor` then `fvm flutter pub get`
 - Enable web: `fvm flutter config --enable-web`
@@ -73,10 +77,9 @@ Target is an offline PWA that a solo developer can iterate on quickly.
 - On‑screen joystick and shoot button; WASD + Space mirror touch controls
 - States: **menu → playing → game over** with quick restart
 - Use a `GameState` enum to manage transitions
-- Centralize asset paths in an `Assets` helper that preloads sprites, audio and fonts
-  so gameplay code never references file paths directly
+- Centralize asset paths in an `Assets` helper that preloads sprites, audio and
+  fonts so gameplay code never references file paths directly
 - Favor small composable components over inheritance
-- Use a centralised asset registry; avoid hard-coded file paths
 - Keep Flutter UI widgets separate from game state updates
 - If saving is needed later, add IDs and JSON‑serializable state
 - Fixed logical resolution scaled to device for consistent gameplay
@@ -86,6 +89,8 @@ Target is an offline PWA that a solo developer can iterate on quickly.
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - Movement and animations should be time‑based using `dt` to stay consistent
   across frame rates
+- Store tunable values like speeds and spawn rates in constants for quick
+  balancing
 
 ## 🎮 MVP
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # 🚀 Space Miner PWA
 
-**Space Miner** is a mobile-first, Codex-assisted 2D space shooter where players fly around, mine asteroids, blast enemies and upgrade their ship — all built with **Flutter** and **Flame**.
+**Space Miner** is a mobile-first, Codex-assisted 2D space shooter where players
+fly around, mine asteroids, blast enemies and upgrade their ship — all built
+with **Flutter** and **Flame**.
 
-The aim is a light-hearted, cartoony game that runs smoothly on both mobile and desktop browsers using **Progressive Web App (PWA)** technology. You can install it straight from your browser and play offline with no app store required.
+The aim is a light-hearted, cartoony game that runs smoothly on both mobile and
+desktop browsers using **Progressive Web App (PWA)** technology. You can
+install it straight from your browser and play offline with no app store
+required.
 
-Multiplayer is planned as a simple host-authoritative co-op mode where one player simulates the world and others connect over the local network — no dedicated server or NAT traversal.
+Multiplayer is planned as a simple host-authoritative co-op mode where one
+player simulates the world and others connect over the local network — no
+dedicated server or NAT traversal.
 
 ---
 
@@ -15,6 +22,7 @@ Multiplayer is planned as a simple host-authoritative co-op mode where one playe
 - Fully playable on iOS/Android/PC via PWA
 - Fun, casual tone with cartoony visuals
 - Modular game logic built with Flame (pinned for stability)
+- Minimal dependencies to keep the project lightweight
 - Multiplayer-ready architecture (host based, offline first)
 - Simple CI/CD through GitHub Actions
 - Fully open-source and remixable
@@ -50,12 +58,16 @@ PLAYTEST_CHECKLIST.md   # Regression checklist
 playtest_logs/          # Logs from manual play sessions
 ```
 
-Additional docs such as `DESIGN.md`, `TASKS.md` and `networking.md` are planned but not yet created. See [PLAN.md](PLAN.md) for the full roadmap.
+Additional docs such as `DESIGN.md`, `TASKS.md` and `networking.md` are planned
+but not yet created. See [PLAN.md](PLAN.md) for the full roadmap.
 
 ---
 
 ## Flutter Version Management
 
-This repo uses [FVM](https://fvm.app/) to pin the Flutter SDK version. After cloning, run `fvm install` to download the SDK specified in `fvm_config.json`. Use `fvm flutter` in place of the global `flutter` command when building or running the game.
+This repo uses [FVM](https://fvm.app/) to pin the Flutter SDK version. After
+cloning, run `fvm install` to download the SDK specified in `fvm_config.json`.
+Use `fvm flutter` in place of the global `flutter` command when building or
+running the game.
 
 The project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- clarify project plan with minimal dependency guideline and simplified setup steps
- highlight lightweight dependency goal in README

## Testing
- `npx markdownlint-cli PLAN.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_6896c3e5b1888330b53ae70ffd66e3be