### PR TITLE
docs: sync asset and icon guides with plan

### DIFF
--- a/assets/audio/README.md
+++ b/assets/audio/README.md
@@ -3,6 +3,7 @@
 Sound effects and music.
 
 - Keep files small and web-friendly.
-- List each file in `assets_manifest.json` and credit sources in
-  [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- List each file in `assets_manifest.json`.
+- See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
+  credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
 - See [../../PLAN.md](../../PLAN.md) for asset management guidance.

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -4,5 +4,6 @@ Font files for UI and HUD.
 
 - Include only openly licensed fonts.
 - Declare fonts in `pubspec.yaml` and track them in `assets_manifest.json`.
-- Credit sources in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
+  credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
 - See [../../PLAN.md](../../PLAN.md) for project goals.

--- a/assets/images/README.md
+++ b/assets/images/README.md
@@ -4,6 +4,7 @@ Sprites and background art.
 
 - Store spritesheets, backgrounds and UI images here.
 - Reference assets through `assets.dart`; avoid hard-coded paths.
-- List files in `assets_manifest.json` and credit sources in
-  [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- List files in `assets_manifest.json`.
+- See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
+  credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
 - See [../../PLAN.md](../../PLAN.md) for asset guidelines.

--- a/web/icons/README.md
+++ b/web/icons/README.md
@@ -4,5 +4,6 @@ PWA application icons.
 
 - Store 192x192 and 512x512 web app icons here.
 - Referenced by `web/manifest.json` for installable PWA support.
-- Keep images lightweight and credit sources in [../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
+- Keep images lightweight. See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
+  credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
 - See [../../PLAN.md](../../PLAN.md) for PWA guidelines.


### PR DESCRIPTION
## Summary
- note asset folder guidelines and references to ASSET_GUIDE and ASSET_CREDITS
- clarify PWA icon sourcing and attribution links

## Testing
- `npx markdownlint-cli '**/*.md'` *(fails: multiple lint warnings)*
- `fvm dart format .` *(command not found)*
- `fvm dart analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bea4cce048330b41b0e2fe65955cd