### PR TITLE
docs: align design docs with plan

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,6 +4,15 @@ This document summarises the current architecture and design goals for Space Min
 See [PLAN.md](PLAN.md) for the authoritative roadmap and
 [lib/README.md](lib/README.md) for code layout details.
 
+## Design Principles
+
+- Keep the codebase small and understandable for a solo developer.
+- Prefer built-in Flutter and Flame features over custom frameworks.
+- Minimise dependencies and avoid code generation.
+- Collect tunable numbers in `constants.dart` and asset paths in `assets.dart`.
+- Use composition and pass dependencies through constructors; keep singletons rare.
+- Optimise iteration by running all commands through FVM (`fvm flutter`, `fvm dart`).
+
 ## Game Layers
 
 - `SpaceGame` extends `FlameGame`, managing world and scene setup while

--- a/lib/README.md
+++ b/lib/README.md
@@ -3,6 +3,9 @@
 Source code lives under `lib/`. The folders listed here will be created when
 the Flutter project is scaffolded.
 
+This repo uses FVM, so run `fvm flutter` and `fvm dart` for all commands to use
+the pinned SDK.
+
 ## Top-Level Files
 
 - `main.dart` – entry point launching `SpaceGame` via `GameWidget`.


### PR DESCRIPTION
## Summary
- capture design principles from PLAN in DESIGN.md
- note FVM usage in lib/README.md for consistent tooling

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint '**/*.md'` *(fails: lint errors in existing docs)*

------
https://chatgpt.com/codex/tasks/task_e_689adf8eca888330a17e16b9cb1ea85a