### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add Dependabot config to keep GitHub Actions and pub packages up to date

## Testing
- `./scripts/dartw format .github/dependabot.yml`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_689efbd6b230833092ca7d454b859178