### PR TITLE
fix: improve markdown lint tooling and web loader

### DIFF
--- a/scripts/markdownlint.sh
+++ b/scripts/markdownlint.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 if command -v markdownlint >/dev/null 2>&1; then
   exec markdownlint "$@"
+elif command -v npx >/dev/null 2>&1; then
+  # Use the markdownlint-cli package when the global binary is missing.
+  exec npx --yes markdownlint-cli "$@"
 else
-  exec npx --yes markdownlint "$@"
+  echo "markdownlint and npx are not installed" >&2
+  exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -65,13 +65,40 @@ if command -v fvm >/dev/null 2>&1 && [ -f "$REPO_ROOT/fvm_config.json" ]; then
   fi
 fi
 
-# Install markdownlint CLI if npm exists and it's not already installed.
+# Ensure Node.js is available for tooling such as markdownlint.
+if ! command -v npm >/dev/null 2>&1; then
+  log "npm not found; attempting to install Node.js"
+  case "$(uname -s)" in
+    Linux*)
+      if command -v apt-get >/dev/null 2>&1; then
+        $SUDO apt-get update || true
+        $SUDO apt-get install -y nodejs npm || log "Failed to install Node.js via apt-get"
+      elif command -v snap >/dev/null 2>&1; then
+        $SUDO snap install node --classic || log "Failed to install Node.js via snap"
+      else
+        log "Skipping Node.js install: no supported package manager found"
+      fi
+      ;;
+    Darwin*)
+      if command -v brew >/dev/null 2>&1; then
+        brew install node || log "brew install node failed"
+      else
+        log "Skipping Node.js install: brew not found"
+      fi
+      ;;
+    *)
+      log "Skipping Node.js install: unsupported OS"
+      ;;
+  esac
+fi
+
+# Install markdownlint CLI if npm is available and the binary is missing.
 if ! command -v markdownlint >/dev/null 2>&1; then
   if command -v npm >/dev/null 2>&1; then
     log "Installing markdownlint-cli"
     $SUDO npm install -g markdownlint-cli || log "Failed to install markdownlint-cli"
   else
-    log "npm not found; markdownlint will run via npx"
+    log "npm not found; markdownlint will run via npx if available"
   fi
 fi
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
     <base href="/">
     <meta charset="UTF-8">
     <meta name="description" content="Space Miner PWA">
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Space Miner</title>
     <link rel="manifest" href="manifest.json">
@@ -19,15 +20,6 @@
         });
       }
     </script>
-    <script src="flutter.js" defer></script>
-    <script>
-      window.addEventListener('load', function() {
-        _flutter.loader.loadEntrypoint({}).then(function(engineInitializer) {
-          return engineInitializer.initializeEngine();
-        }).then(function(appRunner) {
-          return appRunner.runApp();
-        });
-      });
-    </script>
+    <script src="flutter_bootstrap.js" async></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure setup installs Node.js and markdownlint
- allow markdownlint.sh to use markdownlint-cli through npx
- switch web/index.html to Flutter's flutter_bootstrap.js loader

## Testing
- `./scripts/markdownlint.sh README.md`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `./scripts/flutterw build web --release` *(warn: missing font families)*

------
https://chatgpt.com/codex/tasks/task_e_68aaad5176888330bd19c6956a838f53