### PR TITLE
feat: add Flutter bootstrap scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@ doc/api/
 .flutter-plugins-dependencies
 # Ignore FVM-managed Flutter SDK
 .fvm/
+
+# Local tooling and caches
+.tooling/
+.pub-cache/
+
+# Platform-specific builds
+android/local.properties
+ios/Pods/

--- a/scripts/bootstrap_flutter.sh
+++ b/scripts/bootstrap_flutter.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# === Config ===
+: "${FLUTTER_VERSION:=3.22.2}"   # Pin your version here
+: "${FLUTTER_CHANNEL:=stable}"   # stable | beta
+FLUTTER_DIR=".tooling/flutter"
+
+# Helper: lowercase
+lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# If already present, just ensure PATH and exit
+if [ -x "$FLUTTER_DIR/bin/flutter" ]; then
+  export PATH="$(pwd)/$FLUTTER_DIR/bin:$PATH"
+  # Warm up (non-fatal if doctor shows warnings)
+  .tooling/flutter/bin/flutter --version >/dev/null 2>&1 || true
+  exit 0
+fi
+
+echo "Bootstrapping Flutter $FLUTTER_VERSION ($FLUTTER_CHANNEL)…"
+mkdir -p .tooling
+pushd .tooling >/dev/null
+
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  Linux)
+    ARCHIVE="flutter_linux_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.tar.xz"
+    OS_SLUG="linux"
+    ;;
+  Darwin)
+    ARCHIVE="flutter_macos_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.zip"
+    OS_SLUG="macos"
+    ;;
+  CYGWIN*|MINGW*|MSYS*)
+    echo "Windows bootstrap via bash is not supported here. Use scripts/bootstrap_flutter.ps1."
+    exit 1
+    ;;
+  *)
+    echo "Unsupported OS: $OS_NAME"
+    exit 1
+    ;;
+esac
+
+BASE_URL="https://storage.googleapis.com/flutter_infra_release/releases"
+URL="${BASE_URL}/${FLUTTER_CHANNEL}/$(lower "$OS_SLUG")/${ARCHIVE}"
+echo "Downloading: $URL"
+curl -fL "$URL" -o "$ARCHIVE"
+
+echo "Extracting…"
+if [[ "$ARCHIVE" == *.tar.xz ]]; then
+  tar -xJf "$ARCHIVE"
+else
+  unzip -q "$ARCHIVE"
+fi
+rm -f "$ARCHIVE"
+
+popd >/dev/null
+
+# Put Flutter on PATH for this shell
+export PATH="$(pwd)/$FLUTTER_DIR/bin:$PATH"
+
+# Non-interactive sanity checks (allow warnings)
+.tooling/flutter/bin/flutter --version
+.tooling/flutter/bin/flutter config --enable-web || true
+.tooling/flutter/bin/flutter doctor -v || true

--- a/scripts/dartw
+++ b/scripts/dartw
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/bootstrap_flutter.sh"
+exec ".tooling/flutter/bin/dart" "$@"

--- a/scripts/flutterw
+++ b/scripts/flutterw
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Ensure Flutter exists and PATH is set for this process
+source "$(dirname "$0")/bootstrap_flutter.sh"
+exec ".tooling/flutter/bin/flutter" "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap the Flutter SDK so wrapper scripts can use it.
+"$(dirname "$0")/scripts/bootstrap_flutter.sh" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- add bootstrap scripts that download a pinned Flutter SDK
- provide flutterw/dartw wrappers that ensure bootstrapping
- ignore local tooling and platform-specific files

## Testing
- `bash -n scripts/bootstrap_flutter.sh scripts/flutterw scripts/dartw setup.sh`
- `./scripts/flutterw --version` *(fails: download aborted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_689c3298e87083308fd3cb83293c2c58