### PR TITLE
feat: allow resetting high score

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -149,6 +149,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Single endless level without progression for now
 - Player health and high score shown in the HUD with simple start/game‑over screens
 - Local high score stored on device (e.g., shared preferences)
+- Menu offers a reset button to clear the high score
 - Basic sound effects using `flame_audio` with mute toggle (button or `M` key)
   available on menu, HUD, pause and game over overlays
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to

--- a/TASKS.md
+++ b/TASKS.md
@@ -70,3 +70,4 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       `Esc` also closes it.
 - [x] HUD displays current and high scores alongside health.
 - [x] Limit player fire rate with a brief cooldown.
+- [x] Menu includes button to reset the high score.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -287,6 +287,12 @@ class SpaceGame extends FlameGame
     resumeEngine();
   }
 
+  /// Clears the saved high score.
+  Future<void> resetHighScore() async {
+    highScore.value = 0;
+    await storageService.resetHighScore();
+  }
+
   /// Transitions to the game over state.
   void gameOver() {
     state = GameState.gameOver;

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -23,5 +23,6 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 - Exposes `ValueNotifier<int>`s for the current score, health and persisted high
   score so Flutter overlays can render values without touching the game loop.
 - Provide access to `AudioService` for playing sound effects and toggling mute.
+- Offers a method to reset the saved high score.
 
 See [../../PLAN.md](../../PLAN.md) for the roadmap.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -5,7 +5,7 @@ Optional helpers for cross-cutting concerns.
 - `audio_service.dart` wraps `flame_audio` to play sound effects and
   handles a mute toggle persisted via `StorageService`.
 - `storage_service.dart` stores the local high score and mute setting using
-  `shared_preferences`.
+  `shared_preferences` and can clear the high score.
 - Keep services lightweight; add them only when a milestone needs them.
 
 ## Planned Services

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -26,6 +26,11 @@ class StorageService {
     await _prefs.setInt(_highScoreKey, value);
   }
 
+  /// Clears the stored high score.
+  Future<void> resetHighScore() async {
+    await _prefs.remove(_highScoreKey);
+  }
+
   /// Whether audio is muted; defaults to `false` if unset.
   bool isMuted() => _prefs.getBool(_mutedKey) ?? false;
 

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -13,6 +13,6 @@ Handles local persistence using `shared_preferences`.
 
 Create the service with `await StorageService.create()` and call
 `getHighScore()`/`setHighScore()` or `isMuted()`/`setMuted()` to read or update
-values.
+values. Call `resetHighScore()` to clear the stored high score.
 
 See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -11,8 +11,8 @@ Flutter overlays and HUD widgets.
 
 ## Overlays
 
-- [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score, help
-  (`H`) and mute toggle.
+- [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
+  reset, help (`H`) and mute toggle.
 - [HudOverlay](hud_overlay.md) – shows score, high score and health with help,
   mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displayed when the game is paused with

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -33,6 +33,11 @@ class MenuOverlay extends StatelessWidget {
                 : const SizedBox.shrink(),
           ),
           const SizedBox(height: 20),
+          TextButton(
+            onPressed: () => game.resetHighScore(),
+            child: const Text('Reset High Score'),
+          ),
+          const SizedBox(height: 20),
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/lib/ui/menu_overlay.md
+++ b/lib/ui/menu_overlay.md
@@ -13,5 +13,6 @@ Flutter widget shown before gameplay starts.
 - Press `Enter` to start without clicking the button.
 - Help button (or `H` key) lists all controls without starting the game; `Esc`
   closes it.
+- Reset button clears the stored high score.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -15,6 +15,14 @@ void main() {
       await storage.setHighScore(42);
       expect(storage.getHighScore(), 42);
     });
+
+    test('resetHighScore clears value', () async {
+      SharedPreferences.setMockInitialValues({'highScore': 99});
+      final storage = await StorageService.create();
+      expect(storage.getHighScore(), 99);
+      await storage.resetHighScore();
+      expect(storage.getHighScore(), 0);
+    });
   });
 
   group('AudioService', () {


### PR DESCRIPTION
## Summary
- add `resetHighScore` to storage service and expose it in `SpaceGame`
- add reset high score button on menu overlay
- document ability to clear high score

## Testing
- `./scripts/dartw format lib/game/space_game.dart lib/services/storage_service.dart lib/ui/menu_overlay.dart test/services_test.dart`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68aae45836e8833094186de7106c4948