### PR TITLE
docs: add module design notes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,6 +6,8 @@ live in [lib/README.md](lib/README.md), [assets/README.md](assets/README.md),
 [web/README.md](web/README.md) and [test/README.md](test/README.md).
 Design notes for the central helper files are in
 [lib/assets.md](lib/assets.md) and [lib/constants.md](lib/constants.md).
+Modules such as `space_game`, components, overlays and services have dedicated
+docs in their respective subfolders.
 Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 [milestone-core-loop.md](milestone-core-loop.md) and
 [milestone-polish.md](milestone-polish.md), with the day-to-day backlog in

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -16,10 +16,12 @@ Gameplay entities and reusable pieces.
 
 ## Planned Components
 
-- `PlayerComponent` – moves via joystick or keyboard, fires bullets and tracks
-  health.
-- `EnemyComponent` – drifts toward the player and damages on contact.
-- `AsteroidComponent` – floats randomly; mining yields score pickups.
-- `BulletComponent` – short-lived projectile destroyed on hit or timer.
+- [PlayerComponent](player.md) – moves via joystick or keyboard, fires bullets
+  and tracks health.
+- [EnemyComponent](enemy.md) – drifts toward the player and damages on contact.
+- [AsteroidComponent](asteroid.md) – floats randomly; mining yields score
+  pickups.
+- [BulletComponent](bullet.md) – short-lived projectile destroyed on hit or
+  timer.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/components/asteroid.md
+++ b/lib/components/asteroid.md
@@ -1,0 +1,13 @@
+# AsteroidComponent
+
+Neutral obstacle that can be mined for score.
+
+## Behaviour
+
+- Spawns randomly and drifts across the play area.
+- Destroyed by bullets or mining action; awards score pickups.
+- Uses sprites from `assets.dart` and numbers from `constants.dart`.
+- Consider small object pool to reuse instances.
+- Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
+
+See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/bullet.md
+++ b/lib/components/bullet.md
@@ -1,0 +1,13 @@
+# BulletComponent
+
+Short-lived projectile fired by the player.
+
+## Behaviour
+
+- Travels in a straight line from the player's ship.
+- Destroyed on impact or after a brief lifetime.
+- Uses sprite from `assets.dart` and speed from `constants.dart`.
+- Consider pooling to reduce allocations.
+- Uses `RectangleHitbox` or `CircleHitbox` and `HasGameRef<SpaceGame>`.
+
+See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/enemy.md
+++ b/lib/components/enemy.md
@@ -1,0 +1,13 @@
+# EnemyComponent
+
+Basic foe that drifts toward the player.
+
+## Behaviour
+
+- Spawns at screen edges and moves toward the player ship.
+- Damages the player on contact and is destroyed when hit by a bullet.
+- Sprites resolved through `assets.dart`; speeds and hit points from `constants.dart`.
+- Uses `CircleHitbox` or `RectangleHitbox` depending on art.
+- Mixes in `HasGameRef<SpaceGame>` for access to global state.
+
+See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -1,0 +1,13 @@
+# PlayerComponent
+
+Controllable ship for the player.
+
+## Behaviour
+
+- Moves via on-screen joystick or WASD keys.
+- Fires `BulletComponent`s when the shoot button or space bar is pressed.
+- Tracks health and triggers game over when depleted.
+- Pulls sprites from `assets.dart` and tuning values from `constants.dart`.
+- Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
+
+See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -27,7 +27,7 @@ Core game class and shared systems.
 
 ## Planned Files
 
