### PR TITLE
docs: add skeleton design docs

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,13 @@
+# assets/
+
+Game art, audio, and fonts.
+
+- `images/` – sprites and background art.
+- `audio/` – sound effects and music.
+- `fonts/` – font files.
+
+See [../ASSET_GUIDE.md](../ASSET_GUIDE.md) for sourcing guidelines and
+[../ASSET_CREDITS.md](../ASSET_CREDITS.md) for attribution.
+
+Track bundled files in `assets_manifest.json` as noted in
+[../PLAN.md](../PLAN.md).

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -11,3 +11,5 @@ Gameplay entities and reusable pieces.
   `assets.dart`.
 - Consider small object pools for frequently spawned objects to reduce
   garbage collection.
+
+See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -9,3 +9,5 @@ Core game class and shared systems.
   consistent logical resolution.
 - Timer-based spawners generate enemies and asteroids.
 - Keep this layer lean and delegate work to components or services.
+
+See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -7,3 +7,5 @@ Optional helpers for cross-cutting concerns.
 - `storage_service.dart` will store the local high score using
   `shared_preferences` and can expand for save/load later.
 - Keep services lightweight; add them only when a milestone needs them.
+
+See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -8,3 +8,5 @@ Flutter overlays and HUD widgets.
 - UI reads and updates game state through simple `ValueNotifier`s or
   callbacks exposed by `SpaceGame`.
 - Keep rendering separate from gameplay logic to simplify testing.
+
+See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,6 @@
+# test/
+
+Placeholder for automated tests.
+
+Add unit, widget, and Flame component tests here once the game code exists.
+Use `flutter_test` and `flame_test` as noted in [../PLAN.md](../PLAN.md).

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,9 @@
+# web/
+
+PWA configuration and entry-point files.
+
+- `manifest.json` – PWA manifest with start URL, icons, and theme colours.
+- `icons/` – 192x192 and 512x512 icons referenced by the manifest.
+- `flutter_service_worker.js` – default service worker for offline caching.
+
+See [../PLAN.md](../PLAN.md) for full requirements.


### PR DESCRIPTION
## Summary
- add READMEs for assets, web config, and tests referencing the plan
- link lib module docs back to PLAN.md for alignment

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*
- `npx --yes markdownlint-cli assets/README.md web/README.md test/README.md lib/components/README.md lib/game/README.md lib/services/README.md lib/ui/README.md`


------
https://chatgpt.com/codex/tasks/task_e_689ae6280c2083309fe53445e7c4032a