### PR TITLE
feat: add fixed-resolution camera

### DIFF
--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -18,7 +18,8 @@ Core game class and shared systems.
 ## Responsibilities
 
 - Load assets via a central registry before starting play.
-- Configure the world, including the parallax starfield background.
+- Configure the world, including the parallax starfield background and
+  fixed-resolution camera.
 - Spawn the player and register component spawners.
 - Maintain `GameState` values (`menu`, `playing`, `gameOver`) and swap
   overlays accordingly.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/camera.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/foundation.dart';
@@ -47,6 +48,9 @@ class SpaceGame extends FlameGame
 
   @override
   Future<void> onLoad() async {
+    camera.viewport = FixedResolutionViewport(
+      resolution: Vector2(Constants.logicalWidth, Constants.logicalHeight),
+    );
     add(StarfieldComponent());
     joystick = JoystickComponent(
       knob: CircleComponent(
@@ -63,6 +67,7 @@ class SpaceGame extends FlameGame
 
     player = PlayerComponent(joystick: joystick);
     add(player);
+    camera.follow(player);
 
     fireButton = HudButtonComponent(
       button: CircleComponent(

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -5,7 +5,8 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 ## Responsibilities
 
 - Preload assets via the central registry before entering gameplay.
-- Configure the parallax background, camera and component spawners.
+- Configure the parallax background, set up a fixed-resolution camera that
+  follows the player, and register component spawners.
 - Spawn the player and register enemy or asteroid generators.
 - Maintain `GameState` values (`menu`, `playing`, `gameOver`) and toggle overlays.
 - Route joystick, button and keyboard input to the player component.


### PR DESCRIPTION
## Summary
- center gameplay with a fixed-resolution viewport
- follow the player via the Flame camera
- document the viewport setup in game docs

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`
- `npx markdownlint '**/*.md'` *(fails: line-length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ba3eab5483309dc27938bf30e6c4