### PR TITLE
docs: add folder readmes and update design overview

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,10 +1,12 @@
 # 🎮 Design Overview
 
 This document summarises the current architecture and design goals for Space Miner.
-See [PLAN.md](PLAN.md) for the authoritative roadmap and
-[lib/README.md](lib/README.md) for code layout details. Detailed module docs
-live under [lib/game](lib/game/README.md), [lib/components](lib/components/README.md),
-[lib/ui](lib/ui/README.md) and [lib/services](lib/services/README.md).
+See [PLAN.md](PLAN.md) for the authoritative roadmap. Folder overviews live in
+[lib/README.md](lib/README.md), [assets/README.md](assets/README.md),
+[web/README.md](web/README.md) and [test/README.md](test/README.md). Detailed
+module docs live under [lib/game](lib/game/README.md),
+[lib/components](lib/components/README.md), [lib/ui](lib/ui/README.md) and
+[lib/services](lib/services/README.md).
 
 ## Design Principles
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ dedicated server or NAT traversal.
 assets/                 # Art, sounds, etc.
 lib/                    # Game source code (coming soon)
 web/                    # PWA configuration
+test/                   # Automated tests (placeholder)
 .github/workflows/      # CI and deployment scripts
 PLAN.md                 # High-level plan and architecture
 ASSET_GUIDE.md          # Asset format guidelines

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,12 @@
+# assets/
+
+Art, audio and font files used by the game.
+
+- `images/` – sprites, backgrounds and other images
+- `audio/` – sound effects and music
+- `fonts/` – custom fonts
+
+See [../ASSET_GUIDE.md](../ASSET_GUIDE.md) for sourcing guidelines and
+[../ASSET_CREDITS.md](../ASSET_CREDITS.md) for attribution. Keep a versioned
+`assets_manifest.json` at the project root so the service worker can cache the
+correct resources.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,6 @@
+# test/
+
+Placeholder for automated tests.
+
+This folder will host `flutter_test` and `flame_test` suites. Run them with
+`fvm flutter test` once tests are added.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,17 @@
+# web/
+
+PWA configuration and static web files.
+
+- `manifest.json` defines PWA metadata like `start_url`, `display` and theme
+  colours.
+- `icons/` holds 192x192 and 512x512 app icons.
+- The generated `flutter_service_worker.js` enables offline caching.
+
+Build for release with:
+
+```sh
+fvm flutter build web --release
+```
+
+Use `--base-href /space-game/` when targeting GitHub Pages so asset paths
+resolve correctly.


### PR DESCRIPTION
## Summary
- document assets/, web/ and test/ directories
- reference new folder docs from DESIGN overview
- list test/ folder in root project structure

## Testing
- `fvm dart format .` *(fails: command not found)*
- `npx markdownlint-cli '**/*.md'` *(fails: rule violations in existing docs)*

------
https://chatgpt.com/codex/tasks/task_e_689ae6280c2083309fe53445e7c4032a