### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- configure Dependabot for Dart `pub` packages and GitHub Actions with weekly update schedule

## Testing
- `dart format .github/dependabot.yml` *(fails: source could not be parsed)*
- `flutter analyze` *(fails: 9 issues found)*
- `flutter test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689efbd6b230833092ca7d454b859178