### PR TITLE
docs: align design docs with plan

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -48,6 +48,8 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
   `HasCollisionDetection`.
 - Frequently spawned objects (bullets, asteroids) may use small object pools to
   limit garbage collection.
+- Give components deterministic IDs for future multiplayer sync and update
+  movement using `dt` to stay frame-rate independent.
 
 ## Services
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -10,9 +10,10 @@ the pinned SDK.
 
 - `main.dart` – entry point launching `SpaceGame` via `GameWidget`.
 - `assets.dart` – central registry exposing sprite, audio and font paths with a
-  `load()` helper to preload them.
+  `load()` helper to preload them. Gameplay code references assets through this
+  helper rather than hard-coded file paths.
 - `constants.dart` – collects tunable values (speeds, spawn rates, dimensions)
-  in one place for easy balancing.
+  in one place for easy balancing so numbers aren't scattered across files.
 
 ## Folders
 

--- a/lib/assets.md
+++ b/lib/assets.md
@@ -1,0 +1,10 @@
+# assets.dart
+
+Central asset registry for sprites, audio and fonts.
+
+- Exposes typed getters for each asset.
+- Provides a `Future<void> load()` helper to preload required assets at game start.
+- Gameplay code accesses assets only through this registry; no hard-coded file paths.
+- Keeping all keys in one place simplifies refactors and avoids typos.
+
+See [../PLAN.md](../PLAN.md) for broader context.

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -11,6 +11,8 @@ Gameplay entities and reusable pieces.
   `assets.dart`.
 - Consider small object pools for frequently spawned objects to reduce
   garbage collection.
+- Give components deterministic IDs to support future multiplayer sync.
+- Update movement and timers using the `dt` value for frame-rate independence.
 
 ## Planned Components
 

--- a/lib/constants.md
+++ b/lib/constants.md
@@ -1,0 +1,10 @@
+# constants.dart
+
+Holds tunable values and configuration numbers used across the game.
+
+- Group constants by feature (player, enemy, asteroid, UI, etc.).
+- Use descriptive names like `playerSpeed` or `asteroidSpawnRate`.
+- Store only gameplay tuning values here; avoid scattering "magic numbers" in code.
+- Expose values as `const` when possible so the compiler can optimise them.
+
+See [../PLAN.md](../PLAN.md) for the authoritative roadmap.

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -3,20 +3,27 @@
 Core game class and shared systems.
 
 - `space_game.dart` will extend `FlameGame` and drive the main loop.
-- Owns small helpers for input, collisions, spawners and scoring.
+- Owns helpers for world/scene management, input, collisions, spawners and
+  scoring.
 - Tracks state transitions with a `GameState` enum and manages overlays.
 - Uses `CameraComponent` with a `FixedResolutionViewport` to keep a
   consistent logical resolution.
 - Timer-based spawners generate enemies and asteroids.
+- Input uses Flame's `JoystickComponent`, `ButtonComponent` and
+  `KeyboardListenerComponent`.
+- Hooks exist for resource mining, inventory, networking and save/load in later
+  milestones.
 - Keep this layer lean and delegate work to components or services.
 
 ## Responsibilities
 
 - Load assets via a central registry before starting play.
+- Configure the world, including the parallax starfield background.
 - Spawn the player and register component spawners.
 - Maintain `GameState` values (`menu`, `playing`, `gameOver`) and swap
   overlays accordingly.
-- Route input from joystick, buttons or keyboard to the player component.
+- Schedule the update tick and other timers.
+- Route input from joystick, fire button or keyboard to the player component.
 
 ## Planned Files
 


### PR DESCRIPTION
## Summary
- detail asset registry and constants responsibilities
- expand game and component docs to clarify input handling and future hooks
- document top-level lib files for assets and constants

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `fvm flutter test` *(fails: command not found)*
- `npx -y markdownlint-cli "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_689bedea4af08330b50ac9227217a745