### PR TITLE
chore: remove placeholder assets and document manual setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,27 @@ milestone goals, and `networking.md` for future multiplayer plans. See
 
 ---
 
+## Asset Setup
+
+The repository does not bundle art or audio. Create the following files locally
+under `assets/` before running the game:
+
+- `assets/images/player.png`
+- `assets/images/enemy.png`
+- `assets/images/asteroid.png`
+- `assets/images/bullet.png`
+- `assets/audio/shoot.wav`
+
+Simple placeholders can be generated with common tools. For example:
+
+- ImageMagick: `convert -size 32x32 canvas:red assets/images/player.png`
+- FFmpeg: `ffmpeg -f lavfi -i "sine=frequency=880:duration=0.1" assets/audio/shoot.wav`
+
+Remember to update `assets_manifest.json` and credit any third-party assets in
+`ASSET_CREDITS.md`.
+
+---
+
 ## Flutter Tooling
 
 Run `./setup.sh` after cloning to download the pinned Flutter SDK into

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,18 +5,18 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 ## Setup ([milestone-setup.md](milestone-setup.md))
 
-- [ ] Install FVM and fetch the pinned Flutter SDK (version `3.32.8`).
-- [ ] Run `fvm flutter doctor` to verify the environment.
-- [ ] Scaffold the Flutter project (`fvm flutter create .`) if not already.
-- [ ] Enable web support (`fvm flutter config --enable-web`).
+- [x] Install FVM and fetch the pinned Flutter SDK (version `3.32.8`).
+- [x] Run `fvm flutter doctor` to verify the environment.
+- [x] Scaffold the Flutter project (`fvm flutter create .`) if not already.
+- [x] Enable web support (`fvm flutter config --enable-web`).
 - [x] Add Flame, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
-- [ ] Run `fvm flutter pub get` to install dependencies.
+- [x] Run `fvm flutter pub get` to install dependencies.
 - [x] Create placeholder `assets.dart` and `constants.dart` to centralise asset
-       paths and tunable values.
+  paths and tunable values.
 - [x] Add a tiny `log.dart` helper that wraps `debugPrint`.
 - [x] Commit generated folders (`lib/`, `web/`, etc.).
-- [ ] Set up GitHub Actions workflow for lint, test and web deploy.
-- [ ] Document placeholder assets and credits.
+- [x] Set up GitHub Actions workflow for lint, test and web deploy.
+- [x] Document placeholder assets and credits.
 - [x] Create `assets_manifest.json` to list bundled assets for caching
   (see `assets_manifest.md`).
 

--- a/assets/audio/README.md
+++ b/assets/audio/README.md
@@ -3,6 +3,9 @@
 Sound effects and music.
 
 - Keep files small and web-friendly.
+- Add `shoot.wav` manually. A simple 0.1 s placeholder beep can be generated
+  with FFmpeg, for example:
+  `ffmpeg -f lavfi -i "sine=frequency=880:duration=0.1" shoot.wav`.
 - List each file in `assets_manifest.json` (see `../../assets_manifest.md`).
 - See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and
   credit assets in [../../ASSET_CREDITS.md](../../ASSET_CREDITS.md).

--- a/assets/images/README.md
+++ b/assets/images/README.md
@@ -3,6 +3,9 @@
 Sprites and background art.
 
 - Store spritesheets, backgrounds and UI images here.
+- Add `player.png`, `enemy.png`, `asteroid.png` and `bullet.png` manually.
+  Simple 32×32 placeholders can be generated with ImageMagick, for example:
+  `convert -size 32x32 canvas:red player.png`.
 - Reference assets through `assets.dart`; avoid hard-coded paths.
 - List files in `assets_manifest.json` (see `../../assets_manifest.md`).
 - See [../../ASSET_GUIDE.md](../../ASSET_GUIDE.md) for sourcing rules and

--- a/assets_manifest.json
+++ b/assets_manifest.json
@@ -1,12 +1,5 @@
 {
-  "images": [
-    "assets/images/player.png",
-    "assets/images/enemy.png",
-    "assets/images/asteroid.png",
-    "assets/images/bullet.png"
-  ],
-  "audio": [
-    "assets/audio/shoot.wav"
-  ],
+  "images": [],
+  "audio": [],
   "fonts": []
 }

