### PR TITLE
docs: sync plan and milestone tasks

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,9 +2,9 @@
 
 Tiny mobile‑first 2D shooter built with Flutter and Flame.
 Target is an offline PWA that a solo developer can iterate on quickly.
-See [DESIGN.md](DESIGN.md) for architecture details. All design docs align with
-this plan, and tasks are enumerated in the milestone docs and consolidated in
-[TASKS.md](TASKS.md) to kick off implementation.
+See [DESIGN.md](DESIGN.md) for architecture details. Design docs have been
+reviewed and aligned; tasks are broken down in the milestone docs and
+consolidated in [TASKS.md](TASKS.md) to kick off implementation.
 
 ## 🎯 Goals
 

--- a/milestone-setup.md
+++ b/milestone-setup.md
@@ -8,6 +8,7 @@ See [PLAN.md](PLAN.md) for the broader roadmap and
 
 - [ ] Pin the Flutter SDK with FVM (`fvm install` and `fvm use`) targeting version
       `3.32.8` as specified in `fvm_config.json`.
+- [ ] Run `fvm flutter doctor` to verify the environment.
 - [ ] Scaffold the project if needed: `fvm flutter create .`.
 - [ ] Enable web support: `fvm flutter config --enable-web`.
 - [ ] Add `flame`, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
@@ -16,7 +17,7 @@ See [PLAN.md](PLAN.md) for the broader roadmap and
       paths and tunable values.
 - [ ] Add a tiny `log.dart` helper that wraps `debugPrint`.
 - [ ] Commit generated folders (`lib/`, `web/`, etc.) and `pubspec.lock`.
-- [ ] Create `assets_manifest.json` to list bundled assets for caching
+- [x] Create `assets_manifest.json` to list bundled assets for caching
       (see `assets_manifest.md`).
 - [ ] Set up a minimal GitHub Actions workflow for lint, test and web deploy.
 - [ ] Document placeholder assets and credits.


### PR DESCRIPTION
## Summary
- Clarify plan intro to note reviewed design docs and consolidated tasks
- Add `fvm flutter doctor` step and mark asset manifest done in setup milestone

## Testing
- `npx markdownlint-cli '**/*.md'` *(fails: AGENTS.md has style issues)*
- `fvm dart format .` *(fails: fvm not installed)*
- `fvm dart analyze` *(fails: fvm not installed)*
- `fvm flutter test` *(fails: fvm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689c1e8e3b9c8330910032a21971d9ea