### PR TITLE
docs: add asset and playtest readmes

### DIFF
--- a/assets/audio/README.md
+++ b/assets/audio/README.md
@@ -1,0 +1,8 @@
+# audio/
+
+Sound effects and music.
+
+- Keep files small and web-friendly.
+- List each file in `assets_manifest.json` and credit sources in
+  [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- See [../../PLAN.md](../../PLAN.md) for asset management guidance.

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -1,0 +1,8 @@
+# fonts/
+
+Font files for UI and HUD.
+
+- Include only openly licensed fonts.
+- Declare fonts in `pubspec.yaml` and track them in `assets_manifest.json`.
+- Credit sources in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- See [../../PLAN.md](../../PLAN.md) for project goals.

--- a/assets/images/README.md
+++ b/assets/images/README.md
@@ -1,0 +1,9 @@
+# images/
+
+Sprites and background art.
+
+- Store spritesheets, backgrounds and UI images here.
+- Reference assets through `assets.dart`; avoid hard-coded paths.
+- List files in `assets_manifest.json` and credit sources in
+  [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- See [../../PLAN.md](../../PLAN.md) for asset guidelines.

--- a/playtest_logs/README.md
+++ b/playtest_logs/README.md
@@ -1,1 +1,8 @@
 # Playtest Logs
+
+Record findings from manual play sessions here.
+
+- Create a dated markdown file for each session.
+- Summarise observations, bugs and next steps.
+- Use [../PLAYTEST_CHECKLIST.md](../PLAYTEST_CHECKLIST.md) during tests and
+  update tasks in [../TASKS.md](../TASKS.md) accordingly.


### PR DESCRIPTION
## Summary
- add README placeholders for assets subdirectories
- clarify playtest logs usage

## Testing
- `fvm dart format .` *(fails: /bin/sh: 1: dart: not found)*
- `fvm dart analyze` *(fails: /bin/sh: 1: dart: not found)*
- `npx markdownlint-cli '**/*.md'` *(fails: AGENTS.md line-length etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689be443975883308c1727e7972b6713