### PR TITLE
docs: clarify game entry

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,8 @@ module docs live under [lib/game](lib/game/README.md),
 
 ## Game Layers
 
+- `main.dart` boots the app using `GameWidget`, which hosts `SpaceGame` and
+  exposes an `overlays` map for menus and the HUD.
 - `SpaceGame` extends `FlameGame`, managing world and scene setup while
   scheduling the game loop tick.
 - It owns small system classes for input, physics/collisions, entity spawners


### PR DESCRIPTION
## Summary
- note that main.dart uses GameWidget to host SpaceGame and its overlays

## Testing
- `npx markdownlint-cli '**/*.md'` *(fails: lint errors in existing docs)*
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689be624caf083309b4cb1c512c88b84