### PR TITLE
feat: add score for enemy kills

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -143,7 +143,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 
 - Touch/joystick movement and shooting
 - One enemy type with collision and random spawns
-- Asteroids to mine for score or pickups
+- Asteroids to mine for score; destroying enemies also grants points
 - Single endless level without progression for now
 - Player health and simple start/game‑over screens
 - Local high score stored on device (e.g., shared preferences)

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,6 +25,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Player ship moves with joystick or keyboard.
 - [x] Ship can shoot and destroy a basic enemy type.
 - [x] Random asteroids spawn and can be mined for score.
+- [x] Destroying enemies awards score.
 - [x] Game states: menu → playing → game over with restart.
 
 ## Polish ([milestone-polish.md](milestone-polish.md))

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -19,7 +19,7 @@ Gameplay entities and reusable pieces.
 - [PlayerComponent](player.md) – moves via joystick or keyboard, fires bullets
   and tracks health.
 - [EnemyComponent](enemy.md) – drifts toward the player and is destroyed on
-  bullet impact.
+  bullet impact, awarding score when defeated.
 - [BulletComponent](bullet.md) – short-lived projectile destroyed on hit or
   when leaving the screen.
 - [AsteroidComponent](asteroid.md) – floats randomly and awards score when

--- a/lib/components/asteroid.md
+++ b/lib/components/asteroid.md
@@ -7,6 +7,7 @@ Neutral obstacle that can be mined for score.
 - Spawns randomly and drifts across the play area.
 - Destroyed by bullets or mining action; awards score pickups.
 - Uses sprites from `assets.dart` and numbers from `constants.dart`.
+- Awards `Constants.asteroidScore` points when destroyed.
 - Consider small object pool to reuse instances.
 - Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -11,12 +11,12 @@ import 'asteroid.dart';
 class BulletComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, CollisionCallbacks {
   BulletComponent({required Vector2 position, required Vector2 direction})
-      : _direction = direction.normalized(),
-        super(
-          position: position,
-          size: Vector2.all(Constants.bulletSize),
-          anchor: Anchor.center,
-        );
+    : _direction = direction.normalized(),
+      super(
+        position: position,
+        size: Vector2.all(Constants.bulletSize),
+        anchor: Anchor.center,
+      );
 
   final Vector2 _direction;
 
@@ -44,11 +44,12 @@ class BulletComponent extends SpriteComponent
     if (other is EnemyComponent) {
       other.removeFromParent();
       removeFromParent();
+      game.addScore(Constants.enemyScore);
     }
     if (other is AsteroidComponent) {
       other.removeFromParent();
       removeFromParent();
-      game.addScore(1);
+      game.addScore(Constants.asteroidScore);
     }
   }
 }

--- a/lib/components/bullet.md
+++ b/lib/components/bullet.md
@@ -7,6 +7,7 @@ Short-lived projectile fired by the player.
 - Travels in a straight line from the player's ship.
 - Destroyed on impact or after a brief lifetime.
 - Uses sprite from `assets.dart` and speed from `constants.dart`.
+- Awards score on impact using values from `constants.dart`.
 - Consider pooling to reduce allocations.
 - Uses `RectangleHitbox` or `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/lib/components/enemy.md
+++ b/lib/components/enemy.md
@@ -7,6 +7,7 @@ Basic foe that drifts toward the player.
 - Spawns at screen edges and moves toward the player ship.
 - Damages the player on contact and is destroyed when hit by a bullet.
 - Sprites resolved through `assets.dart`; speeds and hit points from `constants.dart`.
+- Awards score when destroyed, using `Constants.enemyScore`.
 - Uses `CircleHitbox` or `RectangleHitbox` depending on art.
 - Mixes in `HasGameRef<SpaceGame>` for access to global state.
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -28,6 +28,12 @@ class Constants {
   /// Asteroid sprite size in logical pixels.
   static const double asteroidSize = 24;
 
+  /// Score awarded for destroying an enemy.
+  static const int enemyScore = 5;
+
+  /// Score awarded for mining an asteroid.
+  static const int asteroidScore = 1;
+
   /// Number of stars spawned per parallax layer.
   static const int starsPerLayer = 30;
 

--- a/lib/constants.md
+++ b/lib/constants.md
@@ -5,6 +5,8 @@ Holds tunable values and configuration numbers used across the game.
 - Group constants by feature (player, enemy, asteroid, UI, etc.).
 - Use descriptive names like `playerSpeed` or `asteroidSpawnRate`.
 - Store only gameplay tuning values here; avoid scattering "magic numbers" in code.
+- Include scoring values like `enemyScore` and `asteroidScore`
+  so they are easy to tweak.
 - Expose values as `const` when possible so the compiler can optimise them.
 
 See [../PLAN.md](../PLAN.md) for the authoritative roadmap.

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -9,6 +9,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Player ship moves using an on-screen joystick or keyboard (WASD).
 - [x] Ship fires bullets and destroys a basic enemy type on collision.
 - [x] Random asteroids spawn and can be mined for score.
+- [x] Destroying enemies awards score.
 - [x] Game states: **menu → playing → game over** with quick restart via overlays
       and a `GameState` enum.
 


### PR DESCRIPTION
## Summary
- award points for destroying enemies
- centralize scoring values in `constants.dart`
- document scoring in plan and component docs

## Testing
- `scripts/dartw format lib/constants.dart lib/components/bullet.dart`
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx markdownlint PLAN.md TASKS.md milestone-core-loop.md lib/components/bullet.md lib/constants.md lib/components/README.md lib/components/enemy.md lib/components/asteroid.md`


------
https://chatgpt.com/codex/tasks/task_e_68a9b849bd888330aad3e9c96b8bb86d