### PR TITLE
feat: add pause overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -63,7 +63,7 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
   and scoring. Hooks for resource mining, inventory, networking and save/load
   will slot in later milestones.
 - Flutter overlays handle menus and the HUD so UI stays outside the game loop.
-- A `GameState` enum tracks **menu → playing → game over** transitions.
+- A `GameState` enum tracks **menu → playing → paused → game over** transitions.
 - Asset paths live in a central `assets.dart` registry and tunable numbers live
   in `constants.dart` to avoid magic strings or numbers.
 
@@ -97,6 +97,8 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 
 - The game starts in a menu overlay.
 - `SpaceGame` transitions to `playing` when the user taps start.
+- Players can pause the game from the HUD or with the Escape key,
+  showing a pause overlay.
 - On player death, a game over overlay appears with a restart button.
 - A `GameState` enum tracks the current phase.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -116,7 +116,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - On‑screen joystick and shoot button; WASD + Space mirror touch controls
 - Use Flame's built-in `JoystickComponent` and `ButtonComponent` for touch input
 - Keyboard support comes from `KeyboardListenerComponent`
-- States: **menu → playing → game over** with quick restart
+- States: **menu → playing → paused → game over** with quick restart
 - Use a `GameState` enum to manage transitions
 - Centralize asset paths in an `Assets` helper that preloads sprites, audio and
   fonts so gameplay code never references file paths directly
@@ -151,6 +151,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Keyboard controls for desktop playtests
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
+- Pause and resume gameplay via overlay
 
 ## 🗓️ Milestones
 

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -10,9 +10,10 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Shooting an asteroid destroys it and increases the on-screen score
 - [ ] Score resets when restarting the game
-- [ ] Game states transition: menu → playing → game over → restart
+- [ ] Game states transition: menu → playing → paused → game over → restart
 - [ ] Parallax starfield renders behind gameplay
 - [ ] Sound effects play and can be muted
+- [ ] Game can be paused and resumed
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ dedicated server or NAT traversal.
 - Touch/joystick movement and shooting
 - One enemy type with collision and random spawns
 - Asteroids to mine for score
-- Single endless level with player health and quick restart
+- Single endless level with quick restart
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle
+- Pause and resume gameplay via overlay
 - Keyboard controls for desktop playtests
 - Game works offline after the first load
 - Parallax starfield background
@@ -122,6 +123,7 @@ wrapper. Example:
 ```powershell
 $env:FLUTTER_VERSION='3.32.8'; scripts\bootstrap_flutter.ps1 -Force
 ```
+
 Use `-Force` to re-download the SDK or `-Quiet` to suppress progress messages.
 
 Examples:

--- a/TASKS.md
+++ b/TASKS.md
@@ -50,3 +50,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 ## Optimisation
 
 - [x] Add bullet object pool to reduce allocations.
+
+## Enhancements
+
+- [x] Pause/resume overlay toggled via HUD and Escape key.

--- a/lib/game/game_state.dart
+++ b/lib/game/game_state.dart
@@ -1,2 +1,2 @@
 /// Simple game lifecycle states.
-enum GameState { menu, playing, gameOver }
+enum GameState { menu, playing, paused, gameOver }

--- a/lib/game/game_state.md
+++ b/lib/game/game_state.md
@@ -6,6 +6,7 @@ Enum describing high-level game phases.
 
 - `menu` – initial overlay before play.
 - `playing` – active gameplay loop.
+- `paused` – gameplay halted with a pause overlay.
 - `gameOver` – player died; show restart overlay.
 
 Used by `SpaceGame` to swap overlays and reset state.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -7,6 +7,9 @@ import 'package:flame/game.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart' show EdgeInsets;
+import 'package:flutter/services.dart'
+    show KeyDownEvent, KeyEvent, LogicalKeyboardKey;
+import 'package:flutter/widgets.dart' show KeyEventResult;
 
 import '../components/asteroid.dart';
 import '../components/enemy.dart';
@@ -19,11 +22,12 @@ import '../services/audio_service.dart';
 import '../ui/game_over_overlay.dart';
 import '../ui/hud_overlay.dart';
 import '../ui/menu_overlay.dart';
