### PR TITLE
docs: refine structure docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,17 @@ dedicated server or NAT traversal.
 ## 📁 Project Structure
 
 ```text
-assets/                 # Art, sounds, etc.
-lib/                    # Game source code (coming soon)
-web/                    # PWA configuration
-test/                   # Automated tests (placeholder)
+assets/                 # Art, sound, music (see assets/README.md)
+lib/                    # Game source code
+  main.dart             # App entry launching SpaceGame
+  game/                 # FlameGame subclass & systems (see lib/game/README.md)
+  components/           # Game entities (see lib/components/README.md)
+  ui/                   # Flutter overlays & HUD (see lib/ui/README.md)
+  assets.dart           # Central asset registry
+  constants.dart        # Tunable values for balancing
+  services/             # Optional helpers (see lib/services/README.md)
+web/                    # PWA configuration (see web/README.md)
+test/                   # Automated tests (placeholder) (see test/README.md)
 assets_manifest.json    # List of bundled asset files for caching
 .github/workflows/      # CI and deployment scripts
 PLAN.md                 # High-level plan and architecture

--- a/lib/README.md
+++ b/lib/README.md
@@ -9,8 +9,10 @@ the pinned SDK.
 ## Top-Level Files
 
 - `main.dart` – entry point launching `SpaceGame` via `GameWidget`.
-- `assets.dart` – central registry that preloads images, audio and fonts.
-- `constants.dart` – tunable values for speeds, spawn rates and other numbers.
+- `assets.dart` – central registry exposing sprite, audio and font paths with a
+  `load()` helper to preload them.
+- `constants.dart` – collects tunable values (speeds, spawn rates, dimensions)
+  in one place for easy balancing.
 
 ## Folders
 


### PR DESCRIPTION
## Summary
- clarify project structure and lib module layout
- expand lib documentation for `assets.dart` and `constants.dart`

## Testing
- `npx markdownlint-cli '**/*.md'`
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bec4d096883309071fc68d86bb16d