### PR TITLE
feat: add shooting and basic enemy

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -23,7 +23,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 ## Core Loop ([milestone-core-loop.md](milestone-core-loop.md))
 
 - [x] Player ship moves with joystick or keyboard.
-- [ ] Ship can shoot and destroy a basic enemy type.
+- [x] Ship can shoot and destroy a basic enemy type.
 - [ ] Random asteroids spawn and can be mined for score.
 - [ ] Game states: menu → playing → game over with restart.
 

--- a/assets_manifest.json
+++ b/assets_manifest.json
@@ -1,5 +1,12 @@
 {
-  "images": [],
-  "audio": [],
+  "images": [
+    "assets/images/player.png",
+    "assets/images/enemy.png",
+    "assets/images/asteroid.png",
+    "assets/images/bullet.png"
+  ],
+  "audio": [
+    "assets/audio/shoot.wav"
+  ],
   "fonts": []
 }

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -14,14 +14,18 @@ Gameplay entities and reusable pieces.
 - Give components deterministic IDs to support future multiplayer sync.
 - Update movement and timers using the `dt` value for frame-rate independence.
 
-## Planned Components
+## Implemented Components
 
 - [PlayerComponent](player.md) – moves via joystick or keyboard, fires bullets
   and tracks health.
-- [EnemyComponent](enemy.md) – drifts toward the player and damages on contact.
+- [EnemyComponent](enemy.md) – drifts toward the player and is destroyed on
+  bullet impact.
+- [BulletComponent](bullet.md) – short-lived projectile destroyed on hit or
+  when leaving the screen.
+
+## Planned Components
+
 - [AsteroidComponent](asteroid.md) – floats randomly; mining yields score
   pickups.
-- [BulletComponent](bullet.md) – short-lived projectile destroyed on hit or
-  timer.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -1,0 +1,45 @@
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+
+import '../assets.dart';
+import '../constants.dart';
+import '../game/space_game.dart';
+import 'enemy.dart';
+
+/// Short-lived projectile fired by the player.
+class BulletComponent extends SpriteComponent
+    with HasGameRef<SpaceGame>, CollisionCallbacks {
+  BulletComponent({required Vector2 position, required Vector2 direction})
+      : _direction = direction.normalized(),
+        super(
+          position: position,
+          size: Vector2.all(Constants.bulletSize),
+          anchor: Anchor.center,
+        );
+
+  final Vector2 _direction;
+
+  @override
+  Future<void> onLoad() async {
+    sprite = await Sprite.load(Assets.bullet);
+    add(CircleHitbox());
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    position += _direction * Constants.bulletSpeed * dt;
+    if (position.y < -size.y || position.y > gameRef.size.y + size.y) {
+      removeFromParent();
+    }
+  }
+
+  @override
+  void onCollisionStart(Set<Vector2> intersectionPoints, PositionComponent other) {
+    super.onCollisionStart(intersectionPoints, other);
+    if (other is EnemyComponent) {
+      other.removeFromParent();
+      removeFromParent();
+    }
+  }
+}

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -1,0 +1,35 @@
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+
+import '../assets.dart';
+import '../constants.dart';
+import '../game/space_game.dart';
+
+/// Basic foe that drifts toward the player.
+class EnemyComponent extends SpriteComponent
+    with HasGameRef<SpaceGame>, CollisionCallbacks {
+  EnemyComponent({Vector2? position})
+      : super(
+          position: position,
+          size: Vector2.all(Constants.enemySize),
+          anchor: Anchor.center,
+        );
+
+  @override
+  Future<void> onLoad() async {
+    sprite = await Sprite.load(Assets.enemy);
+    add(CircleHitbox());
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    final direction = (gameRef.player.position - position).normalized();
+    position += direction * Constants.enemySpeed * dt;
+    if (position.y > gameRef.size.y + size.y ||
+        position.x < -size.x ||
+        position.x > gameRef.size.x + size.x) {
+      removeFromParent();
+    }
+  }
+}

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -2,11 +2,13 @@ import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/input.dart';
+import 'package:flame_audio/flame_audio.dart';
 import 'package:flutter/services.dart';
 
 import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
