### PR TITLE
Ensure Flutter bootstrap upgrades on version mismatch

### DIFF
--- a/scripts/dartw
+++ b/scripts/dartw
@@ -4,4 +4,5 @@ source "$(dirname "$0")/bootstrap_flutter.sh"
 if [[ "${1-}" == "format" && $# -eq 1 ]]; then
   set -- "$1" .
 fi
+echo "[dartw] dart $@"
 exec ".tooling/flutter/bin/dart" "$@"

--- a/scripts/flutterw
+++ b/scripts/flutterw
@@ -2,4 +2,5 @@
 set -euo pipefail
 # Ensure Flutter exists and PATH is set for this process
 source "$(dirname "$0")/bootstrap_flutter.sh"
+echo "[flutterw] flutter $@"
 exec ".tooling/flutter/bin/flutter" "$@"


### PR DESCRIPTION
## Summary
- Reinstall pinned Flutter SDK when existing installation has different version or channel
- Apply the same version check upgrade logic to the Windows bootstrap script
- Add verbose logging so bootstrap and wrapper scripts show each step

## Testing
- `./scripts/dartw pub get`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68a9bb0135f08330bf24464b0aedac68