### PR TITLE
feat: add game state overlays

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -25,7 +25,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Player ship moves with joystick or keyboard.
 - [x] Ship can shoot and destroy a basic enemy type.
 - [x] Random asteroids spawn and can be mined for score.
-- [ ] Game states: menu → playing → game over with restart.
+- [x] Game states: menu → playing → game over with restart.
 
 ## Polish ([milestone-polish.md](milestone-polish.md))
 

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/input.dart';
 import 'package:flame_audio/flame_audio.dart';
@@ -8,11 +9,13 @@ import 'package:flutter/services.dart';
 import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
+import 'asteroid.dart';
 import 'bullet.dart';
+import 'enemy.dart';
 
 /// Controllable player ship.
 class PlayerComponent extends SpriteComponent
-    with HasGameRef<SpaceGame>, KeyboardHandler {
+    with HasGameRef<SpaceGame>, KeyboardHandler, CollisionCallbacks {
   PlayerComponent({required this.joystick})
     : super(size: Vector2.all(Constants.playerSize), anchor: Anchor.center);
 
@@ -35,6 +38,7 @@ class PlayerComponent extends SpriteComponent
   @override
   Future<void> onLoad() async {
     sprite = await Sprite.load(Assets.player);
+    add(CircleHitbox());
   }
 
   @override
@@ -88,5 +92,16 @@ class PlayerComponent extends SpriteComponent
           ? 1
           : 0;
     return true;
+  }
+
+  @override
+  void onCollisionStart(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
+    super.onCollisionStart(intersectionPoints, other);
+    if (other is EnemyComponent || other is AsteroidComponent) {
+      gameRef.gameOver();
+    }
   }
 }

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -10,5 +10,7 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 - Maintain `GameState` values (`menu`, `playing`, `gameOver`) and toggle overlays.
 - Route joystick, button and keyboard input to the player component.
 - Drive the update cycle while delegating work to components and services.
+- Exposes a `ValueNotifier<int>` for score so Flutter overlays can render HUD
+  values without touching the game loop.
 
 See [../../PLAN.md](../../PLAN.md) for the roadmap.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,28 @@
 import 'package:flame/game.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+
+import 'assets.dart';
 import 'game/space_game.dart';
+import 'ui/game_over_overlay.dart';
+import 'ui/hud_overlay.dart';
+import 'ui/menu_overlay.dart';
 
 /// Application entry point.
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Assets.load();
   final game = SpaceGame();
-  runApp(GameWidget(game: game));
+  runApp(
+    MaterialApp(
+      home: GameWidget(
+        game: game,
+        overlayBuilderMap: {
+          MenuOverlay.id: (context, game) => MenuOverlay(game: game),
+          HudOverlay.id: (context, game) => HudOverlay(game: game),
+          GameOverOverlay.id:
+              (context, game) => GameOverOverlay(game: game),
+        },
+      ),
+    ),
+  );
 }

--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../game/space_game.dart';
+
+/// Overlay displayed when the player dies.
+class GameOverOverlay extends StatelessWidget {
+  const GameOverOverlay({super.key, required this.game});
+
+  /// Reference to the running game instance.
+  final SpaceGame game;
+
+  /// Overlay identifier used by [GameWidget].
+  static const String id = 'gameOverOverlay';
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Game Over',
+            style: TextStyle(fontSize: 32, color: Colors.white),
+          ),
+          const SizedBox(height: 20),
+          ValueListenableBuilder<int>(
+            valueListenable: game.score,
+            builder: (context, value, _) => Text(
+              'Final Score: $value',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: game.startGame,
+            child: const Text('Restart'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+import '../game/space_game.dart';
+
+/// Simple heads-up display shown during play.
+class HudOverlay extends StatelessWidget {
+  const HudOverlay({super.key, required this.game});
+
+  /// Running game instance providing score updates.
+  final SpaceGame game;
+
+  /// Overlay identifier used by [GameWidget].
+  static const String id = 'hudOverlay';
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Align(
+        alignment: Alignment.topLeft,
+        child: ValueListenableBuilder<int>(
+          valueListenable: game.score,
+          builder: (context, value, _) => Padding(
+            padding: const EdgeInsets.all(8),
+            child: Text(
+              'Score: $value',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -4,9 +4,8 @@ Heads-up display shown during play.
 
 ## Features
 
-- Shows current score and player health.
-- Contains a mute toggle linked to `AudioService`.
-- Reads values via `ValueNotifier`s or callbacks from `SpaceGame`.
+- Shows current score using a `ValueNotifier` exposed by `SpaceGame`.
+- Player health and a mute toggle will be added in later milestones.
 - Visible only in the `playing` state.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../game/space_game.dart';
+
+/// Start screen shown before gameplay begins.
+class MenuOverlay extends StatelessWidget {
+  const MenuOverlay({super.key, required this.game});
+
+  /// Reference to the running game.
+  final SpaceGame game;
+
+  /// Overlay identifier used by [GameWidget].
+  static const String id = 'menuOverlay';
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Space Miner',
+            style: TextStyle(fontSize: 32, color: Colors.white),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: game.startGame,
+            child: const Text('Start'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -9,7 +9,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Player ship moves using an on-screen joystick or keyboard (WASD).
 - [x] Ship fires bullets and destroys a basic enemy type on collision.
 - [x] Random asteroids spawn and can be mined for score.
-- [ ] Game states: **menu → playing → game over** with quick restart via overlays
+- [x] Game states: **menu → playing → game over** with quick restart via overlays
       and a `GameState` enum.
 
 ## Design Notes


### PR DESCRIPTION
## Summary
- add menu, HUD, and game-over overlays
- wire SpaceGame to manage state transitions and score via ValueNotifier
- detect player collisions with enemies or asteroids to trigger game over

## Testing
- `fvm dart format .` *(fails: command not found)*
- `fvm dart analyze` *(fails: command not found)*
- `npx markdownlint '**/*.md'` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_689f0076247483309fdfdb8577814da1