### PR TITLE
docs: add log helper design

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,8 +5,8 @@ Miner. See [PLAN.md](PLAN.md) for the authoritative roadmap. Folder overviews
 live in [lib/README.md](lib/README.md), [assets/README.md](assets/README.md),
 [web/README.md](web/README.md) and [test/README.md](test/README.md).
 Design notes for the central helper files are in
-[lib/main.md](lib/main.md), [lib/assets.md](lib/assets.md) and
-[lib/constants.md](lib/constants.md).
+[lib/main.md](lib/main.md), [lib/assets.md](lib/assets.md),
+[lib/constants.md](lib/constants.md) and [lib/log.md](lib/log.md).
 Modules such as `space_game`, components, overlays and services have dedicated
 docs in their respective subfolders.
 Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
@@ -25,13 +25,15 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 - Collect tunable numbers in `constants.dart` and asset paths in `assets.dart`.
 - Use composition and pass dependencies through constructors; keep singletons rare.
 - Optimise iteration by running all commands through FVM (`fvm flutter`, `fvm dart`).
-- Flutter SDK version pinned to `3.32.8` via [`fvm_config.json`](fvm_config.json) for
-  consistent builds.
+- Flutter SDK version pinned to `3.32.8` via
+  [`fvm_config.json`](fvm_config.json) for consistent builds.
 - Build only the features needed for the current milestone; defer extras until
   they are actually required.
 - Favour readability and quick iteration over micro-optimisation.
 - Use simple state handling (plain classes or `ValueNotifier`s) instead of heavy
   patterns like BLoC or Redux.
+- Provide a small `log()` helper wrapping `debugPrint` so logs can be silenced
+  in release builds.
 
 ## Entry Point
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ lib/                    # Game source code
   ui/                   # Flutter overlays & HUD (see lib/ui/README.md)
   assets.dart           # Central asset registry
   constants.dart        # Tunable values for balancing
+  log.dart              # Tiny log() wrapper around debugPrint
   services/             # Optional helpers (see lib/services/README.md)
 web/                    # PWA configuration (see web/README.md)
 test/                   # Automated tests (placeholder) (see test/README.md)

--- a/lib/README.md
+++ b/lib/README.md
@@ -15,6 +15,8 @@ the pinned SDK.
   helper rather than hard-coded file paths.
 - `constants.dart` – collects tunable values (speeds, spawn rates, dimensions)
   in one place for easy balancing so numbers aren't scattered across files.
+- `log.dart` – tiny `log()` wrapper around `debugPrint` so logs can be muted in
+  release builds.
 
 ## Folders
 

--- a/lib/log.md
+++ b/lib/log.md
@@ -1,0 +1,11 @@
+# log.dart
+
+Tiny logging helper wrapping `debugPrint`.
+
+## Responsibilities
+
+- Provide a simple `log()` function that forwards to `debugPrint` in debug builds.
+- Allow silencing logs in release builds.
+- Keep the helper dependency-free and lightweight.
+
+See [../PLAN.md](../PLAN.md) for style and testing notes.


### PR DESCRIPTION
## Summary
- add design doc for `log.dart` helper to centralize logging control
- reference `log.dart` in architecture and README summaries

## Testing
- `npx markdownlint-cli README.md DESIGN.md lib/README.md lib/log.md`
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689c028c7b2c8330bd99ede91dd276d6