### PR TITLE
docs: add asset manifest guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,8 @@ Other docs: `PLAN.md`, `DESIGN.md`, `TASKS.md`, `networking.md`, `ASSET_GUIDE.md
   - Optional: scheduled runs for dependency checks and Lighthouse audits.
 
 ## 13. Asset Management
-- Store versioned asset manifests (`assets_manifest.json`) per release.
+- Store versioned asset manifests (`assets_manifest.json`) per release
+  (see `assets_manifest.md`).
 - Compress textures/audio for web performance.
 - Credit and license all third-party assets in `ASSET_CREDITS.md`.
 

--- a/ASSET_CREDITS.md
+++ b/ASSET_CREDITS.md
@@ -9,5 +9,5 @@ required attribution details.
 
 Add more entries as you include assets.
 
-Keep this file in sync with `assets_manifest.json` and follow the sourcing
-rules noted in [PLAN.md](PLAN.md).
+Keep this file in sync with `assets_manifest.json` (see `assets_manifest.md`)
+and follow the sourcing rules noted in [PLAN.md](PLAN.md).

--- a/ASSET_GUIDE.md
+++ b/ASSET_GUIDE.md
@@ -11,8 +11,9 @@ This project organizes art and audio files under the `assets/` directory.
 ## Asset tracking
 
 - Keep a versioned `assets_manifest.json` at the project root listing all
-  bundled assets. Update it whenever files are added or removed so builds and
-  service workers can cache the correct resources.
+  bundled assets (see `assets_manifest.md`). Update it whenever files are
+  added or removed so builds and service workers can cache the correct
+  resources.
 - Keep total asset size under roughly **5 MB** to ensure fast web downloads,
   as outlined in [PLAN.md](PLAN.md).
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,7 +103,7 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 - Gameplay code references assets through a central `assets.dart` registry;
   no hard-coded file paths.
 - A versioned `assets_manifest.json` tracks files for each release to help with
-  caching and PWA updates.
+  caching and PWA updates (see `assets_manifest.md`).
 - See [ASSET_GUIDE.md](ASSET_GUIDE.md) for sourcing guidelines and
   [ASSET_CREDITS.md](ASSET_CREDITS.md) for attribution.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -160,7 +160,7 @@ Target is an offline PWA that a solo developer can iterate on quickly.
   document sources in `ASSET_GUIDE.md` and credit in `ASSET_CREDITS.md`
 - Prefer CC0 or similar licenses and keep total assets <5 MB
 - Maintain a versioned `assets_manifest.json` to track assets for each release
-  and help with caching
+  and help with caching (see `assets_manifest.md`)
 
 ### PWA & Deployment
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ lib/                    # Game source code
   services/             # Optional helpers (see lib/services/README.md)
 web/                    # PWA configuration (see web/README.md)
 test/                   # Automated tests (placeholder) (see test/README.md)
-assets_manifest.json    # List of bundled asset files for caching
+assets_manifest.json    # List of bundled asset files for caching (see assets_manifest.md)
 .github/workflows/      # CI and deployment scripts
 PLAN.md                 # High-level plan and architecture
 ASSET_GUIDE.md          # Asset format guidelines

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,7 +14,8 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 - [ ] Commit generated folders (`lib/`, `web/`, etc.).
 - [ ] Set up GitHub Actions workflow for lint, test and web deploy.
 - [ ] Document placeholder assets and credits.
-- [x] Create `assets_manifest.json` to list bundled assets for caching.
+- [x] Create `assets_manifest.json` to list bundled assets for caching
+  (see `assets_manifest.md`).
 
 ## Core Loop
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -9,4 +9,6 @@ Game art, audio, and fonts.
 See [../ASSET_GUIDE.md](../ASSET_GUIDE.md) for sourcing guidelines and
 [../ASSET_CREDITS.md](../ASSET_CREDITS.md) for attribution.
 
-Track bundled files in [../assets_manifest.json](../assets_manifest.json) as noted in [../PLAN.md](../PLAN.md).
+Track bundled files in [../assets_manifest.json](../assets_manifest.json)
+(see [../assets_manifest.md](../assets_manifest.md)) as noted in
+[../PLAN.md](../PLAN.md).

--- a/assets/audio/README.md
+++ b/assets/audio/README.md
@@ -3,7 +3,7 @@
 Sound effects and music.
 
 - Keep files small and web-friendly.
-- List each file in `assets_manifest.json`.
+- List each file in `assets_manifest.json` (see `../../assets_manifest.md`).
 - See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
   credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
 - See [../../PLAN.md](../../PLAN.md) for asset management guidance.

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -3,7 +3,8 @@
 Font files for UI and HUD.
 
 - Include only openly licensed fonts.
-- Declare fonts in `pubspec.yaml` and track them in `assets_manifest.json`.
+- Declare fonts in `pubspec.yaml` and track them in `assets_manifest.json`
+  (see `../../assets_manifest.md`).
 - See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
   credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
 - See [../../PLAN.md](../../PLAN.md) for project goals.

--- a/assets/images/README.md
+++ b/assets/images/README.md
@@ -4,7 +4,7 @@ Sprites and background art.
 
 - Store spritesheets, backgrounds and UI images here.
 - Reference assets through `assets.dart`; avoid hard-coded paths.
-- List files in `assets_manifest.json`.
+- List files in `assets_manifest.json` (see `../../assets_manifest.md`).
 - See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
   credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).
 - See [../../PLAN.md](../../PLAN.md) for asset guidelines.

--- a/assets_manifest.md
+++ b/assets_manifest.md
@@ -1,0 +1,10 @@
+# assets_manifest.json
+
+Reference manifest tracking bundled asset files.
+
+- Lists every file under `assets/` that ships with the game.
+- Version the manifest per release to aid caching and PWA updates.
+- Update this file whenever assets are added, removed or renamed.
+- Keep entries sorted for readability.
+- The build pipeline and service worker can use this list to precache assets.
+- See [PLAN.md](PLAN.md) for broader context.


### PR DESCRIPTION
## Summary
- add assets_manifest.md describing asset listing and update steps
- link asset manifest guide from plan, design, README, and asset docs

## Testing
- `fvm dart format .` *(fails: command not found: fvm)*
- `fvm dart analyze` *(fails: command not found: fvm)*
- `npx markdownlint '**/*.md'` *(fails: markdown style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689bfe24cd108330aaac78733ca0f863