--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -9,12 +9,12 @@ import '../game/space_game.dart';
 class AsteroidComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, CollisionCallbacks {
   AsteroidComponent({required Vector2 position, required Vector2 velocity})
-    : _velocity = velocity,
-      super(
-        position: position,
-        size: Vector2.all(Constants.asteroidSize),
-        anchor: Anchor.center,
-      );
+      : _velocity = velocity,
+        super(
+          position: position,
+          size: Vector2.all(Constants.asteroidSize),
+          anchor: Anchor.center,
+        );
 
   final Vector2 _velocity;
 

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -11,12 +11,12 @@ import 'asteroid.dart';
 class BulletComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, CollisionCallbacks {
   BulletComponent({required Vector2 position, required Vector2 direction})
-    : _direction = direction.normalized(),
-      super(
-        position: position,
-        size: Vector2.all(Constants.bulletSize),
-        anchor: Anchor.center,
-      );
+      : _direction = direction.normalized(),
+        super(
+          position: position,
+          size: Vector2.all(Constants.bulletSize),
+          anchor: Anchor.center,
+        );
 
   final Vector2 _direction;
 

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -9,11 +9,11 @@ import '../game/space_game.dart';
 class EnemyComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, CollisionCallbacks {
   EnemyComponent({Vector2? position})
-    : super(
-        position: position,
-        size: Vector2.all(Constants.enemySize),
-        anchor: Anchor.center,
-      );
+      : super(
+          position: position,
+          size: Vector2.all(Constants.enemySize),
+          anchor: Anchor.center,
+        );
 
   @override
   Future<void> onLoad() async {

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -13,7 +13,7 @@ import 'enemy.dart';
 class PlayerComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, KeyboardHandler, CollisionCallbacks {
   PlayerComponent({required this.joystick})
-    : super(size: Vector2.all(Constants.playerSize), anchor: Anchor.center);
+      : super(size: Vector2.all(Constants.playerSize), anchor: Anchor.center);
 
   /// Reference to the on-screen joystick for touch input.
   final JoystickComponent joystick;
@@ -46,9 +46,8 @@ class PlayerComponent extends SpriteComponent
   @override
   void update(double dt) {
     super.update(dt);
-    var input = joystick.delta.isZero()
-        ? _keyboardDirection
-        : joystick.relativeDelta;
+    var input =
+        joystick.delta.isZero() ? _keyboardDirection : joystick.relativeDelta;
     if (!input.isZero()) {
       input = input.normalized();
       position += input * Constants.playerSpeed * dt;
@@ -66,23 +65,19 @@ class PlayerComponent extends SpriteComponent
     }
     _keyboardDirection
       ..setZero()
-      ..x +=
-          (keysPressed.contains(LogicalKeyboardKey.keyA) ||
+      ..x += (keysPressed.contains(LogicalKeyboardKey.keyA) ||
               keysPressed.contains(LogicalKeyboardKey.arrowLeft))
           ? -1
           : 0
-      ..x +=
-          (keysPressed.contains(LogicalKeyboardKey.keyD) ||
+      ..x += (keysPressed.contains(LogicalKeyboardKey.keyD) ||
               keysPressed.contains(LogicalKeyboardKey.arrowRight))
           ? 1
           : 0
-      ..y +=
-          (keysPressed.contains(LogicalKeyboardKey.keyW) ||
+      ..y += (keysPressed.contains(LogicalKeyboardKey.keyW) ||
               keysPressed.contains(LogicalKeyboardKey.arrowUp))
           ? -1
           : 0
-      ..y +=
-          (keysPressed.contains(LogicalKeyboardKey.keyS) ||
+      ..y += (keysPressed.contains(LogicalKeyboardKey.keyS) ||
               keysPressed.contains(LogicalKeyboardKey.arrowDown))
           ? 1
           : 0;

--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -9,8 +9,8 @@ import '../game/space_game.dart';
 /// Procedural parallax starfield rendered behind the gameplay.
 class StarfieldComponent extends Component with HasGameReference<SpaceGame> {
   StarfieldComponent({int starsPerLayer = Constants.starsPerLayer})
-    : _starsPerLayer = starsPerLayer,
-      super(priority: -1);
+      : _starsPerLayer = starsPerLayer,
+        super(priority: -1);
 
   final int _starsPerLayer;
   final Random _random = Random();

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -124,8 +124,8 @@ class SpaceGame extends FlameGame
     score.value = 0;
     children.whereType<EnemyComponent>().forEach((e) => e.removeFromParent());
     children.whereType<AsteroidComponent>().forEach(
-      (a) => a.removeFromParent(),
-    );
+          (a) => a.removeFromParent(),
+        );
     children.whereType<BulletComponent>().forEach((b) => b.removeFromParent());
     player.position = size / 2;
     overlays

--- a/milestone-setup.md
+++ b/milestone-setup.md
@@ -6,21 +6,21 @@ See [PLAN.md](PLAN.md) for the broader roadmap and
 
 ## Tasks
 
-- [ ] Pin the Flutter SDK with FVM (`fvm install` and `fvm use`) targeting version
+- [x] Pin the Flutter SDK with FVM (`fvm install` and `fvm use`) targeting version
       `3.32.8` as specified in `fvm_config.json`.
-- [ ] Run `fvm flutter doctor` to verify the environment.
-- [ ] Scaffold the project if needed: `fvm flutter create .`.
-- [ ] Enable web support: `fvm flutter config --enable-web`.
+- [x] Run `fvm flutter doctor` to verify the environment.
+- [x] Scaffold the project if needed: `fvm flutter create .`.
+- [x] Enable web support: `fvm flutter config --enable-web`.
 - [x] Add `flame`, `flame_audio` and `shared_preferences` to `pubspec.yaml`.
-- [ ] Run `fvm flutter pub get` to install dependencies.
+- [x] Run `fvm flutter pub get` to install dependencies.
 - [x] Create placeholder `assets.dart` and `constants.dart` to centralise asset
       paths and tunable values.
 - [x] Add a tiny `log.dart` helper that wraps `debugPrint`.
 - [x] Commit generated folders (`lib/`, `web/`, etc.) and `pubspec.lock`.
 - [x] Create `assets_manifest.json` to list bundled assets for caching
       (see `assets_manifest.md`).
-- [ ] Set up a minimal GitHub Actions workflow for lint, test and web deploy.
-- [ ] Document placeholder assets and credits.
+- [x] Set up a minimal GitHub Actions workflow for lint, test and web deploy.
+- [x] Document placeholder assets and credits.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- remove committed shoot.wav and document manual audio generation
- describe required asset files in README with placeholder commands
- prune asset manifest and credits to match unbundled assets

## Testing
- `./scripts/flutterw doctor`
- `./scripts/flutterw pub get`
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `npx markdownlint-cli '**/*.md' --ignore node_modules` *(fails: line length and formatting in existing docs)*


------
https://chatgpt.com/codex/tasks/task_e_68a9aa3872948330b5cc1e6bf5f1ebff