### PR TITLE
docs: clarify asset management

### DIFF
--- a/ASSET_GUIDE.md
+++ b/ASSET_GUIDE.md
@@ -3,21 +3,32 @@
 This project organizes art and audio files under the `assets/` directory.
 
 ## Folder layout
+
 - `assets/images/` – sprites, backgrounds and other images
 - `assets/audio/` – sound effects and music
 - `assets/fonts/` – custom fonts
 
+## Asset tracking
+
+- Keep a versioned `assets_manifest.json` at the project root listing all
+  bundled assets. Update it whenever files are added or removed so builds and
+  service workers can cache the correct resources.
+
 ## Finding assets
+
 Look for public domain or permissively licensed assets from:
+
 - [Kenney](https://kenney.nl/)
 - [OpenGameArt](https://opengameart.org/)
 - [Itch.io](https://itch.io)
 - [Freesound](https://freesound.org)
 
 ## Attribution
+
 Always check the license for each asset and provide credit as required.
 
 ## Optional tools
+
 - [Aseprite](https://www.aseprite.org/) for pixel art
 - [Audacity](https://www.audacityteam.org/) for sound editing
 - [Bfxr](https://www.bfxr.net/) for retro sound effects

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -64,6 +64,17 @@ See [PLAN.md](PLAN.md) for the authoritative roadmap and
 - Camera follows the player via `CameraComponent` and `FixedResolutionViewport`.
 - A parallax starfield provides the background.
 
+## Assets
+
+- Art, audio and fonts live under `assets/` with subfolders for images,
+  audio and fonts.
+- Gameplay code references assets through a central `assets.dart` registry;
+  no hard-coded file paths.
+- A versioned `assets_manifest.json` tracks files for each release to help with
+  caching and PWA updates.
+- See [ASSET_GUIDE.md](ASSET_GUIDE.md) for sourcing guidelines and
+  [ASSET_CREDITS.md](ASSET_CREDITS.md) for attribution.
+
 ## PWA & Platform
 
 - Web-only Flutter app managed through FVM (`fvm flutter` commands).

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,6 +14,7 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 - [ ] Commit generated folders (`lib/`, `web/`, etc.).
 - [ ] Set up GitHub Actions workflow for lint, test and web deploy.
 - [ ] Document placeholder assets and credits.
+- [ ] Create `assets_manifest.json` to list bundled assets for caching.
 
 ## Core Loop
 


### PR DESCRIPTION
## Summary
- expand design doc with dedicated assets section and references to an `assets_manifest.json`
- document asset manifest tracking in the asset guide
- add setup task to create `assets_manifest.json`

## Testing
- `npx markdownlint-cli '**/*.md'`
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689ae458a1d483308243296fed47bd96