+import 'bullet.dart';
 
 /// Controllable player ship.
 class PlayerComponent extends SpriteComponent
@@ -19,6 +21,16 @@ class PlayerComponent extends SpriteComponent
 
   /// Direction from keyboard input.
   final Vector2 _keyboardDirection = Vector2.zero();
+
+  /// Fires a bullet from the player's current position.
+  void shoot() {
+    final bullet = BulletComponent(
+      position: position.clone(),
+      direction: Vector2(0, -1),
+    );
+    gameRef.add(bullet);
+    FlameAudio.play(Assets.shootSfx);
+  }
 
   @override
   Future<void> onLoad() async {
@@ -49,6 +61,10 @@ class PlayerComponent extends SpriteComponent
 
   @override
   bool onKeyEvent(RawKeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
+    if (event is RawKeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.space) {
+      shoot();
+    }
     _keyboardDirection
       ..setZero()
       ..x +=

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -12,4 +12,13 @@ class Constants {
 
   /// Bullet travel speed in pixels per second.
   static const double bulletSpeed = 400;
+
+  /// Bullet sprite size in logical pixels.
+  static const double bulletSize = 8;
+
+  /// Enemy movement speed in pixels per second.
+  static const double enemySpeed = 100;
+
+  /// Enemy sprite size in logical pixels.
+  static const double enemySize = 32;
 }

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -1,19 +1,27 @@
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
+import 'package:flame/timer.dart';
 import 'package:flutter/painting.dart' show EdgeInsets;
 
 import '../assets.dart';
+import '../components/enemy.dart';
 import '../components/player.dart';
+import '../constants.dart';
 import 'game_state.dart';
 
 /// Root Flame game handling the core loop.
-class SpaceGame extends FlameGame with HasKeyboardHandlerComponents {
+class SpaceGame extends FlameGame
+    with HasKeyboardHandlerComponents, HasCollisionDetection {
   GameState state = GameState.menu;
   late final PlayerComponent player;
   late final JoystickComponent joystick;
+  late final HudButtonComponent fireButton;
+  late final Timer _enemySpawnTimer;
+  final Random _random = Random();
 
   @override
   Future<void> onLoad() async {
@@ -33,5 +41,33 @@ class SpaceGame extends FlameGame with HasKeyboardHandlerComponents {
 
     player = PlayerComponent(joystick: joystick);
     add(player);
+
+    fireButton = HudButtonComponent(
+      button: CircleComponent(
+        radius: 30,
+        paint: Paint()..color = const Color(0x66ffffff),
+      ),
+      buttonDown: CircleComponent(
+        radius: 30,
+        paint: Paint()..color = const Color(0xffffffff),
+      ),
+      anchor: Anchor.bottomRight,
+      margin: const EdgeInsets.only(right: 40, bottom: 40),
+      onPressed: () => player.shoot(),
+    );
+    add(fireButton);
+
+    _enemySpawnTimer = Timer(2, onTick: _spawnEnemy, repeat: true)..start();
+  }
+
+  void _spawnEnemy() {
+    final x = _random.nextDouble() * size.x;
+    add(EnemyComponent(position: Vector2(x, -Constants.enemySize)));
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    _enemySpawnTimer.update(dt);
   }
 }

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -7,7 +7,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 ## Tasks
 
 - [x] Player ship moves using an on-screen joystick or keyboard (WASD).
-- [ ] Ship fires bullets and destroys a basic enemy type on collision.
+- [x] Ship fires bullets and destroys a basic enemy type on collision.
 - [ ] Random asteroids spawn and can be mined for score.
 - [ ] Game states: **menu → playing → game over** with quick restart via overlays
       and a `GameState` enum.


### PR DESCRIPTION
## Summary
- allow player to fire bullets and destroy simple enemies
- spawn enemies periodically and add on-screen fire button
- track shooting task completion in docs

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx markdownlint '**/*.md'` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c4c87148330beb488801243b7ab