### PR TITLE
refactor: centralize spawn intervals

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -28,11 +28,17 @@ class Constants {
   /// Enemy sprite size in logical pixels.
   static const double enemySize = 32;
 
+  /// Seconds between enemy spawns.
+  static const double enemySpawnInterval = 2;
+
   /// Asteroid movement speed in pixels per second.
   static const double asteroidSpeed = 50;
 
   /// Asteroid sprite size in logical pixels.
   static const double asteroidSize = 24;
+
+  /// Seconds between asteroid spawns.
+  static const double asteroidSpawnInterval = 3;
 
   /// Score awarded for destroying an enemy.
   static const int enemyScore = 5;

--- a/lib/constants.md
+++ b/lib/constants.md
@@ -7,8 +7,8 @@ Holds tunable values and configuration numbers used across the game.
 - Store only gameplay tuning values here; avoid scattering "magic numbers" in code.
 - Include scoring values like `enemyScore` and `asteroidScore`
   so they are easy to tweak.
-- Include timing values such as `bulletCooldown` so behaviour like fire rates can
-  be adjusted centrally.
+- Include timing values such as `bulletCooldown` and spawn intervals so
+  behaviour like fire rates and spawn rates can be adjusted centrally.
 - Expose values as `const` when possible so the compiler can optimise them.
 
 See [../PLAN.md](../PLAN.md) for the authoritative roadmap.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -106,8 +106,16 @@ class SpaceGame extends FlameGame
     );
     add(fireButton);
 
-    _enemySpawnTimer = Timer(2, onTick: _spawnEnemy, repeat: true);
-    _asteroidSpawnTimer = Timer(3, onTick: _spawnAsteroid, repeat: true);
+    _enemySpawnTimer = Timer(
+      Constants.enemySpawnInterval,
+      onTick: _spawnEnemy,
+      repeat: true,
+    );
+    _asteroidSpawnTimer = Timer(
+      Constants.asteroidSpawnInterval,
+      onTick: _spawnAsteroid,
+      repeat: true,
+    );
 
     highScore.value = storageService.getHighScore();
 


### PR DESCRIPTION
## Summary
- centralize enemy and asteroid spawn intervals in constants.dart
- use centralized spawn intervals in SpaceGame
- document spawn interval tuning guidance

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68aae2054a6c8330877f99dd18d9451c