### PR TITLE
docs: add milestone design docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,16 +5,21 @@ See [PLAN.md](PLAN.md) for the authoritative roadmap.
 
 ## Game Layers
 
-- `SpaceGame` extends `FlameGame`.
-- The Flame canvas hosts the world; Flutter overlays provide menus and HUD.
-- Systems manage input, collisions, spawning and game state transitions.
-- Assets load through a central `Assets` registry; gameplay code avoids file paths.
+- `SpaceGame` extends `FlameGame` and is embedded in a `GameWidget`.
+- Flutter overlays handle menus and the HUD so UI stays outside the game loop.
+- A `GameState` enum tracks **menu → playing → game over** transitions.
+- Systems manage input, collisions, spawning and scoring.
+- Assets and tunable constants live in `assets.dart` and `constants.dart` so
+  gameplay code avoids raw paths or magic numbers.
 
 ## Components
 
 - Player, enemy, asteroid and bullet components live under `lib/components/`.
 - Components mix in `HasGameRef<SpaceGame>` when they need game context.
-- Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and `HasCollisionDetection`.
+- Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and
+  `HasCollisionDetection`.
+- Frequently spawned objects (bullets, asteroids) may use small object pools to
+  limit garbage collection.
 
 ## State and Data
 
@@ -37,3 +42,8 @@ See [PLAN.md](PLAN.md) for the authoritative roadmap.
 
 - Web-only Flutter app managed through FVM (`fvm flutter` commands).
 - `web/manifest.json` and the service worker enable installable offline play.
+
+## Milestones
+
+- See [milestone-setup.md](milestone-setup.md) and
+  [milestone-core-loop.md](milestone-core-loop.md) for upcoming work.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ PLAYTEST_CHECKLIST.md   # Regression checklist
 playtest_logs/          # Logs from manual play sessions
 ```
 
-Further docs include `DESIGN.md` for architecture, `TASKS.md` for the backlog and
+Further docs include `DESIGN.md` for architecture, `TASKS.md` for the backlog,
+`milestone-setup.md` and `milestone-core-loop.md` for milestone goals, and
 `networking.md` for future multiplayer plans. See [PLAN.md](PLAN.md) for the full
 roadmap.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # ✅ Task List
 
-Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) for context.
+Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
+`milestone-*.md` for detailed goals.
 
 ## Setup
 

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -1,0 +1,21 @@
+# 🎯 Milestone: Core Loop
+
+Basic gameplay loop with movement, shooting and a simple enemy.
+See [PLAN.md](PLAN.md) for overall project goals.
+
+## Goals
+
+- Player ship moves using an on-screen joystick or keyboard (WASD).
+- Ship fires bullets and destroys a basic enemy type on collision.
+- Random asteroids spawn and can be mined for score.
+- Game states: **menu → playing → game over** with quick restart via overlays
+  and a `GameState` enum.
+- Parallax starfield background renders behind gameplay.
+
+## Design Notes
+
+- Use Flame's `JoystickComponent` and `ButtonComponent` for touch controls.
+- Keyboard input uses `KeyboardListenerComponent`.
+- Components mix in `HasGameRef<SpaceGame>` and use simple hit boxes.
+- Timer-based spawners generate enemies and asteroids.
+- Consider small object pools for bullets and asteroids to limit garbage.

--- a/milestone-setup.md
+++ b/milestone-setup.md
@@ -1,0 +1,20 @@
+# 🏁 Milestone: Setup
+
+Initial scaffolding so the game builds in the browser.
+See [PLAN.md](PLAN.md) for the broader roadmap.
+
+## Goals
+
+- Pin the Flutter SDK with FVM (`fvm install` and `fvm use`).
+- Scaffold the project if needed: `fvm flutter create .`.
+- Enable web support: `fvm flutter config --enable-web`.
+- Add `flame`, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
+- Commit generated folders (`lib/`, `web/`, etc.) and `pubspec.lock`.
+- Set up a minimal GitHub Actions workflow for lint, test and web deploy.
+- Document placeholder assets and credits.
+
+## Notes
+
+- Use `fvm flutter` and `fvm dart` for all commands.
+- Run `fvm dart format .` and `fvm dart analyze` before committing.
+- After editing docs, run `npx markdownlint '**/*.md'`.


### PR DESCRIPTION
## Summary
- expand design overview with game state and asset notes
- add milestone docs for setup and core gameplay
- link milestone docs from README and task list

## Testing
- `fvm dart format .` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_689ad80e3dcc8330b55604b3db9a5613