### PR TITLE
docs: finalize plan and task references

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,9 +2,9 @@
 
 Tiny mobile‑first 2D shooter built with Flutter and Flame.
 Target is an offline PWA that a solo developer can iterate on quickly.
-See [DESIGN.md](DESIGN.md) for architecture details. Design docs have been
-reviewed and aligned; tasks are broken down in the milestone docs and
-consolidated in [TASKS.md](TASKS.md) to kick off implementation.
+See [DESIGN.md](DESIGN.md) for architecture details. All design docs are now
+in sync, and tasks are broken down in the milestone docs and consolidated in
+[TASKS.md](TASKS.md) so we can start coding.
 
 ## 🎯 Goals
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,7 @@
 Tracking immediate work to reach the MVP. See [PLAN.md](PLAN.md) and [DESIGN.md](DESIGN.md)
 for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
-## Setup
+## Setup ([milestone-setup.md](milestone-setup.md))
 
 - [ ] Install FVM and fetch the pinned Flutter SDK (version `3.32.8`).
 - [ ] Run `fvm flutter doctor` to verify the environment.
@@ -20,14 +20,14 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Create `assets_manifest.json` to list bundled assets for caching
   (see `assets_manifest.md`).
 
-## Core Loop
+## Core Loop ([milestone-core-loop.md](milestone-core-loop.md))
 
 - [ ] Player ship moves with joystick or keyboard.
 - [ ] Ship can shoot and destroy a basic enemy type.
 - [ ] Random asteroids spawn and can be mined for score.
 - [ ] Game states: menu → playing → game over with restart.
 
-## Polish
+## Polish ([milestone-polish.md](milestone-polish.md))
 
 - [ ] Parallax starfield renders behind gameplay.
 - [ ] Implement `audio_service.dart` wrapping `flame_audio` with a


### PR DESCRIPTION
## Summary
- clarify that all design docs are synchronized and coding can begin
- link TASKS sections to their corresponding milestone documents

## Testing
- `fvm dart format .` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `markdownlint "**/*.md"` *(fails: multiple lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689c1fd6844883309cf79dada567ab18