+import '../ui/pause_overlay.dart';
 import 'game_state.dart';
 
 /// Root Flame game handling the core loop.
 class SpaceGame extends FlameGame
-    with HasKeyboardHandlerComponents, HasCollisionDetection {
+    with HasKeyboardHandlerComponents, HasCollisionDetection, KeyboardEvents {
   SpaceGame({required this.storageService, required this.audioService});
 
   /// Handles persistence for the high score.
@@ -114,9 +118,8 @@ class SpaceGame extends FlameGame
 
   /// Retrieves a bullet from the pool or creates a new one.
   BulletComponent acquireBullet(Vector2 position, Vector2 direction) {
-    final bullet = _bulletPool.isNotEmpty
-        ? _bulletPool.removeLast()
-        : BulletComponent();
+    final bullet =
+        _bulletPool.isNotEmpty ? _bulletPool.removeLast() : BulletComponent();
     bullet.reset(position, direction);
     return bullet;
   }
@@ -140,19 +143,44 @@ class SpaceGame extends FlameGame
     }
   }
 
+  /// Pauses the game and shows the pause overlay.
+  void pauseGame() {
+    if (state != GameState.playing) {
+      return;
+    }
+    state = GameState.paused;
+    overlays
+      ..remove(HudOverlay.id)
+      ..add(PauseOverlay.id);
+    pauseEngine();
+  }
+
+  /// Resumes the game from a paused state.
+  void resumeGame() {
+    if (state != GameState.paused) {
+      return;
+    }
+    state = GameState.playing;
+    overlays
+      ..remove(PauseOverlay.id)
+      ..add(HudOverlay.id);
+    resumeEngine();
+  }
+
   /// Starts a new game session.
   void startGame() {
     state = GameState.playing;
     score.value = 0;
     children.whereType<EnemyComponent>().forEach((e) => e.removeFromParent());
     children.whereType<AsteroidComponent>().forEach(
-      (a) => a.removeFromParent(),
-    );
+          (a) => a.removeFromParent(),
+        );
     children.whereType<BulletComponent>().forEach((b) => b.removeFromParent());
     player.position = size / 2;
     overlays
       ..remove(MenuOverlay.id)
       ..remove(GameOverOverlay.id)
+      ..remove(PauseOverlay.id)
       ..add(HudOverlay.id);
     _enemySpawnTimer
       ..stop()
@@ -172,7 +200,26 @@ class SpaceGame extends FlameGame
     }
     overlays
       ..remove(HudOverlay.id)
+      ..remove(PauseOverlay.id)
       ..add(GameOverOverlay.id);
     pauseEngine();
+  }
+
+  @override
+  KeyEventResult onKeyEvent(
+    KeyEvent event,
+    Set<LogicalKeyboardKey> keysPressed,
+  ) {
+    if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.escape) {
+      if (state == GameState.playing) {
+        pauseGame();
+        return KeyEventResult.handled;
+      } else if (state == GameState.paused) {
+        resumeGame();
+        return KeyEventResult.handled;
+      }
+    }
+    return super.onKeyEvent(event, keysPressed);
   }
 }

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -9,8 +9,10 @@ Main FlameGame subclass managing world setup, state transitions and the update l
   follows the player, and register component spawners.
 - Spawn the player and register enemy or asteroid generators.
 - Provide a small bullet pool to limit allocations.
-- Maintain `GameState` values (`menu`, `playing`, `gameOver`) and toggle overlays.
+- Maintain `GameState` values (`menu`, `playing`, `paused`, `gameOver`)
+  and toggle overlays.
 - Route joystick, button and keyboard input to the player component.
+- Expose helpers to pause and resume the game loop.
 - Drive the update cycle while delegating work to components and services.
 - Persist and load the high score through `StorageService`.
 - Exposes `ValueNotifier<int>`s for the current score and persisted high score so

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'game/space_game.dart';
 import 'ui/game_over_overlay.dart';
 import 'ui/hud_overlay.dart';
 import 'ui/menu_overlay.dart';
