### PR TITLE
docs: note existing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ lib/                    # Game source code
   log.dart              # Tiny log() wrapper around debugPrint
   services/             # Optional helpers (see lib/services/README.md)
 web/                    # PWA configuration (see web/README.md)
-test/                   # Automated tests (placeholder) (see test/README.md)
+test/                   # Automated tests for services and game logic (see test/README.md)
 assets_manifest.json    # List of bundled asset files for caching (see assets_manifest.md)
 .github/workflows/      # CI and deployment scripts
 PLAN.md                 # High-level plan and architecture

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,12 @@
 # test/
 
-Placeholder for automated tests.
+Contains automated tests covering core services and game components.
 
-Add unit, widget, and Flame component tests here once the game code exists.
-Use `flutter_test` and `flame_test` as noted in [../PLAN.md](../PLAN.md).
+Current suites verify:
+
+- Storage and audio services
+- Object pooling for bullets, asteroids and enemies
+- Player shot cooldown logic
+- Help overlay pause behaviour
+
+Tests use `flutter_test` and `flame_test` as noted in [../PLAN.md](../PLAN.md).


### PR DESCRIPTION
## Summary
- clarify README project structure to mention existing automated tests
- replace placeholder test README with description of current suites

## Testing
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68aae45836e8833094186de7106c4948