### PR TITLE
fix: enhance setup tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ milestone goals, and `networking.md` for future multiplayer plans. See
 ## Flutter Tooling
 
 Run `./setup.sh` after cloning to download the pinned Flutter SDK into
-`.tooling/flutter` and add it to your `PATH` for the current shell. The
-repository provides wrapper scripts for both Unix-like shells and Windows, which
-bootstrap this SDK on demand and then delegate to the real `flutter` and `dart`
-binaries:
+`.tooling/flutter`, install the FVM and Markdown tooling, and add pub global
+binaries to your `PATH`. The repository provides wrapper scripts for both
+Unix-like shells and Windows, which bootstrap this SDK on demand and then
+delegate to the real `flutter` and `dart` binaries:
 
 - Unix shells: `scripts/flutterw`, `scripts/dartw`
 - PowerShell: `scripts\flutterw.ps1`, `scripts\dartw.ps1`

--- a/scripts/dartw
+++ b/scripts/dartw
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 source "$(dirname "$0")/bootstrap_flutter.sh"
+if [[ "${1-}" == "format" && $# -eq 1 ]]; then
+  set -- "$1" .
+fi
 exec ".tooling/flutter/bin/dart" "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -5,13 +5,39 @@ set -euo pipefail
 echo "[setup] Bootstrapping Flutter SDK"
 source "$(dirname "$0")/scripts/bootstrap_flutter.sh"
 
+# Add pub global binaries to PATH and persist for future shells.
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+PUB_CACHE_BIN="$HOME/.pub-cache/bin"
+FLUTTER_BIN="$REPO_ROOT/.tooling/flutter/bin"
+if [[ ":$PATH:" != *":$PUB_CACHE_BIN:"* ]]; then
+  export PATH="$PUB_CACHE_BIN:$PATH"
+fi
+if [[ ":$PATH:" != *":$FLUTTER_BIN:"* ]]; then
+  export PATH="$FLUTTER_BIN:$PATH"
+fi
+shell_profile="$HOME/.bashrc"
+if [ -w "$shell_profile" ]; then
+  if ! grep -q "$PUB_CACHE_BIN" "$shell_profile" 2>/dev/null; then
+    printf '\nexport PATH="%s:$PATH"\n' "$PUB_CACHE_BIN" >> "$shell_profile"
+    echo "[setup] Added $PUB_CACHE_BIN to PATH in $shell_profile"
+  fi
+  if ! grep -q "$FLUTTER_BIN" "$shell_profile" 2>/dev/null; then
+    printf '\nexport PATH="%s:$PATH"\n' "$FLUTTER_BIN" >> "$shell_profile"
+    echo "[setup] Added $FLUTTER_BIN to PATH in $shell_profile"
+  fi
+fi
+
 # Install FVM (Flutter Version Manager) if it isn't available.
 if ! command -v fvm >/dev/null 2>&1; then
   echo "[setup] Installing FVM"
   dart pub global activate fvm >/dev/null
 fi
-# Add pub global binaries to PATH for the current shell.
-export PATH="$HOME/.pub-cache/bin:$PATH"
+
+# Install markdownlint CLI for Markdown linting if missing.
+if ! command -v markdownlint >/dev/null 2>&1; then
+  echo "[setup] Installing markdownlint-cli"
+  npm install -g markdownlint-cli >/dev/null 2>&1 || echo "[setup] Failed to install markdownlint-cli"
+fi
 
 # Ensure a Chrome-compatible browser exists for Flutter web runs.
 if ! command -v google-chrome >/dev/null 2>&1 && \


### PR DESCRIPTION
## Summary
- persist pub-cache and Flutter SDK paths in `setup.sh`
- install FVM and markdownlint CLI during setup
- default `dartw format` to run on the repo root
- document setup script improvements

## Testing
- `./setup.sh`
- `bash -ic 'fvm --version'`
- `markdownlint --version`
- `npx markdownlint '**/*.md'` *(fails: line-length etc.)*
- `./scripts/dartw format`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68a9af4647c08330a614702bc5d88e4e