+import 'ui/pause_overlay.dart';
 import 'services/storage_service.dart';
 import 'services/audio_service.dart';
 
@@ -23,6 +24,8 @@ Future<void> main() async {
         overlayBuilderMap: {
           MenuOverlay.id: (context, SpaceGame game) => MenuOverlay(game: game),
           HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
+          PauseOverlay.id: (context, SpaceGame game) =>
+              PauseOverlay(game: game),
           GameOverOverlay.id: (context, SpaceGame game) =>
               GameOverOverlay(game: game),
         },

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -9,10 +9,11 @@ Flutter overlays and HUD widgets.
   callbacks exposed by `SpaceGame`.
 - Keep rendering separate from gameplay logic to simplify testing.
 
-## Planned Overlays
+## Overlays
 
 - [MenuOverlay](menu_overlay.md) – start button and basic instructions.
-- [HudOverlay](hud_overlay.md) – shows score, health and a mute toggle.
+- [HudOverlay](hud_overlay.md) – shows score with mute and pause buttons.
+- [PauseOverlay](pause_overlay.md) – displayed when the game is paused.
 - [GameOverOverlay](game_over_overlay.md) – displays final score with a restart option.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -30,15 +30,23 @@ class HudOverlay extends StatelessWidget {
                 ),
               ),
             ),
-            ValueListenableBuilder<bool>(
-              valueListenable: game.audioService.muted,
-              builder: (context, muted, _) => IconButton(
-                icon: Icon(
-                  muted ? Icons.volume_off : Icons.volume_up,
-                  color: Colors.white,
+            Row(
+              children: [
+                ValueListenableBuilder<bool>(
+                  valueListenable: game.audioService.muted,
+                  builder: (context, muted, _) => IconButton(
+                    icon: Icon(
+                      muted ? Icons.volume_off : Icons.volume_up,
+                      color: Colors.white,
+                    ),
+                    onPressed: game.audioService.toggleMute,
+                  ),
                 ),
-                onPressed: game.audioService.toggleMute,
-              ),
+                IconButton(
+                  icon: const Icon(Icons.pause, color: Colors.white),
+                  onPressed: game.pauseGame,
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -5,7 +5,7 @@ Heads-up display shown during play.
 ## Features
 
 - Shows current score using a `ValueNotifier` exposed by `SpaceGame`.
-- Provides a mute button bound to `AudioService`.
+- Provides mute and pause buttons bound to `AudioService` and `SpaceGame`.
 - Player health will be added in a later milestone.
 - Visible only in the `playing` state.
 

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../game/space_game.dart';
+
+/// Overlay shown when the game is paused.
+class PauseOverlay extends StatelessWidget {
+  const PauseOverlay({super.key, required this.game});
+
+  /// Reference to the running game.
+  final SpaceGame game;
+
+  /// Overlay identifier used by [GameWidget].
+  static const String id = 'pauseOverlay';
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Paused',
+            style: TextStyle(fontSize: 32, color: Colors.white),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: game.resumeGame,
+            child: const Text('Resume'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pause_overlay.md
+++ b/lib/ui/pause_overlay.md
@@ -1,0 +1,11 @@
+# PauseOverlay
+
+Overlay displayed when the game is paused.
+
+## Features
+
+- Shows a "Paused" label with a resume button.
+- Triggered from the HUD pause button or the Escape key.
+- Visible only while the game state is `paused`.
+
+See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- add paused state with pause/resume controls and overlay
- expose pause button in HUD and map PauseOverlay in main
- update docs and checklists for new pause feature

## Testing
- `./scripts/dartw format lib/main.dart lib/game/space_game.dart lib/ui/hud_overlay.dart lib/ui/pause_overlay.dart lib/game/game_state.dart`
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`
- `npx markdownlint lib/ui/README.md lib/ui/hud_overlay.md lib/ui/pause_overlay.md lib/game/space_game.md lib/game/game_state.md PLAN.md DESIGN.md README.md TASKS.md PLAYTEST_CHECKLIST.md`

------
https://chatgpt.com/codex/tasks/task_e_68aa695011fc8330882b362ee633c9a7