### PR TITLE
chore: ignore fvm cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ doc/api/
 .flutter-plugins-dependencies
 # Ignore FVM-managed Flutter SDK
 .fvm/
+.fvm_cache/
 
 # Local tooling and caches
 .tooling/


### PR DESCRIPTION
## Summary
- ignore `.fvm_cache/` in Git

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68aadf5cc79883309ee342aa76e28553