### PR TITLE
docs: expand module design details

### DIFF
--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -12,4 +12,12 @@ Gameplay entities and reusable pieces.
 - Consider small object pools for frequently spawned objects to reduce
   garbage collection.
 
+## Planned Components
+
+- `PlayerComponent` – moves via joystick or keyboard, fires bullets and tracks
+  health.
+- `EnemyComponent` – drifts toward the player and damages on contact.
+- `AsteroidComponent` – floats randomly; mining yields score pickups.
+- `BulletComponent` – short-lived projectile destroyed on hit or timer.
+
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -10,4 +10,17 @@ Core game class and shared systems.
 - Timer-based spawners generate enemies and asteroids.
 - Keep this layer lean and delegate work to components or services.
 
+## Responsibilities
+
+- Load assets via a central registry before starting play.
+- Spawn the player and register component spawners.
+- Maintain `GameState` values (`menu`, `playing`, `gameOver`) and swap
+  overlays accordingly.
+- Route input from joystick, buttons or keyboard to the player component.
+
+## Planned Files
+
+- `space_game.dart` – main game class.
+- `game_state.dart` – enum describing the game's phases.
+
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -8,4 +8,11 @@ Optional helpers for cross-cutting concerns.
   `shared_preferences` and can expand for save/load later.
 - Keep services lightweight; add them only when a milestone needs them.
 
+## Planned Services
+
+- `AudioService` – preloads clips, plays one-shot effects and remembers a
+  mute flag.
+- `StorageService` – loads and saves the high score; may persist settings or
+  future save data.
+
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -9,4 +9,10 @@ Flutter overlays and HUD widgets.
   callbacks exposed by `SpaceGame`.
 - Keep rendering separate from gameplay logic to simplify testing.
 
+## Planned Overlays
+
+- `MenuOverlay` – start button and basic instructions.
+- `HudOverlay` – shows score, health and a mute toggle.
+- `GameOverOverlay` – displays final score with a restart option.
+
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.


### PR DESCRIPTION
## Summary
- detail planned components for player, enemy, asteroid and bullet
- outline SpaceGame responsibilities and planned files
- document planned overlays and helper services

## Testing
- `npx markdownlint '**/*.md'` *(fails: existing repo files)*
- `npx -y markdownlint-cli lib/components/README.md lib/game/README.md lib/ui/README.md lib/services/README.md`

------
https://chatgpt.com/codex/tasks/task_e_689bec4d096883309071fc68d86bb16d