### PR TITLE
Add help overlay pause toggle test

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -47,6 +47,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 - [x] Add unit tests for storage and audio services.
 - [x] Add unit tests verifying bullet, asteroid and enemy pooling reuse.
+- [x] Add unit test ensuring help overlay toggles pause state.
 
 ## Optimisation
 

--- a/test/help_overlay_test.dart
+++ b/test/help_overlay_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/help_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('toggleHelp pauses and resumes the game', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(HelpOverlay.id, (_, __) => const SizedBox());
+
+    game.state = GameState.playing;
+    expect(game.overlays.isActive(HelpOverlay.id), isFalse);
+    expect(game.paused, isFalse);
+
+    game.toggleHelp();
+    expect(game.overlays.isActive(HelpOverlay.id), isTrue);
+    expect(game.paused, isTrue);
+
+    game.toggleHelp();
+    expect(game.overlays.isActive(HelpOverlay.id), isFalse);
+    expect(game.paused, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add unit test ensuring help overlay pauses and resumes the game
- document test addition in task list

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68aae2054a6c8330877f99dd18d9451c