### PR TITLE
docs: add asset manifest placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ assets/                 # Art, sounds, etc.
 lib/                    # Game source code (coming soon)
 web/                    # PWA configuration
 test/                   # Automated tests (placeholder)
+assets_manifest.json    # List of bundled asset files for caching
 .github/workflows/      # CI and deployment scripts
 PLAN.md                 # High-level plan and architecture
 ASSET_GUIDE.md          # Asset format guidelines

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,7 +14,7 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 - [ ] Commit generated folders (`lib/`, `web/`, etc.).
 - [ ] Set up GitHub Actions workflow for lint, test and web deploy.
 - [ ] Document placeholder assets and credits.
-- [ ] Create `assets_manifest.json` to list bundled assets for caching.
+- [x] Create `assets_manifest.json` to list bundled assets for caching.
 
 ## Core Loop
 

--- a/assets_manifest.json
+++ b/assets_manifest.json
@@ -1,0 +1,5 @@
+{
+  "images": [],
+  "audio": [],
+  "fonts": []
+}


### PR DESCRIPTION
## Summary
- document assets_manifest.json in root README
- add placeholder assets_manifest.json file
- note manifest setup in TASKS checklist

## Testing
- `fvm dart format .`
- `fvm dart analyze`
- `npx -y markdownlint-cli '**/*.md'` *(fails: line-length and style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689be78968808330b4eef6b6f3806ce2