### PR TITLE
fix: update Flutter bootstrap and wrapper support

### DIFF
--- a/scripts/bootstrap_flutter.ps1
+++ b/scripts/bootstrap_flutter.ps1
@@ -3,17 +3,18 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 # === Config ===
-$FLUTTER_VERSION = if ($env:FLUTTER_VERSION) { $env:FLUTTER_VERSION } else { '3.22.2' }
+$FLUTTER_VERSION = if ($env:FLUTTER_VERSION) { $env:FLUTTER_VERSION } else { '3.32.8' }
 $FLUTTER_CHANNEL = if ($env:FLUTTER_CHANNEL) { $env:FLUTTER_CHANNEL } else { 'stable' }
 $FLUTTER_DIR = '.tooling/flutter'
 
 # If already present, just ensure PATH and exit
 if (Test-Path "$FLUTTER_DIR/bin/flutter.bat") {
     $env:PATH = (Resolve-Path "$FLUTTER_DIR/bin").Path + ";" + $env:PATH
+    try { git config --global --add safe.directory (Resolve-Path "$FLUTTER_DIR").Path } catch {}
     try {
         & "$FLUTTER_DIR/bin/flutter.bat" --version | Out-Null
     } catch {}
-    exit 0
+    return
 }
 
 Write-Host "Bootstrapping Flutter $FLUTTER_VERSION ($FLUTTER_CHANNEL)…"
@@ -34,6 +35,7 @@ Pop-Location
 
 # Put Flutter on PATH for this session
 $env:PATH = (Resolve-Path "$FLUTTER_DIR/bin").Path + ";" + $env:PATH
+try { git config --global --add safe.directory (Resolve-Path "$FLUTTER_DIR").Path } catch {}
 
 # Non-interactive sanity checks (allow warnings)
 & "$FLUTTER_DIR/bin/flutter.bat" --version

--- a/scripts/bootstrap_flutter.sh
+++ b/scripts/bootstrap_flutter.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # === Config ===
-: "${FLUTTER_VERSION:=3.22.2}"   # Pin your version here
+: "${FLUTTER_VERSION:=3.32.8}"   # Pin your version here
 : "${FLUTTER_CHANNEL:=stable}"   # stable | beta
 FLUTTER_DIR=".tooling/flutter"
 
@@ -12,9 +12,10 @@ lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
 # If already present, just ensure PATH and exit
 if [ -x "$FLUTTER_DIR/bin/flutter" ]; then
   export PATH="$(pwd)/$FLUTTER_DIR/bin:$PATH"
+  git config --global --add safe.directory "$(pwd)/$FLUTTER_DIR" 2>/dev/null || true
   # Warm up (non-fatal if doctor shows warnings)
   .tooling/flutter/bin/flutter --version >/dev/null 2>&1 || true
-  exit 0
+  return 0 2>/dev/null || exit 0
 fi
 
 echo "Bootstrapping Flutter $FLUTTER_VERSION ($FLUTTER_CHANNEL)…"
@@ -58,6 +59,7 @@ popd >/dev/null
 
 # Put Flutter on PATH for this shell
 export PATH="$(pwd)/$FLUTTER_DIR/bin:$PATH"
+git config --global --add safe.directory "$(pwd)/$FLUTTER_DIR" 2>/dev/null || true
 
 # Non-interactive sanity checks (allow warnings)
 .tooling/flutter/bin/flutter --version


### PR DESCRIPTION
## Summary
- pin bootstrap script to Flutter 3.32.8
- ensure bootstrap returns when sourced so wrapper scripts run
- mark downloaded SDK as git safe directory to silence warnings

## Testing
- `./setup.sh` *(installs Flutter 3.32.8 and runs flutter doctor)*
- `./scripts/flutterw --version`
- `./scripts/dartw --version`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68a948705d2c8330a204d07d697903b3