### PR TITLE
ci: grant deploy workflow push permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow GitHub Pages deploy workflow to push by granting contents write permission

## Testing
- `dart format --output=none --set-exit-if-changed .` (reported changes)
- `dart analyze` (failed: 434 issues)
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9781a4fc8330bbcbd47f532a265b