### PR TITLE
feat: add player movement

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -22,7 +22,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 ## Core Loop ([milestone-core-loop.md](milestone-core-loop.md))
 
-- [ ] Player ship moves with joystick or keyboard.
+- [x] Player ship moves with joystick or keyboard.
 - [ ] Ship can shoot and destroy a basic enemy type.
 - [ ] Random asteroids spawn and can be mined for score.
 - [ ] Game states: menu → playing → game over with restart.

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,0 +1,76 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/input.dart';
+import 'package:flutter/services.dart';
+
+import '../assets.dart';
+import '../constants.dart';
+import '../game/space_game.dart';
+
+/// Controllable player ship.
+class PlayerComponent extends SpriteComponent
+    with HasGameRef<SpaceGame>, KeyboardHandler {
+  PlayerComponent({required this.joystick})
+    : super(size: Vector2.all(Constants.playerSize), anchor: Anchor.center);
+
+  /// Reference to the on-screen joystick for touch input.
+  final JoystickComponent joystick;
+
+  /// Direction from keyboard input.
+  final Vector2 _keyboardDirection = Vector2.zero();
+
+  @override
+  Future<void> onLoad() async {
+    sprite = await Sprite.load(Assets.player);
+  }
+
+  @override
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    position = size / 2;
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    var input = joystick.delta.isZero()
+        ? _keyboardDirection
+        : joystick.relativeDelta;
+    if (!input.isZero()) {
+      input = input.normalized();
+      position += input * Constants.playerSpeed * dt;
+      position.clamp(
+        Vector2.all(size.x / 2),
+        gameRef.size - Vector2.all(size.x / 2),
+      );
+    }
+  }
+
+  @override
+  bool onKeyEvent(RawKeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
+    _keyboardDirection
+      ..setZero()
+      ..x +=
+          (keysPressed.contains(LogicalKeyboardKey.keyA) ||
+              keysPressed.contains(LogicalKeyboardKey.arrowLeft))
+          ? -1
+          : 0
+      ..x +=
+          (keysPressed.contains(LogicalKeyboardKey.keyD) ||
+              keysPressed.contains(LogicalKeyboardKey.arrowRight))
+          ? 1
+          : 0
+      ..y +=
+          (keysPressed.contains(LogicalKeyboardKey.keyW) ||
+              keysPressed.contains(LogicalKeyboardKey.arrowUp))
+          ? -1
+          : 0
+      ..y +=
+          (keysPressed.contains(LogicalKeyboardKey.keyS) ||
+              keysPressed.contains(LogicalKeyboardKey.arrowDown))
+          ? 1
+          : 0;
+    return true;
+  }
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -7,6 +7,9 @@ class Constants {
   /// Player movement speed in pixels per second.
   static const double playerSpeed = 200;
 
+  /// Player sprite size in logical pixels.
+  static const double playerSize = 32;
+
   /// Bullet travel speed in pixels per second.
   static const double bulletSpeed = 400;
 }

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -1,13 +1,37 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+import 'package:flutter/painting.dart' show EdgeInsets;
+
 import '../assets.dart';
+import '../components/player.dart';
 import 'game_state.dart';
 
 /// Root Flame game handling the core loop.
-class SpaceGame extends FlameGame {
+class SpaceGame extends FlameGame with HasKeyboardHandlerComponents {
   GameState state = GameState.menu;
+  late final PlayerComponent player;
+  late final JoystickComponent joystick;
 
   @override
   Future<void> onLoad() async {
     await Assets.load();
+    joystick = JoystickComponent(
+      knob: CircleComponent(
+        radius: 20,
+        paint: Paint()..color = const Color(0xffffffff),
+      ),
+      background: CircleComponent(
+        radius: 50,
+        paint: Paint()..color = const Color(0x66ffffff),
+      ),
+      margin: const EdgeInsets.only(left: 40, bottom: 40),
+    );
+    add(joystick);
+
+    player = PlayerComponent(joystick: joystick);
+    add(player);
   }
 }

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -6,7 +6,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 ## Tasks
 
-- [ ] Player ship moves using an on-screen joystick or keyboard (WASD).
+- [x] Player ship moves using an on-screen joystick or keyboard (WASD).
 - [ ] Ship fires bullets and destroys a basic enemy type on collision.
 - [ ] Random asteroids spawn and can be mined for score.
 - [ ] Game states: **menu → playing → game over** with quick restart via overlays


### PR DESCRIPTION
## Summary
- add PlayerComponent with joystick and keyboard controls
- spawn player and joystick in SpaceGame
- track player size in constants and update task docs

## Testing
- `fvm dart format lib/game/space_game.dart lib/components/player.dart lib/constants.dart TASKS.md milestone-core-loop.md` (fails: command not found)
- `/tmp/dart-sdk/dart-sdk/bin/dart format lib/components/player.dart lib/game/space_game.dart lib/constants.dart`
- `/tmp/dart-sdk/dart-sdk/bin/dart analyze` (fails: missing Flutter packages)
- `npx markdownlint-cli '**/*.md'` (fails: multiple lint errors)

------
https://chatgpt.com/codex/tasks/task_e_689c28a3eed08330bdc235f4017206d3