### PR TITLE
test: add service persistence tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -35,3 +35,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Implement `storage_service.dart` using `shared_preferences`
       to persist the local high score.
 - [x] Simple HUD and menus layered with Flutter overlays.
+
+## Testing
+
+- [x] Add unit tests for storage and audio services.

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/audio_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('StorageService', () {
+    test('persists and retrieves high score', () async {
+      SharedPreferences.setMockInitialValues({});
+      final storage = await StorageService.create();
+      expect(storage.getHighScore(), 0);
+      await storage.setHighScore(42);
+      expect(storage.getHighScore(), 42);
+    });
+  });
+
+  group('AudioService', () {
+    test('toggleMute updates storage', () async {
+      SharedPreferences.setMockInitialValues({});
+      final storage = await StorageService.create();
+      final audio = await AudioService.create(storage);
+      expect(audio.muted.value, isFalse);
+      await audio.toggleMute();
+      expect(audio.muted.value, isTrue);
+      expect(storage.isMuted(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for storage and audio services
- track testing work in TASKS backlog

## Testing
- `./scripts/dartw analyze` *(fails: warnings present)*
- `./scripts/flutterw test`
- `npx markdownlint '**/*.md'` *(fails: warnings present)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b42d0b0c8330b41a837d44fab0cc