### PR TITLE
docs: align design docs with plan

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,6 +35,16 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 - Provide a small `log()` helper wrapping `debugPrint` so logs can be silenced
   in release builds.
 
+## Workflow & Tooling
+
+- Run all Flutter and Dart commands through [FVM](https://fvm.app/) to use the
+  pinned SDK version from `fvm_config.json`.
+- Keep commits small and focused on `main`; branch only for larger features.
+- Before committing, format and analyse code with `fvm dart format .` and
+  `fvm dart analyze`.
+- Lint Markdown files with `npx markdownlint '**/*.md'`.
+- See [PLAN.md](PLAN.md) for the full development loop.
+
 ## Entry Point
 
 - `main.dart` starts the Flutter app using the Flutter SDK pinned via FVM (3.32.8).

--- a/TASKS.md
+++ b/TASKS.md
@@ -6,9 +6,11 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 ## Setup
 
 - [ ] Install FVM and fetch the pinned Flutter SDK (version `3.32.8`).
+- [ ] Run `fvm flutter doctor` to verify the environment.
 - [ ] Scaffold the Flutter project (`fvm flutter create .`) if not already.
 - [ ] Enable web support (`fvm flutter config --enable-web`).
 - [ ] Add Flame, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
+- [ ] Run `fvm flutter pub get` to install dependencies.
 - [ ] Create placeholder `assets.dart` and `constants.dart` to centralise asset
       paths and tunable values.
 - [ ] Commit generated folders (`lib/`, `web/`, etc.).


### PR DESCRIPTION
## Summary
- document workflow and tooling steps in the design overview
- expand setup tasks with doctor and pub get steps

## Testing
- ⚠️ `npx markdownlint '**/*.md'` *(could not determine executable to run)*
- ✅ `markdownlint DESIGN.md TASKS.md`
- ⚠️ `fvm dart format .` *(command not found: fvm)*
- ⚠️ `fvm dart analyze` *(command not found: fvm)*

------
https://chatgpt.com/codex/tasks/task_e_689c0500328c83308a815d0399036da6