### PR TITLE
chore: improve tooling wrappers and setup

### DIFF
--- a/TOOLING_REVIEW.md
+++ b/TOOLING_REVIEW.md
@@ -11,11 +11,11 @@
 | `./scripts/flutterw run -d web-server` | Manual testing guide suggests web-server target | ⚠️ Launches but warns project isn’t configured for web |
 | `./scripts/flutterw build web --release` | Web README describes release build | ❌ Fails: missing `index.html` |
 | `fvm flutter doctor` / `fvm dart format` | Plan/TASKS show FVM usage | ❌ `fvm` command not found |
-| `npx markdownlint '**/*.md'` | Plan recommends markdownlint after doc edits | ❌ npm cannot determine executable to run |
+| `./scripts/markdownlint.sh '**/*.md'` | Plan recommends markdownlint after doc edits | ✅ Uses local install or `npx --yes` |
 
 ## Notes
 
 - Install FVM or remove FVM-specific instructions if not required.
 - Add web support (`flutter create .`) and `web/index.html` to enable builds/run targets.
 - Provide Chrome or Edge in the environment if Chrome device debugging is desired.
-- Include markdownlint (npm) in setup scripts or adjust documentation.
+- Use `scripts/markdownlint.sh` to lint docs without interactive prompts.

--- a/scripts/dartw
+++ b/scripts/dartw
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Preserve original args before sourcing bootstrap script to avoid option parsing.
+args=("$@")
+set --
 source "$(dirname "$0")/bootstrap_flutter.sh"
+set -- "${args[@]}"
 if [[ "${1-}" == "format" && $# -eq 1 ]]; then
   set -- "$1" .
 fi

--- a/scripts/flutterw
+++ b/scripts/flutterw
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Ensure Flutter exists and PATH is set for this process
+# Preserve original args before sourcing bootstrap script, which consumes positional params.
+args=("$@")
+set --
+# Ensure Flutter exists and PATH is set for this process without seeing user args.
 source "$(dirname "$0")/bootstrap_flutter.sh"
+# Restore original args for the actual flutter invocation.
+set -- "${args[@]}"
 echo "[flutterw] flutter $@"
 exec ".tooling/flutter/bin/flutter" "$@"

--- a/scripts/markdownlint.sh
+++ b/scripts/markdownlint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if command -v markdownlint >/dev/null 2>&1; then
+  exec markdownlint "$@"
+else
+  exec npx --yes markdownlint "$@"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -34,6 +34,10 @@ add_path() {
 add_path "$PUB_CACHE_BIN"
 add_path "$FLUTTER_BIN"
 
+# Ensure Dart/Flutter dependencies are fetched.
+log "Fetching pub dependencies"
+dart pub get || log "dart pub get failed"
+
 # Use repo-local cache for FVM (FVM_HOME is deprecated).
 unset FVM_HOME 2>/dev/null || true
 export FVM_CACHE_PATH="$REPO_ROOT/.fvm"


### PR DESCRIPTION
## Summary
- fix flutterw/dartw argument forwarding
- fetch pub dependencies during setup
- add markdownlint helper script and docs

## Testing
- `./scripts/flutterw --version`
- `./scripts/dartw pub get`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `./scripts/dartw format . --output=none --set-exit-if-changed`
- `./scripts/markdownlint.sh '**/*.md'`
- `./setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa94baa2208330a8037786879fc153