### PR TITLE
docs: scaffold module design outlines

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,9 @@
 
 This document summarises the current architecture and design goals for Space Miner.
 See [PLAN.md](PLAN.md) for the authoritative roadmap and
-[lib/README.md](lib/README.md) for code layout details.
+[lib/README.md](lib/README.md) for code layout details. Detailed module docs
+live under [lib/game](lib/game/README.md), [lib/components](lib/components/README.md),
+[lib/ui](lib/ui/README.md) and [lib/services](lib/services/README.md).
 
 ## Design Principles
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -14,13 +14,12 @@ the pinned SDK.
 
 ## Folders
 
-- `game/` – `SpaceGame` and global systems such as input handlers,
+- [game/](game/) – `SpaceGame` and global systems such as input handlers,
   collision logic and entity spawners.
-- `components/` – gameplay entities like player, enemy, asteroid and bullet
-  components. Each mixes in `HasGameRef<SpaceGame>` when game context is
-  required.
-- `ui/` – Flutter widgets for menus and HUD displayed using Flame overlays.
-- `services/` – optional helpers for audio, storage (`shared_preferences`) and
-  other utilities added as needed.
+- [components/](components/) – gameplay entities like player, enemy, asteroid
+  and bullet components.
+- [ui/](ui/) – Flutter widgets for menus and HUD displayed using Flame overlays.
+- [services/](services/) – optional helpers for audio, storage
+  (`shared_preferences`) and other utilities added as needed.
 
 See [../PLAN.md](../PLAN.md) for the broader roadmap.

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -1,0 +1,13 @@
+# components/
+
+Gameplay entities and reusable pieces.
+
+- Includes player, enemy, asteroid and bullet components.
+- Each extends a Flame component and mixes in `HasGameRef<SpaceGame>`
+  when it needs game context.
+- Use simple hit boxes like `CircleHitbox` or `RectangleHitbox` with
+  `HasCollisionDetection` on the game.
+- Pull tunable values from `constants.dart` and asset references from
+  `assets.dart`.
+- Consider small object pools for frequently spawned objects to reduce
+  garbage collection.

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -1,0 +1,11 @@
+# game/
+
+Core game class and shared systems.
+
+- `space_game.dart` will extend `FlameGame` and drive the main loop.
+- Owns small helpers for input, collisions, spawners and scoring.
+- Tracks state transitions with a `GameState` enum and manages overlays.
+- Uses `CameraComponent` with a `FixedResolutionViewport` to keep a
+  consistent logical resolution.
+- Timer-based spawners generate enemies and asteroids.
+- Keep this layer lean and delegate work to components or services.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -1,0 +1,9 @@
+# services/
+
+Optional helpers for cross-cutting concerns.
+
+- `audio_service.dart` will wrap `flame_audio` to play sound effects and
+  handle a mute toggle.
+- `storage_service.dart` will store the local high score using
+  `shared_preferences` and can expand for save/load later.
+- Keep services lightweight; add them only when a milestone needs them.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -1,0 +1,10 @@
+# ui/
+
+Flutter overlays and HUD widgets.
+
+- Menus, heads-up display and game-over screens live here.
+- Widgets are shown using Flame's `overlays` map so UI stays outside the
+  game loop.
+- UI reads and updates game state through simple `ValueNotifier`s or
+  callbacks exposed by `SpaceGame`.
+- Keep rendering separate from gameplay logic to simplify testing.


### PR DESCRIPTION
## Summary
- document lib submodules for game, components, UI, and services
- link module docs from main design file and lib/README

## Testing
- `npx --yes markdownlint-cli '**/*.md'` (fails: AGENTS.md and others violate lint rules)
- `fvm dart format .` (fails: command not found)
- `fvm dart analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689ae458a1d483308243296fed47bd96