### PR TITLE
feat: vary starfield brightness

### DIFF
--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -15,7 +15,7 @@ class StarfieldComponent extends Component with HasGameReference<SpaceGame> {
   final int _starsPerLayer;
   final Random _random = Random();
   final List<_Star> _stars = [];
-  final Paint _paint = Paint()..color = const Color(0xffffffff);
+  final Paint _paint = Paint();
 
   @override
   Future<void> onLoad() async {
@@ -34,6 +34,7 @@ class StarfieldComponent extends Component with HasGameReference<SpaceGame> {
 
   List<_Star> _generateLayer(double speed) {
     return List.generate(_starsPerLayer, (_) {
+      final brightness = 128 + _random.nextInt(128);
       return _Star(
         position: Vector2(
           _random.nextDouble() * game.size.x,
@@ -41,6 +42,7 @@ class StarfieldComponent extends Component with HasGameReference<SpaceGame> {
         ),
         speed: speed,
         radius: _random.nextDouble() * Constants.starMaxSize + 1,
+        color: Color.fromARGB(255, brightness, brightness, brightness),
       );
     });
   }
@@ -66,15 +68,22 @@ class StarfieldComponent extends Component with HasGameReference<SpaceGame> {
   @override
   void render(Canvas canvas) {
     for (final star in _stars) {
+      _paint.color = star.color;
       canvas.drawCircle(star.position.toOffset(), star.radius, _paint);
     }
   }
 }
 
 class _Star {
-  _Star({required this.position, required this.speed, required this.radius});
+  _Star({
+    required this.position,
+    required this.speed,
+    required this.radius,
+    required this.color,
+  });
 
   Vector2 position;
   double speed;
   double radius;
+  Color color;
 }

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -5,6 +5,7 @@ Procedurally renders a simple three-layer starfield behind the game.
 - Generates stars on the fly, so no image assets are required.
 - Each layer moves at a different speed defined in `constants.dart` to create a
   basic parallax effect.
+- Stars vary in brightness for a subtle depth cue.
 - Regenerates the star positions whenever the game viewport changes size.
 - Added to `SpaceGame` with a negative priority so it always draws beneath
   gameplay components.


### PR DESCRIPTION
## Summary
- add per-star brightness for starfield depth cue
- document starfield brightness variation

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx markdownlint-cli lib/components/starfield.md`


------
https://chatgpt.com/codex/tasks/task_e_68aadf5cc79883309ee342aa76e28553