### PR TITLE
docs: sync plan and tasks with design

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -86,6 +86,7 @@ tracked via the milestone docs and consolidated in [TASKS.md](TASKS.md).
   - `ui/` – Flutter widgets for menus/HUD
   - `assets.dart` – central asset registry that preloads sprites, audio and fonts
   - `constants.dart` – central place for tunable values
+  - `log.dart` – tiny `log()` helper wrapping `debugPrint`
   - `services/` – optional helpers such as storage or audio, added only when needed
 - `assets/` – images, audio and fonts
 - `web/` – PWA manifest, icons and service worker
@@ -96,6 +97,9 @@ tracked via the milestone docs and consolidated in [TASKS.md](TASKS.md).
 - Root Markdown docs: `AGENTS.md`, `PLAN.md`, `PLAYTEST_CHECKLIST.md`,
   `MANUAL_TESTING.md`, `ASSET_GUIDE.md`, `ASSET_CREDITS.md`, `playtest_logs/`,
   plus optional `DESIGN.md`, `TASKS.md`, `milestone-*.md`
+- Each of `lib/`, `assets/`, `web/` and `test/` includes a `README.md`
+  describing its contents, with additional design notes in
+  `lib/main.md`, `lib/assets.md`, `lib/constants.md` and `lib/log.md`
 - Keep `README.md` and other docs updated as features change and remove any
   stale sections
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,6 +13,7 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 - [ ] Run `fvm flutter pub get` to install dependencies.
 - [ ] Create placeholder `assets.dart` and `constants.dart` to centralise asset
       paths and tunable values.
+- [ ] Add a tiny `log.dart` helper that wraps `debugPrint`.
 - [ ] Commit generated folders (`lib/`, `web/`, etc.).
 - [ ] Set up GitHub Actions workflow for lint, test and web deploy.
 - [ ] Document placeholder assets and credits.

--- a/milestone-setup.md
+++ b/milestone-setup.md
@@ -10,7 +10,13 @@ See [PLAN.md](PLAN.md) for the broader roadmap.
 - [ ] Scaffold the project if needed: `fvm flutter create .`.
 - [ ] Enable web support: `fvm flutter config --enable-web`.
 - [ ] Add `flame`, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
+- [ ] Run `fvm flutter pub get` to install dependencies.
+- [ ] Create placeholder `assets.dart` and `constants.dart` to centralise asset
+      paths and tunable values.
+- [ ] Add a tiny `log.dart` helper that wraps `debugPrint`.
 - [ ] Commit generated folders (`lib/`, `web/`, etc.) and `pubspec.lock`.
+- [ ] Create `assets_manifest.json` to list bundled assets for caching
+      (see `assets_manifest.md`).
 - [ ] Set up a minimal GitHub Actions workflow for lint, test and web deploy.
 - [ ] Document placeholder assets and credits.
 


### PR DESCRIPTION
## Summary
- document `log.dart` helper and location of per-folder READMEs in PLAN
- list `log.dart` setup work in TASKS and milestone-setup docs

## Testing
- `fvm dart format .`
- `fvm dart analyze`
- `npx markdownlint '**/*.md'` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c135c257c833085094c458a25485b