### PR TITLE
docs: add design and task docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,8 @@ lib/
 web/                    # PWA manifest, service worker
 .github/workflows/      # CI/CD configs
 ```
-Other docs: `PLAN.md`, `ASSET_GUIDE.md`, `ASSET_CREDITS.md`, `MANUAL_TESTING.md`, `PLAYTEST_CHECKLIST.md`, `playtest_logs/`.
+Other docs: `PLAN.md`, `DESIGN.md`, `TASKS.md`, `networking.md`, `ASSET_GUIDE.md`,
+`ASSET_CREDITS.md`, `MANUAL_TESTING.md`, `PLAYTEST_CHECKLIST.md`, `playtest_logs/`.
 
 ## 11. Testing & Observability
 - Use `flutter_test` for unit and widget tests; `flame_test` for component/system tests.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,39 @@
+# 🎮 Design Overview
+
+This document summarises the current architecture and design goals for Space Miner.
+See [PLAN.md](PLAN.md) for the authoritative roadmap.
+
+## Game Layers
+
+- `SpaceGame` extends `FlameGame`.
+- The Flame canvas hosts the world; Flutter overlays provide menus and HUD.
+- Systems manage input, collisions, spawning and game state transitions.
+- Assets load through a central `Assets` registry; gameplay code avoids file paths.
+
+## Components
+
+- Player, enemy, asteroid and bullet components live under `lib/components/`.
+- Components mix in `HasGameRef<SpaceGame>` when they need game context.
+- Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and `HasCollisionDetection`.
+
+## State and Data
+
+- Tunable numbers live in `constants.dart`.
+- Use immutable data objects and pass dependencies via constructors.
+- Local save data will use `shared_preferences` in the MVP.
+
+## Input
+
+- On-screen joystick and fire button mirror keyboard controls (WASD + Space).
+- Input handling stays isolated from rendering for easier testing.
+
+## Rendering & Camera
+
+- Fixed logical resolution scaled to the device.
+- Camera follows the player via `CameraComponent` and `FixedResolutionViewport`.
+- A parallax starfield provides the background.
+
+## PWA & Platform
+
+- Web-only Flutter app managed through FVM (`fvm flutter` commands).
+- `web/manifest.json` and the service worker enable installable offline play.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ PLAYTEST_CHECKLIST.md   # Regression checklist
 playtest_logs/          # Logs from manual play sessions
 ```
 
-Additional docs such as `DESIGN.md`, `TASKS.md` and `networking.md` are planned
-but not yet created. See [PLAN.md](PLAN.md) for the full roadmap.
+Further docs include `DESIGN.md` for architecture, `TASKS.md` for the backlog and
+`networking.md` for future multiplayer plans. See [PLAN.md](PLAN.md) for the full
+roadmap.
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,27 @@
+# ✅ Task List
+
+Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) for context.
+
+## Setup
+
+- [ ] Install FVM and fetch the pinned Flutter SDK.
+- [ ] Scaffold the Flutter project (`fvm flutter create .`) if not already.
+- [ ] Enable web support (`fvm flutter config --enable-web`).
+- [ ] Add Flame, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
+- [ ] Commit generated folders (`lib/`, `web/`, etc.).
+- [ ] Set up GitHub Actions workflow for lint, test and web deploy.
+- [ ] Document placeholder assets and credits.
+
+## Core Loop
+
+- [ ] Player ship moves with joystick or keyboard.
+- [ ] Ship can shoot and destroy a basic enemy type.
+- [ ] Random asteroids spawn and can be mined for score.
+- [ ] Game states: menu → playing → game over with restart.
+- [ ] Parallax starfield renders behind gameplay.
+
+## Polish
+
+- [ ] Sound effects via `flame_audio` with mute toggle.
+- [ ] Local high score using `shared_preferences`.
+- [ ] Simple HUD and menus layered with Flutter.

--- a/networking.md
+++ b/networking.md
@@ -1,0 +1,18 @@
+# 🌐 Networking (Future)
+
+Multiplayer is not part of the MVP but the design allows a
+host-authoritative model later.
+
+## Overview
+
+- One player simulates the world; others connect over local network WebSockets.
+- Actions are exchanged as JSON packets, e.g.
+  `{ "type": "move", "payload": {...} }`.
+- No NAT traversal or central server; peers connect via QR code or direct IP.
+
+## Goals
+
+- Reuse the same systems for offline and online play.
+- Keep protocol definitions in a shared module.
+
+This document will expand once multiplayer work begins.


### PR DESCRIPTION
## Summary
- add DESIGN.md outlining game layers and architecture
- track upcoming work items in TASKS.md and stub networking plan
- reference new docs from README and AGENTS

## Testing
- `npx markdownlint-cli '**/*.md'` *(fails: line length and other issues in existing docs)*
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689989c6ea848330a10ca721058643aa