### PR TITLE
feat: enable debug mode with FPS overlay

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -29,7 +29,9 @@ import 'game_state.dart';
 /// Root Flame game handling the core loop.
 class SpaceGame extends FlameGame
     with HasKeyboardHandlerComponents, HasCollisionDetection, KeyboardEvents {
-  SpaceGame({required this.storageService, required this.audioService});
+  SpaceGame({required this.storageService, required this.audioService}) {
+    debugMode = kDebugMode;
+  }
 
   /// Handles persistence for the high score.
   final StorageService storageService;
@@ -74,6 +76,9 @@ class SpaceGame extends FlameGame
       resolution: Vector2(Constants.logicalWidth, Constants.logicalHeight),
     );
     add(StarfieldComponent());
+    if (kDebugMode) {
+      add(FpsTextComponent(position: Vector2.all(10)));
+    }
     joystick = JoystickComponent(
       knob: CircleComponent(
         radius: 20,


### PR DESCRIPTION
## Summary
- show bounding boxes and FPS in debug builds by enabling Flame's debug mode
- add FpsTextComponent when running in debug for performance insight

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68aae2054a6c8330877f99dd18d9451c