### PR TITLE
docs: outline lib structure and game state flow

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,8 @@
 # 🎮 Design Overview
 
 This document summarises the current architecture and design goals for Space Miner.
-See [PLAN.md](PLAN.md) for the authoritative roadmap.
+See [PLAN.md](PLAN.md) for the authoritative roadmap and
+[lib/README.md](lib/README.md) for code layout details.
 
 ## Game Layers
 
@@ -21,6 +22,13 @@ See [PLAN.md](PLAN.md) for the authoritative roadmap.
 - Tunable numbers live in `constants.dart`.
 - Use immutable data objects and pass dependencies via constructors.
 - Local save data will use `shared_preferences` in the MVP.
+
+## Game State Flow
+
+- The game starts in a menu overlay.
+- `SpaceGame` transitions to `playing` when the user taps start.
+- On player death, a game over overlay appears with a restart button.
+- A `GameState` enum tracks the current phase.
 
 ## Input
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,23 @@
+# lib/ Directory Structure
+
+Source code lives under `lib/`. The folders listed here will be created when
+the Flutter project is scaffolded.
+
+## Top-Level Files
+
+- `main.dart` – entry point launching `SpaceGame` via `GameWidget`.
+- `assets.dart` – central registry that preloads images, audio and fonts.
+- `constants.dart` – tunable values for speeds, spawn rates and other numbers.
+
+## Folders
+
+- `game/` – `SpaceGame` and global systems such as input handlers,
+  collision logic and entity spawners.
+- `components/` – gameplay entities like player, enemy, asteroid and bullet
+  components. Each mixes in `HasGameRef<SpaceGame>` when game context is
+  required.
+- `ui/` – Flutter widgets for menus and HUD displayed using Flame overlays.
+- `services/` – optional helpers for audio, storage (`shared_preferences`) and
+  other utilities added as needed.
+
+See [../PLAN.md](../PLAN.md) for the broader roadmap.


### PR DESCRIPTION
## Summary
- expand design overview with game state flow and link to lib layout
- document planned lib/ directory structure for upcoming implementation

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint-cli '**/*.md'` *(fails: multiple markdownlint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689ad80e3dcc8330b55604b3db9a5613