### PR TITLE
feat: persist high score across sessions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -32,6 +32,6 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [ ] Parallax starfield renders behind gameplay.
 - [ ] Implement `audio_service.dart` wrapping `flame_audio` with a
       mute toggle.
-- [ ] Implement `storage_service.dart` using `shared_preferences`
+- [x] Implement `storage_service.dart` using `shared_preferences`
       to persist the local high score.
 - [ ] Simple HUD and menus layered with Flutter overlays.

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -10,7 +10,8 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 - Maintain `GameState` values (`menu`, `playing`, `gameOver`) and toggle overlays.
 - Route joystick, button and keyboard input to the player component.
 - Drive the update cycle while delegating work to components and services.
-- Exposes a `ValueNotifier<int>` for score so Flutter overlays can render HUD
-  values without touching the game loop.
+- Persist and load the high score through `StorageService`.
+- Exposes `ValueNotifier<int>`s for the current score and persisted high score so
+  Flutter overlays can render values without touching the game loop.
 
 See [../../PLAN.md](../../PLAN.md) for the roadmap.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,12 +6,14 @@ import 'game/space_game.dart';
 import 'ui/game_over_overlay.dart';
 import 'ui/hud_overlay.dart';
 import 'ui/menu_overlay.dart';
+import 'services/storage_service.dart';
 
 /// Application entry point.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Assets.load();
-  final game = SpaceGame();
+  final storage = await StorageService.create();
+  final game = SpaceGame(storageService: storage);
   runApp(
     MaterialApp(
       home: GameWidget<SpaceGame>(

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -4,7 +4,7 @@ Optional helpers for cross-cutting concerns.
 
 - `audio_service.dart` will wrap `flame_audio` to play sound effects and
   handle a mute toggle.
-- `storage_service.dart` will store the local high score using
+- `storage_service.dart` stores the local high score using
   `shared_preferences` and can expand for save/load later.
 - Keep services lightweight; add them only when a milestone needs them.
 

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,0 +1,28 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Simple wrapper around [SharedPreferences] for persisting small bits of data.
+///
+/// Currently only stores and retrieves the local high score but can expand to
+/// handle additional settings in the future.
+class StorageService {
+  StorageService(this._prefs);
+
+  /// Asynchronously create a [StorageService] instance.
+  static Future<StorageService> create() async {
+    final prefs = await SharedPreferences.getInstance();
+    return StorageService(prefs);
+  }
+
+  final SharedPreferences _prefs;
+
+  static const _highScoreKey = 'highScore';
+
+  /// Returns the stored high score or `0` if none exists.
+  int getHighScore() => _prefs.getInt(_highScoreKey) ?? 0;
+
+  /// Persists a new high score value.
+  Future<void> setHighScore(int value) async {
+    await _prefs.setInt(_highScoreKey, value);
+  }
+}
+

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -9,4 +9,9 @@ Handles local persistence using `shared_preferences`.
 - Provide simple async getters and setters.
 - Future expansion can add save/load for other data.
 
+## Usage
+
+Create the service with `await StorageService.create()` and call
+`getHighScore()`/`setHighScore()` to read or update the value.
+
 See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -30,6 +30,14 @@ class GameOverOverlay extends StatelessWidget {
               style: const TextStyle(color: Colors.white),
             ),
           ),
+          const SizedBox(height: 10),
+          ValueListenableBuilder<int>(
+            valueListenable: game.highScore,
+            builder: (context, value, _) => Text(
+              'High Score: $value',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ),
           const SizedBox(height: 20),
           ElevatedButton(
             onPressed: game.startGame,

--- a/lib/ui/game_over_overlay.md
+++ b/lib/ui/game_over_overlay.md
@@ -4,9 +4,8 @@ Flutter widget shown when the player dies.
 
 ## Features
 
-- Displays final score and a restart button.
+- Displays final score and the persisted high score.
 - Tapping restart resets `SpaceGame` to the `playing` state.
-- May show a high score loaded via `StorageService`.
 - Visible when `GameState.gameOver` is active.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -23,6 +23,17 @@ class MenuOverlay extends StatelessWidget {
             style: TextStyle(fontSize: 32, color: Colors.white),
           ),
           const SizedBox(height: 20),
+          ValueListenableBuilder<int>(
+            valueListenable: game.highScore,
+            builder: (context, value, _) =>
+                value > 0
+                    ? Text(
+                        'High Score: $value',
+                        style: const TextStyle(color: Colors.white),
+                      )
+                    : const SizedBox.shrink(),
+          ),
+          const SizedBox(height: 20),
           ElevatedButton(
             onPressed: game.startGame,
             child: const Text('Start'),

--- a/lib/ui/menu_overlay.md
+++ b/lib/ui/menu_overlay.md
@@ -4,7 +4,7 @@ Flutter widget shown before gameplay starts.
 
 ## Features
 
-- Displays the game title and basic instructions.
+- Displays the game title and current high score.
 - Start button signals `SpaceGame` to enter the `playing` state.
 - Accesses the game via callbacks or a `ValueNotifier`.
 - Visible when `GameState.menu` is active.


### PR DESCRIPTION
## Summary
- add StorageService using shared_preferences
- wire SpaceGame and overlays to load and save persistent high score
- document storage service and update tasks

## Testing
- `./scripts/dartw format lib/main.dart lib/game/space_game.dart lib/ui/menu_overlay.dart lib/ui/game_over_overlay.dart lib/services/storage_service.dart` and `./scripts/dartw analyze`
- `markdownlint '**/*.md'` *(fails: AGENTS.md and others violate markdownlint rules)*
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68a945cec2a083308e88e1b619dd10e1