### PR TITLE
docs: detail polish service tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -30,6 +30,8 @@ Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and
 ## Polish
 
 - [ ] Parallax starfield renders behind gameplay.
-- [ ] Sound effects via `flame_audio` with mute toggle.
-- [ ] Local high score using `shared_preferences`.
-- [ ] Simple HUD and menus layered with Flutter.
+- [ ] Implement `audio_service.dart` wrapping `flame_audio` with a
+      mute toggle.
+- [ ] Implement `storage_service.dart` using `shared_preferences`
+      to persist the local high score.
+- [ ] Simple HUD and menus layered with Flutter overlays.

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -6,8 +6,10 @@ See [PLAN.md](PLAN.md) for overall project goals.
 ## Tasks
 
 - [ ] Parallax starfield background renders behind gameplay.
-- [ ] Sound effects via `flame_audio` with a mute toggle.
-- [ ] Local high score stored on device using `shared_preferences`.
+- [ ] Implement `audio_service.dart` wrapping `flame_audio` with a
+      mute toggle.
+- [ ] Implement `storage_service.dart` using `shared_preferences`
+      to persist the local high score.
 - [ ] Simple HUD and menus layered with Flutter overlays.
 
 ## Design Notes


### PR DESCRIPTION
## Summary
- spell out audio and storage service work in the Polish milestone
- enumerate matching tasks in TASKS.md

## Testing
- `npx --yes markdownlint-cli TASKS.md milestone-polish.md`


------
https://chatgpt.com/codex/tasks/task_e_689c1c42eac88330b340a7cf5d38b603