### PR TITLE
docs: align asset and web docs with plan

### DIFF
--- a/ASSET_CREDITS.md
+++ b/ASSET_CREDITS.md
@@ -1,9 +1,13 @@
 # Asset Credits
 
-List any third-party assets used in the project along with their licenses and attribution details.
+List any third-party assets used in the project along with their licenses and
+required attribution details.
 
 | Asset | Source | License | Attribution |
 |-------|--------|---------|-------------|
-| _Example sprite_ | https://kenney.nl/ | CC0 | None required |
+| _Example sprite_ | [Kenney](https://kenney.nl/) | CC0 | None required |
 
 Add more entries as you include assets.
+
+Keep this file in sync with `assets_manifest.json` and follow the sourcing
+rules noted in [PLAN.md](PLAN.md).

--- a/ASSET_GUIDE.md
+++ b/ASSET_GUIDE.md
@@ -13,6 +13,8 @@ This project organizes art and audio files under the `assets/` directory.
 - Keep a versioned `assets_manifest.json` at the project root listing all
   bundled assets. Update it whenever files are added or removed so builds and
   service workers can cache the correct resources.
+- Keep total asset size under roughly **5 MB** to ensure fast web downloads,
+  as outlined in [PLAN.md](PLAN.md).
 
 ## Finding assets
 
@@ -32,3 +34,5 @@ Always check the license for each asset and provide credit as required.
 - [Aseprite](https://www.aseprite.org/) for pixel art
 - [Audacity](https://www.audacityteam.org/) for sound editing
 - [Bfxr](https://www.bfxr.net/) for retro sound effects
+
+See [PLAN.md](PLAN.md) for the broader roadmap and asset guidelines.

--- a/web/README.md
+++ b/web/README.md
@@ -6,6 +6,7 @@ PWA configuration and static web files.
   colours.
 - `icons/` holds 192x192 and 512x512 app icons.
 - The generated `flutter_service_worker.js` enables offline caching.
+- See [../PLAN.md](../PLAN.md) for PWA goals and deployment guidelines.
 
 Build for release with:
 


### PR DESCRIPTION
## Summary
- add asset size guideline and plan references to asset guide
- clarify asset credits doc and link to asset manifest
- reference plan for PWA guidance in web readme

## Testing
- `markdownlint '**/*.md'` *(fails: multiple existing lint issues)*
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf9d42e8083308e58124140ff4f58