### PR TITLE
docs: align design docs with Plan

### DIFF
--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -1,6 +1,7 @@
 # Manual Testing Strategy
 
 Manual testing fills the gap until automated tests are added.
+See [PLAN.md](PLAN.md) for the features currently in scope.
 
 - Work primarily on the `main` branch; create short-lived feature branches only
   when needed.
@@ -8,3 +9,4 @@ Manual testing fills the gap until automated tests are added.
   to verify changes.
 - Use the [PLAYTEST_CHECKLIST.md](PLAYTEST_CHECKLIST.md) during each round of
   testing and log findings in `playtest_logs/`.
+- Update [TASKS.md](TASKS.md) based on findings to stay aligned with the plan.

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -1,5 +1,7 @@
 # Manual Playtest Checklist
 
+Based on MVP features in [PLAN.md](PLAN.md).
+
 - [ ] Game loads on mobile and desktop browsers
 - [ ] Touch and keyboard controls move the player
 - [ ] Player can shoot and destroy a basic enemy
@@ -10,3 +12,4 @@
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices
+- [ ] Findings logged in `playtest_logs/` and next steps noted in [TASKS.md](TASKS.md)

--- a/networking.md
+++ b/networking.md
@@ -1,7 +1,8 @@
 # 🌐 Networking (Future)
 
 Multiplayer is not part of the MVP but the design allows a
-host-authoritative model later.
+host-authoritative model later. See [PLAN.md](PLAN.md) for how networking fits
+into the long-term roadmap.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- reference PLAN in networking overview for future multiplayer
- link manual testing guidance and playtest checklist back to PLAN and TASKS

## Testing
- `npx markdownlint '**/*.md'` *(fails: AGENTS.md and other pre-existing warnings)*
- `npx markdownlint networking.md MANUAL_TESTING.md PLAYTEST_CHECKLIST.md`
- `fvm dart format .` *(fails: fvm not installed)*
- `fvm dart analyze` *(fails: fvm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689bea4cce048330b41b0e2fe65955cd