### PR TITLE
feat: add audio service with mute toggle

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -30,7 +30,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 ## Polish ([milestone-polish.md](milestone-polish.md))
 
 - [ ] Parallax starfield renders behind gameplay.
-- [ ] Implement `audio_service.dart` wrapping `flame_audio` with a
+- [x] Implement `audio_service.dart` wrapping `flame_audio` with a
       mute toggle.
 - [x] Implement `storage_service.dart` using `shared_preferences`
       to persist the local high score.

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,6 +1,5 @@
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
-import 'package:flame_audio/flame_audio.dart';
 import 'package:flutter/services.dart';
 
 import '../assets.dart';
@@ -29,7 +28,7 @@ class PlayerComponent extends SpriteComponent
       direction: Vector2(0, -1),
     );
     game.add(bullet);
-    FlameAudio.play(Assets.shootSfx);
+    game.audioService.playShoot();
   }
 
   @override

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -13,6 +13,7 @@ import '../components/bullet.dart';
 import '../components/player.dart';
 import '../constants.dart';
 import '../services/storage_service.dart';
+import '../services/audio_service.dart';
 import '../ui/game_over_overlay.dart';
 import '../ui/hud_overlay.dart';
 import '../ui/menu_overlay.dart';
@@ -21,10 +22,13 @@ import 'game_state.dart';
 /// Root Flame game handling the core loop.
 class SpaceGame extends FlameGame
     with HasKeyboardHandlerComponents, HasCollisionDetection {
-  SpaceGame({required this.storageService});
+  SpaceGame({required this.storageService, required this.audioService});
 
   /// Handles persistence for the high score.
   final StorageService storageService;
+
+  /// Plays sound effects and handles the mute toggle.
+  final AudioService audioService;
 
   GameState state = GameState.menu;
   late final PlayerComponent player;

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -13,5 +13,6 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 - Persist and load the high score through `StorageService`.
 - Exposes `ValueNotifier<int>`s for the current score and persisted high score so
   Flutter overlays can render values without touching the game loop.
+- Provide access to `AudioService` for playing sound effects and toggling mute.
 
 See [../../PLAN.md](../../PLAN.md) for the roadmap.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,13 +7,18 @@ import 'ui/game_over_overlay.dart';
 import 'ui/hud_overlay.dart';
 import 'ui/menu_overlay.dart';
 import 'services/storage_service.dart';
+import 'services/audio_service.dart';
 
 /// Application entry point.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Assets.load();
   final storage = await StorageService.create();
-  final game = SpaceGame(storageService: storage);
+  final audio = await AudioService.create(storage);
+  final game = SpaceGame(
+    storageService: storage,
+    audioService: audio,
+  );
   runApp(
     MaterialApp(
       home: GameWidget<SpaceGame>(

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -2,10 +2,10 @@
 
 Optional helpers for cross-cutting concerns.
 
-- `audio_service.dart` will wrap `flame_audio` to play sound effects and
-  handle a mute toggle.
-- `storage_service.dart` stores the local high score using
-  `shared_preferences` and can expand for save/load later.
+- `audio_service.dart` wraps `flame_audio` to play sound effects and
+  handles a mute toggle persisted via `StorageService`.
+- `storage_service.dart` stores the local high score and mute setting using
+  `shared_preferences`.
 - Keep services lightweight; add them only when a milestone needs them.
 
 ## Planned Services

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -1,0 +1,33 @@
+import 'package:flame_audio/flame_audio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../assets.dart';
+import 'storage_service.dart';
+
+/// Wrapper around `flame_audio` providing sound effects with a mute toggle.
+class AudioService {
+  AudioService._(this._storage, this.muted);
+
+  /// Asynchronously create the service and load the persisted mute flag.
+  static Future<AudioService> create(StorageService storage) async {
+    final muted = ValueNotifier<bool>(storage.isMuted());
+    return AudioService._(storage, muted);
+  }
+
+  final StorageService _storage;
+
+  /// Whether audio is muted. Exposed as a [ValueNotifier] for UI binding.
+  final ValueNotifier<bool> muted;
+
+  /// Toggles the mute flag and persists the new value.
+  Future<void> toggleMute() async {
+    muted.value = !muted.value;
+    await _storage.setMuted(muted.value);
+  }
+
+  /// Plays the shoot sound effect if not muted.
+  void playShoot() {
+    if (muted.value) return;
+    FlameAudio.play(Assets.shootSfx);
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -16,6 +16,7 @@ class StorageService {
   final SharedPreferences _prefs;
 
   static const _highScoreKey = 'highScore';
+  static const _mutedKey = 'muted';
 
   /// Returns the stored high score or `0` if none exists.
   int getHighScore() => _prefs.getInt(_highScoreKey) ?? 0;
@@ -23,6 +24,14 @@ class StorageService {
   /// Persists a new high score value.
   Future<void> setHighScore(int value) async {
     await _prefs.setInt(_highScoreKey, value);
+  }
+
+  /// Whether audio is muted; defaults to `false` if unset.
+  bool isMuted() => _prefs.getBool(_mutedKey) ?? false;
+
+  /// Persists the mute flag.
+  Future<void> setMuted(bool value) async {
+    await _prefs.setBool(_mutedKey, value);
   }
 }
 

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -5,13 +5,14 @@ Handles local persistence using `shared_preferences`.
 ## Responsibilities
 
 - Save and load the local high score.
-- Optionally store settings like the mute flag.
+- Store settings such as the mute flag.
 - Provide simple async getters and setters.
 - Future expansion can add save/load for other data.
 
 ## Usage
 
 Create the service with `await StorageService.create()` and call
-`getHighScore()`/`setHighScore()` to read or update the value.
+`getHighScore()`/`setHighScore()` or `isMuted()`/`setMuted()` to read or update
+values.
 
 See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -15,17 +15,32 @@ class HudOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Align(
-        alignment: Alignment.topLeft,
-        child: ValueListenableBuilder<int>(
-          valueListenable: game.score,
-          builder: (context, value, _) => Padding(
-            padding: const EdgeInsets.all(8),
-            child: Text(
-              'Score: $value',
-              style: const TextStyle(color: Colors.white),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            ValueListenableBuilder<int>(
+              valueListenable: game.score,
+              builder: (context, value, _) => Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  'Score: $value',
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ),
             ),
-          ),
+            ValueListenableBuilder<bool>(
+              valueListenable: game.audioService.muted,
+              builder: (context, muted, _) => IconButton(
+                icon: Icon(
+                  muted ? Icons.volume_off : Icons.volume_up,
+                  color: Colors.white,
+                ),
+                onPressed: game.audioService.toggleMute,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -5,7 +5,8 @@ Heads-up display shown during play.
 ## Features
 
 - Shows current score using a `ValueNotifier` exposed by `SpaceGame`.
-- Player health and a mute toggle will be added in later milestones.
+- Provides a mute button bound to `AudioService`.
+- Player health will be added in a later milestone.
 - Visible only in the `playing` state.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -7,9 +7,9 @@ See [PLAN.md](PLAN.md) for overall project goals and
 ## Tasks
 
 - [ ] Parallax starfield background renders behind gameplay.
-- [ ] Implement `audio_service.dart` wrapping `flame_audio` with a
+- [x] Implement `audio_service.dart` wrapping `flame_audio` with a
       mute toggle.
-- [ ] Implement `storage_service.dart` using `shared_preferences`
+- [x] Implement `storage_service.dart` using `shared_preferences`
       to persist the local high score.
 - [ ] Simple HUD and menus layered with Flutter overlays.
 


### PR DESCRIPTION
## Summary
- add `AudioService` to manage sound effects with persistent mute toggle
- integrate audio service into game, player shooting, and HUD overlay
- document and track audio service work in tasks and milestone

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'` *(fails: existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a94cd35d5483309d5811d16fb0b278