-- `space_game.dart` – main game class.
-- `game_state.dart` – enum describing the game's phases.
+- [space_game.dart](space_game.md) – main game class.
+- [game_state.dart](game_state.md) – enum describing the game's phases.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/game/game_state.md
+++ b/lib/game/game_state.md
@@ -1,0 +1,13 @@
+# game_state.dart
+
+Enum describing high-level game phases.
+
+## Values
+
+- `menu` – initial overlay before play.
+- `playing` – active gameplay loop.
+- `gameOver` – player died; show restart overlay.
+
+Used by `SpaceGame` to swap overlays and reset state.
+
+See [../../PLAN.md](../../PLAN.md) for the state flow.

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -1,0 +1,14 @@
+# space_game.dart
+
+Main FlameGame subclass managing world setup, state transitions and the update loop.
+
+## Responsibilities
+
+- Preload assets via the central registry before entering gameplay.
+- Configure the parallax background, camera and component spawners.
+- Spawn the player and register enemy or asteroid generators.
+- Maintain `GameState` values (`menu`, `playing`, `gameOver`) and toggle overlays.
+- Route joystick, button and keyboard input to the player component.
+- Drive the update cycle while delegating work to components and services.
+
+See [../../PLAN.md](../../PLAN.md) for the roadmap.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -10,9 +10,9 @@ Optional helpers for cross-cutting concerns.
 
 ## Planned Services
 
-- `AudioService` – preloads clips, plays one-shot effects and remembers a
-  mute flag.
-- `StorageService` – loads and saves the high score; may persist settings or
-  future save data.
+- [AudioService](audio_service.md) – preloads clips, plays one-shot effects and
+  remembers a mute flag.
+- [StorageService](storage_service.md) – loads and saves the high score; may
+  persist settings or future save data.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/services/audio_service.md
+++ b/lib/services/audio_service.md
@@ -1,0 +1,12 @@
+# AudioService
+
+Lightweight wrapper around `flame_audio`.
+
+## Responsibilities
+
+- Preload sound effect clips during game startup.
+- Play one-shot effects for actions like shooting or explosions.
+- Expose a mute toggle persisted via `StorageService`.
+- Provide simple methods like `playShoot()` or `playExplosion()`.
+
+See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -1,0 +1,12 @@
+# StorageService
+
+Handles local persistence using `shared_preferences`.
+
+## Responsibilities
+
+- Save and load the local high score.
+- Optionally store settings like the mute flag.
+- Provide simple async getters and setters.
+- Future expansion can add save/load for other data.
+
+See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -11,8 +11,8 @@ Flutter overlays and HUD widgets.
 
 ## Planned Overlays
 
-- `MenuOverlay` – start button and basic instructions.
-- `HudOverlay` – shows score, health and a mute toggle.
-- `GameOverOverlay` – displays final score with a restart option.
+- [MenuOverlay](menu_overlay.md) – start button and basic instructions.
+- [HudOverlay](hud_overlay.md) – shows score, health and a mute toggle.
+- [GameOverOverlay](game_over_overlay.md) – displays final score with a restart option.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/game_over_overlay.md
+++ b/lib/ui/game_over_overlay.md
@@ -1,0 +1,12 @@
+# GameOverOverlay
+
+Flutter widget shown when the player dies.
+
+## Features
+
+- Displays final score and a restart button.
+- Tapping restart resets `SpaceGame` to the `playing` state.
+- May show a high score loaded via `StorageService`.
+- Visible when `GameState.gameOver` is active.
+
+See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -1,0 +1,12 @@
+# HudOverlay
+
+Heads-up display shown during play.
+
+## Features
+
+- Shows current score and player health.
+- Contains a mute toggle linked to `AudioService`.
+- Reads values via `ValueNotifier`s or callbacks from `SpaceGame`.
+- Visible only in the `playing` state.
+
+See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/menu_overlay.md
+++ b/lib/ui/menu_overlay.md
@@ -1,0 +1,12 @@
+# MenuOverlay
+
+Flutter widget shown before gameplay starts.
+
+## Features
+
+- Displays the game title and basic instructions.
+- Start button signals `SpaceGame` to enter the `playing` state.
+- Accesses the game via callbacks or a `ValueNotifier`.
+- Visible when `GameState.menu` is active.
+
+See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- add dedicated design notes for SpaceGame and GameState
- document player, enemy, asteroid and bullet component behaviour
- outline overlay and service responsibilities before implementation

## Testing
- `npx markdownlint-cli '**/*.md'` *(fails: AGENTS.md etc. have lint issues)*
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689bfc3311dc83309007d02a88dfc84e