### PR TITLE
feat: add custom PWA service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ doc/api/
 *.js_
 *.js.deps
 *.js.map
+# Keep custom service worker
+!web/sw.js
 
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/PLAN.md
+++ b/PLAN.md
@@ -184,7 +184,8 @@ in [TASKS.md](TASKS.md).
   - `background_color` `#000000`
   - `theme_color` `#0f0f0f`
 - Icons 192x192 and 512x512 in `web/icons/`
-- Default `flutter_service_worker.js` for offline caching
+- Custom `sw.js` precaches assets listed in `assets_manifest.json` and
+  handles runtime caching
 - Build with `fvm flutter build web --release`
 - Test with `fvm flutter run -d web-server`
 - Deploy via GitHub Pages (`gh-pages`) using a GitHub Actions workflow

--- a/TASKS.md
+++ b/TASKS.md
@@ -39,7 +39,8 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 ## PWA
 
 - [x] Add `web/manifest.json` and placeholder icons for installable PWA.
-- [ ] Review service worker caching strategy.
+- [x] Review service worker caching strategy and add custom `sw.js` for
+      cache-first asset handling.
 
 ## Testing
 

--- a/web/README.md
+++ b/web/README.md
@@ -5,7 +5,9 @@ PWA configuration and static web files.
 - `manifest.json` defines PWA metadata like `start_url`, `display` and theme
   colours.
 - `icons/` holds 192x192 and 512x512 app icons.
-- The generated `flutter_service_worker.js` enables offline caching.
+- `index.html` bootstraps the Flutter app and registers `sw.js`.
+- `sw.js` precaches assets listed in `assets_manifest.json` and provides a
+  simple cache-first strategy.
 - See [../PLAN.md](../PLAN.md) for PWA goals and deployment guidelines.
 
 Build for release with:

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base href="/">
+    <meta charset="UTF-8">
+    <meta name="description" content="Space Miner PWA">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Space Miner</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  </head>
+  <body>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function () {
+          navigator.serviceWorker.register('sw.js');
+        });
+      }
+    </script>
+    <script src="flutter.js" defer></script>
+    <script>
+      window.addEventListener('load', function() {
+        _flutter.loader.loadEntrypoint({}).then(function(engineInitializer) {
+          return engineInitializer.initializeEngine();
+        }).then(function(appRunner) {
+          return appRunner.runApp();
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,0 +1,60 @@
+const CACHE_NAME = 'space-game-cache-v1';
+const CORE_ASSETS = [
+  '/',
+  'index.html',
+  'manifest.json',
+  'assets_manifest.json',
+  'flutter.js',
+  'main.dart.js',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      await cache.addAll(CORE_ASSETS);
+      try {
+        const response = await fetch('assets_manifest.json');
+        const manifest = await response.json();
+        const assetList = [
+          ...(manifest.images || []),
+          ...(manifest.audio || []),
+          ...(manifest.fonts || []),
+        ];
+        await cache.addAll(assetList);
+      } catch (err) {
+        console.error('Asset manifest fetch failed', err);
+      }
+    })
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request)
+        .then((response) => {
+          if (
+            event.request.method === 'GET' &&
+            response.status === 200 &&
+            !event.request.url.startsWith('chrome-extension')
+          ) {
+            const responseClone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          }
+          return response;
+        })
+        .catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add `sw.js` to precache assets and cache network requests
- register service worker in custom `index.html`
- document PWA caching strategy and mark task complete

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `npx markdownlint PLAN.md TASKS.md web/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68a9b849bd888330aad3e9c96b8bb86d