### PR TITLE
docs: add workflow and icon docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+# GitHub Workflows
+
+Continuous integration and deployment.
+
+- `ci.yml` runs `dart format .` and `flutter analyze` on pull requests.
+- `deploy.yml` builds the web target and publishes to GitHub Pages.
+- Commands should use the pinned SDK via FVM; update workflows if needed to stay aligned with [PLAN.md](../../PLAN.md).

--- a/web/icons/README.md
+++ b/web/icons/README.md
@@ -1,0 +1,8 @@
+# icons/
+
+PWA application icons.
+
+- Store 192x192 and 512x512 web app icons here.
+- Referenced by `web/manifest.json` for installable PWA support.
+- Keep images lightweight and credit sources in [../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- See [../../PLAN.md](../../PLAN.md) for PWA guidelines.


### PR DESCRIPTION
## Summary
- document GitHub CI/CD workflows
- add README for PWA icon directory

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint-cli '**/*.md'` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689be624caf083309b4cb1c512c88b84