### PR TITLE
Install FVM and Chromium in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,5 +3,37 @@ set -euo pipefail
 
 # Bootstrap the Flutter SDK so wrapper scripts can use it.
 echo "[setup] Bootstrapping Flutter SDK"
-"$(dirname "$0")/scripts/bootstrap_flutter.sh"
+source "$(dirname "$0")/scripts/bootstrap_flutter.sh"
+
+# Install FVM (Flutter Version Manager) if it isn't available.
+if ! command -v fvm >/dev/null 2>&1; then
+  echo "[setup] Installing FVM"
+  dart pub global activate fvm >/dev/null
+fi
+# Add pub global binaries to PATH for the current shell.
+export PATH="$HOME/.pub-cache/bin:$PATH"
+
+# Ensure a Chrome-compatible browser exists for Flutter web runs.
+if ! command -v google-chrome >/dev/null 2>&1 && \
+   ! command -v chromium-browser >/dev/null 2>&1 && \
+   ! command -v chromium >/dev/null 2>&1; then
+  echo "[setup] Installing Chromium"
+  case "$(uname -s)" in
+    Linux*)
+      if command -v apt-get >/dev/null 2>&1; then
+        apt-get update || true
+        apt-get install -y chromium-browser || apt-get install -y chromium || true
+      fi
+      ;;
+    Darwin*)
+      if command -v brew >/dev/null 2>&1; then
+        brew install --cask google-chrome || true
+      fi
+      ;;
+    *)
+      echo "[setup] Skipping Chrome install: unsupported OS"
+      ;;
+  esac
+fi
+
 echo "[setup] Completed"


### PR DESCRIPTION
## Summary
- install FVM via `dart pub global activate` during setup
- attempt Chromium or Chrome installation if no browser found
- source Flutter bootstrap script so `dart` is available within setup

## Testing
- `./setup.sh`
- `./scripts/flutterw --version`
- `./scripts/dartw pub get`
- `./scripts/dartw format setup.sh` *(fails: source could not be parsed)*
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint '**/*.md'` *(fails: executable not found)*
- `~/.pub-cache/bin/fvm --version`
- `which chromium-browser`


------
https://chatgpt.com/codex/tasks/task_e_68a99627dbbc8330a979984fc49011fa