### PR TITLE
docs: add main entry design doc

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,7 +5,8 @@ Miner. See [PLAN.md](PLAN.md) for the authoritative roadmap. Folder overviews
 live in [lib/README.md](lib/README.md), [assets/README.md](assets/README.md),
 [web/README.md](web/README.md) and [test/README.md](test/README.md).
 Design notes for the central helper files are in
-[lib/assets.md](lib/assets.md) and [lib/constants.md](lib/constants.md).
+[lib/main.md](lib/main.md), [lib/assets.md](lib/assets.md) and
+[lib/constants.md](lib/constants.md).
 Modules such as `space_game`, components, overlays and services have dedicated
 docs in their respective subfolders.
 Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),

--- a/lib/README.md
+++ b/lib/README.md
@@ -8,7 +8,8 @@ the pinned SDK.
 
 ## Top-Level Files
 
-- `main.dart` – entry point launching `SpaceGame` via `GameWidget`.
+- `main.dart` – entry point launching `SpaceGame` via `GameWidget`. See
+  [main.md](main.md) for design notes.
 - `assets.dart` – central registry exposing sprite, audio and font paths with a
   `load()` helper to preload them. Gameplay code references assets through this
   helper rather than hard-coded file paths.

--- a/lib/main.md
+++ b/lib/main.md
@@ -1,0 +1,13 @@
+# main.dart
+
+Entry point launching the Flutter app and `SpaceGame`.
+
+## Responsibilities
+
+- Bootstraps the Flutter app using the FVM-pinned SDK.
+- Preloads assets via `Assets.load()` before gameplay.
+- Wraps `SpaceGame` in a `GameWidget` so overlays can render Flutter UI.
+- Ensures the PWA manifest and other web configuration are loaded before play.
+- Serves as a thin launcher; game logic lives in `SpaceGame` and components.
+
+See [../PLAN.md](../PLAN.md) for the authoritative roadmap.


### PR DESCRIPTION
## Summary
- document main.dart entrypoint responsibilities
- link main design doc from overall architecture docs

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx -y markdownlint-cli '**/*.md'` *(fails: lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689c006c599883308798bb87e136ce5a