### PR TITLE
docs: align design and testing docs with plan

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,12 +6,15 @@ See [PLAN.md](PLAN.md) for the authoritative roadmap and
 
 ## Game Layers
 
-- `SpaceGame` extends `FlameGame` and is embedded in a `GameWidget`.
+- `SpaceGame` extends `FlameGame`, managing world and scene setup while
+  scheduling the game loop tick.
+- It owns small system classes for input, physics/collisions, entity spawners
+  and scoring. Hooks for resource mining, inventory, networking and save/load
+  will slot in later milestones.
 - Flutter overlays handle menus and the HUD so UI stays outside the game loop.
 - A `GameState` enum tracks **menu → playing → game over** transitions.
-- Systems manage input, collisions, spawning and scoring.
-- Assets and tunable constants live in `assets.dart` and `constants.dart` so
-  gameplay code avoids raw paths or magic numbers.
+- Asset paths live in a central `assets.dart` registry and tunable numbers live
+  in `constants.dart` to avoid magic strings or numbers.
 
 ## Components
 

--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -1,9 +1,10 @@
 # Manual Testing Strategy
 
-This project uses manual testing until automated tests are added.
+Manual testing fills the gap until automated tests are added.
 
-- The `develop` branch deploys to a staging environment for testing.
-- The `main` branch deploys to production.
-
-Use the [PLAYTEST_CHECKLIST.md](PLAYTEST_CHECKLIST.md) during each round of testing.
-Track issues in `playtest_logs/` as needed.
+- Work primarily on the `main` branch; create short-lived feature branches only
+  when needed.
+- Run the web build locally with `fvm flutter run -d chrome` or `-d web-server`
+  to verify changes.
+- Use the [PLAYTEST_CHECKLIST.md](PLAYTEST_CHECKLIST.md) during each round of
+  testing and log findings in `playtest_logs/`.

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -1,9 +1,12 @@
 # Manual Playtest Checklist
 
-- [ ] Game loads on mobile and desktop
-- [ ] Core gameplay: movement, upgrades, main loop
-- [ ] Saving and loading works
-- [ ] Upgrade system functions
-- [ ] Multiplayer join and sync
-- [ ] PWA installability
+- [ ] Game loads on mobile and desktop browsers
+- [ ] Touch and keyboard controls move the player
+- [ ] Player can shoot and destroy a basic enemy
+- [ ] Asteroids spawn randomly and can be mined for score
+- [ ] Game states transition: menu → playing → game over → restart
+- [ ] Parallax starfield renders behind gameplay
+- [ ] Sound effects play and can be muted
+- [ ] Local high score persists between sessions
+- [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/TASKS.md
+++ b/TASKS.md
@@ -9,6 +9,8 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 - [ ] Scaffold the Flutter project (`fvm flutter create .`) if not already.
 - [ ] Enable web support (`fvm flutter config --enable-web`).
 - [ ] Add Flame, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
+- [ ] Create placeholder `assets.dart` and `constants.dart` to centralise asset
+      paths and tunable values.
 - [ ] Commit generated folders (`lib/`, `web/`, etc.).
 - [ ] Set up GitHub Actions workflow for lint, test and web deploy.
 - [ ] Document placeholder assets and credits.


### PR DESCRIPTION
## Summary
- Clarify SpaceGame responsibilities and centralised asset/constants registries in design overview
- Add setup task for placeholder `assets.dart` and `constants.dart`
- Refresh manual testing strategy and playtest checklist for MVP scope

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint-cli DESIGN.md TASKS.md MANUAL_TESTING.md PLAYTEST_CHECKLIST.md`


------
https://chatgpt.com/codex/tasks/task_e_689addd09a18833087bc9d493f2d25df