### PR TITLE
docs: note pinned Flutter version

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,8 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 - Collect tunable numbers in `constants.dart` and asset paths in `assets.dart`.
 - Use composition and pass dependencies through constructors; keep singletons rare.
 - Optimise iteration by running all commands through FVM (`fvm flutter`, `fvm dart`).
+- Flutter SDK version pinned to `3.32.8` via [`fvm_config.json`](fvm_config.json) for
+  consistent builds.
 - Build only the features needed for the current milestone; defer extras until
   they are actually required.
 - Favour readability and quick iteration over micro-optimisation.
@@ -32,7 +34,7 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 
 ## Entry Point
 
-- `main.dart` starts the Flutter app using the SDK pinned via FVM.
+- `main.dart` starts the Flutter app using the Flutter SDK pinned via FVM (3.32.8).
 - It wraps `SpaceGame` in a `GameWidget`, ensures the PWA manifest loads and
   preloads assets through `Assets.load()` before play.
 - Run all development commands through FVM (`fvm flutter`, `fvm dart`) to keep

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ milestone goals, and `networking.md` for future multiplayer plans. See
 ## Flutter Version Management
 
 This repo uses [FVM](https://fvm.app/) to pin the Flutter SDK version. After
-cloning, run `fvm install` to download the SDK specified in `fvm_config.json`.
+cloning, run `fvm install` to download the SDK specified in `fvm_config.json`
+(currently `3.32.8`).
 Use `fvm flutter` in place of the global `flutter` command when building or
 running the game.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,7 +5,7 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 
 ## Setup
 
-- [ ] Install FVM and fetch the pinned Flutter SDK.
+- [ ] Install FVM and fetch the pinned Flutter SDK (version `3.32.8`).
 - [ ] Scaffold the Flutter project (`fvm flutter create .`) if not already.
 - [ ] Enable web support (`fvm flutter config --enable-web`).
 - [ ] Add Flame, `flame_audio` and `shared_preferences` to `pubspec.yaml`.

--- a/milestone-setup.md
+++ b/milestone-setup.md
@@ -5,7 +5,8 @@ See [PLAN.md](PLAN.md) for the broader roadmap.
 
 ## Goals
 
-- Pin the Flutter SDK with FVM (`fvm install` and `fvm use`).
+- Pin the Flutter SDK with FVM (`fvm install` and `fvm use`) targeting version
+  `3.32.8` as specified in `fvm_config.json`.
 - Scaffold the project if needed: `fvm flutter create .`.
 - Enable web support: `fvm flutter config --enable-web`.
 - Add `flame`, `flame_audio` and `shared_preferences` to `pubspec.yaml`.


### PR DESCRIPTION
## Summary
- document FVM-pinned Flutter 3.32.8 in design docs, task list, setup milestone, and readme

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx --yes markdownlint-cli '**/*.md'` *(fails: markdownlint issues in repo)*

------
https://chatgpt.com/codex/tasks/task_e_689bfe24cd108330aaac78733ca0f863