### PR TITLE
docs: add polish milestone and sync design docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -53,5 +53,6 @@ See [PLAN.md](PLAN.md) for the authoritative roadmap and
 
 ## Milestones
 
-- See [milestone-setup.md](milestone-setup.md) and
-  [milestone-core-loop.md](milestone-core-loop.md) for upcoming work.
+- See [milestone-setup.md](milestone-setup.md),
+  [milestone-core-loop.md](milestone-core-loop.md) and
+  [milestone-polish.md](milestone-polish.md) for upcoming work.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ playtest_logs/          # Logs from manual play sessions
 ```
 
 Further docs include `DESIGN.md` for architecture, `TASKS.md` for the backlog,
-`milestone-setup.md` and `milestone-core-loop.md` for milestone goals, and
-`networking.md` for future multiplayer plans. See [PLAN.md](PLAN.md) for the full
-roadmap.
+`milestone-setup.md`, `milestone-core-loop.md` and `milestone-polish.md` for
+milestone goals, and `networking.md` for future multiplayer plans. See
+[PLAN.md](PLAN.md) for the full roadmap.
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -19,10 +19,10 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 - [ ] Ship can shoot and destroy a basic enemy type.
 - [ ] Random asteroids spawn and can be mined for score.
 - [ ] Game states: menu → playing → game over with restart.
-- [ ] Parallax starfield renders behind gameplay.
 
 ## Polish
 
+- [ ] Parallax starfield renders behind gameplay.
 - [ ] Sound effects via `flame_audio` with mute toggle.
 - [ ] Local high score using `shared_preferences`.
 - [ ] Simple HUD and menus layered with Flutter.

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -10,7 +10,6 @@ See [PLAN.md](PLAN.md) for overall project goals.
 - Random asteroids spawn and can be mined for score.
 - Game states: **menu → playing → game over** with quick restart via overlays
   and a `GameState` enum.
-- Parallax starfield background renders behind gameplay.
 
 ## Design Notes
 

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -1,0 +1,21 @@
+# ✨ Milestone: Polish
+
+Final touches for the MVP, adding background, audio and persistent score.
+See [PLAN.md](PLAN.md) for overall project goals.
+
+## Goals
+
+- Parallax starfield background renders behind gameplay.
+- Sound effects via `flame_audio` with a mute toggle.
+- Local high score stored on device using `shared_preferences`.
+- Simple HUD and menus layered with Flutter overlays.
+
+## Design Notes
+
+- Use Flame's `ParallaxComponent` for the starfield background.
+- Centralise audio assets in `assets.dart` and play them through a small
+  audio service.
+- Persist the high score with `shared_preferences` using a lightweight storage
+  helper.
+- Place HUD elements (score, health, mute) in Flutter overlays separate from
+  the game loop.


### PR DESCRIPTION
## Summary
- document Polish milestone with background, audio, HUD and scoring goals
- link new milestone from design overview, README and task list
- move starfield task to Polish milestone and simplify core loop doc

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint-cli '**/*.md'` *(fails: multiple lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689adb925034833097895569c0f2838f