### PR TITLE
docs: document services and add asset manifest

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,6 +45,13 @@ module docs live under [lib/game](lib/game/README.md),
 - Frequently spawned objects (bullets, asteroids) may use small object pools to
   limit garbage collection.
 
+## Services
+
+- Small helpers for cross-cutting concerns live under `lib/services/`.
+- `audio_service.dart` will wrap `flame_audio` and expose a mute toggle.
+- `storage_service.dart` will use `shared_preferences` to persist the local high score and can expand for save/load later.
+- Add services only when needed to keep the project lightweight.
+
 ## State and Data
 
 - Tunable numbers live in `constants.dart`.

--- a/assets/README.md
+++ b/assets/README.md
@@ -9,5 +9,4 @@ Game art, audio, and fonts.
 See [../ASSET_GUIDE.md](../ASSET_GUIDE.md) for sourcing guidelines and
 [../ASSET_CREDITS.md](../ASSET_CREDITS.md) for attribution.
 
-Track bundled files in `assets_manifest.json` as noted in
-[../PLAN.md](../PLAN.md).
+Track bundled files in [../assets_manifest.json](../assets_manifest.json) as noted in [../PLAN.md](../PLAN.md).

--- a/assets_manifest.json
+++ b/assets_manifest.json
@@ -1,0 +1,5 @@
+{
+  "images": [],
+  "audio": [],
+  "fonts": []
+}


### PR DESCRIPTION
## Summary
- document planned audio and storage helpers under new Services section
- add placeholder `assets_manifest.json` and link it from assets README

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint-cli '**/*.md'` *(reports markdown style issues)*

------
https://chatgpt.com/codex/tasks/task_e_689be78968808330b4eef6b6f3806ce2