### PR TITLE
docs: align plan with design and tasks

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,8 +2,9 @@
 
 Tiny mobile‑first 2D shooter built with Flutter and Flame.
 Target is an offline PWA that a solo developer can iterate on quickly.
-See [DESIGN.md](DESIGN.md) for architecture details. Day-to-day work is
-tracked via the milestone docs and consolidated in [TASKS.md](TASKS.md).
+See [DESIGN.md](DESIGN.md) for architecture details. All design docs align with
+this plan, and tasks are enumerated in the milestone docs and consolidated in
+[TASKS.md](TASKS.md) to kick off implementation.
 
 ## 🎯 Goals
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,7 +1,7 @@
 # ✅ Task List
 
-Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
-`milestone-*.md` for detailed goals.
+Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and [DESIGN.md](DESIGN.md)
+for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 ## Setup
 

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -1,7 +1,8 @@
 # 🎯 Milestone: Core Loop
 
 Basic gameplay loop with movement, shooting and a simple enemy.
-See [PLAN.md](PLAN.md) for overall project goals.
+See [PLAN.md](PLAN.md) for overall project goals and
+[TASKS.md](TASKS.md) for the consolidated backlog.
 
 ## Tasks
 

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -1,7 +1,8 @@
 # ✨ Milestone: Polish
 
 Final touches for the MVP, adding background, audio and persistent score.
-See [PLAN.md](PLAN.md) for overall project goals.
+See [PLAN.md](PLAN.md) for overall project goals and
+[TASKS.md](TASKS.md) for the consolidated backlog.
 
 ## Tasks
 

--- a/milestone-setup.md
+++ b/milestone-setup.md
@@ -1,7 +1,8 @@
 # 🏁 Milestone: Setup
 
 Initial scaffolding so the game builds in the browser.
-See [PLAN.md](PLAN.md) for the broader roadmap.
+See [PLAN.md](PLAN.md) for the broader roadmap and
+[TASKS.md](TASKS.md) for the consolidated backlog.
 
 ## Tasks
 


### PR DESCRIPTION
## Summary
- clarify that design docs align with PLAN and tasks are tracked in milestone docs and TASKS.md
- cross-link TASKS.md with DESIGN.md and milestone docs
- reference TASKS.md from each milestone document for consolidated backlog

## Testing
- `npx markdownlint-cli PLAN.md TASKS.md milestone-setup.md milestone-core-loop.md milestone-polish.md`
- `fvm dart format .` *(fails: command not found)*
- `fvm flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c1c42eac88330b340a7cf5d38b603