### PR TITLE
docs: align plan with design and enumerate milestone tasks

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,8 @@
 
 Tiny mobile‑first 2D shooter built with Flutter and Flame.
 Target is an offline PWA that a solo developer can iterate on quickly.
+See [DESIGN.md](DESIGN.md) for architecture details. Day-to-day work is
+tracked via the milestone docs and consolidated in [TASKS.md](TASKS.md).
 
 ## 🎯 Goals
 
@@ -150,6 +152,12 @@ Target is an offline PWA that a solo developer can iterate on quickly.
 - **Setup** – basic project scaffolding runs in the browser with placeholder assets
 - **Core Loop** – player moves and shoots, one enemy type, basic scoring
 - **Polish** – starfield background, sound effects, and local high score
+
+Detailed tasks for each milestone live in
+[milestone-setup.md](milestone-setup.md),
+[milestone-core-loop.md](milestone-core-loop.md) and
+[milestone-polish.md](milestone-polish.md). The combined backlog is maintained
+in [TASKS.md](TASKS.md).
 
 ## 🎨 Assets & PWA
 

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -3,13 +3,13 @@
 Basic gameplay loop with movement, shooting and a simple enemy.
 See [PLAN.md](PLAN.md) for overall project goals.
 
-## Goals
+## Tasks
 
-- Player ship moves using an on-screen joystick or keyboard (WASD).
-- Ship fires bullets and destroys a basic enemy type on collision.
-- Random asteroids spawn and can be mined for score.
-- Game states: **menu → playing → game over** with quick restart via overlays
-  and a `GameState` enum.
+- [ ] Player ship moves using an on-screen joystick or keyboard (WASD).
+- [ ] Ship fires bullets and destroys a basic enemy type on collision.
+- [ ] Random asteroids spawn and can be mined for score.
+- [ ] Game states: **menu → playing → game over** with quick restart via overlays
+      and a `GameState` enum.
 
 ## Design Notes
 

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -3,12 +3,12 @@
 Final touches for the MVP, adding background, audio and persistent score.
 See [PLAN.md](PLAN.md) for overall project goals.
 
-## Goals
+## Tasks
 
-- Parallax starfield background renders behind gameplay.
-- Sound effects via `flame_audio` with a mute toggle.
-- Local high score stored on device using `shared_preferences`.
-- Simple HUD and menus layered with Flutter overlays.
+- [ ] Parallax starfield background renders behind gameplay.
+- [ ] Sound effects via `flame_audio` with a mute toggle.
+- [ ] Local high score stored on device using `shared_preferences`.
+- [ ] Simple HUD and menus layered with Flutter overlays.
 
 ## Design Notes
 

--- a/milestone-setup.md
+++ b/milestone-setup.md
@@ -3,16 +3,16 @@
 Initial scaffolding so the game builds in the browser.
 See [PLAN.md](PLAN.md) for the broader roadmap.
 
-## Goals
+## Tasks
 
-- Pin the Flutter SDK with FVM (`fvm install` and `fvm use`) targeting version
-  `3.32.8` as specified in `fvm_config.json`.
-- Scaffold the project if needed: `fvm flutter create .`.
-- Enable web support: `fvm flutter config --enable-web`.
-- Add `flame`, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
-- Commit generated folders (`lib/`, `web/`, etc.) and `pubspec.lock`.
-- Set up a minimal GitHub Actions workflow for lint, test and web deploy.
-- Document placeholder assets and credits.
+- [ ] Pin the Flutter SDK with FVM (`fvm install` and `fvm use`) targeting version
+      `3.32.8` as specified in `fvm_config.json`.
+- [ ] Scaffold the project if needed: `fvm flutter create .`.
+- [ ] Enable web support: `fvm flutter config --enable-web`.
+- [ ] Add `flame`, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
+- [ ] Commit generated folders (`lib/`, `web/`, etc.) and `pubspec.lock`.
+- [ ] Set up a minimal GitHub Actions workflow for lint, test and web deploy.
+- [ ] Document placeholder assets and credits.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- reference design details and task tracking in PLAN
- add explicit task checklists in each milestone doc

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `markdownlint '**/*.md'` *(fails: lint issues in existing files)*
- `fvm flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c10bb3054833088c25135e0b1ea9f