### PR TITLE
feat: add runtime debug toggle

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -215,7 +215,8 @@ in [TASKS.md](TASKS.md).
 - Manual testing for now; automate later under `test/`
 - Use `PLAYTEST_CHECKLIST.md`, `MANUAL_TESTING.md`, and optional `playtest_logs/`
 - Follow `AGENTS.md` conventions when contributing
-- Enable Flame's debug mode in dev builds to show bounding boxes and FPS
+  - Enable Flame's debug mode in dev builds to show bounding boxes and FPS;
+    toggle at runtime with the `D` key
 - Add a tiny `log()` helper around `debugPrint` so messages can be silenced in release
 
 ## 🔮 Future Ideas

--- a/PLAN.md
+++ b/PLAN.md
@@ -215,8 +215,8 @@ in [TASKS.md](TASKS.md).
 - Manual testing for now; automate later under `test/`
 - Use `PLAYTEST_CHECKLIST.md`, `MANUAL_TESTING.md`, and optional `playtest_logs/`
 - Follow `AGENTS.md` conventions when contributing
-  - Enable Flame's debug mode in dev builds to show bounding boxes and FPS;
-    toggle at runtime with the `D` key
+- Enable Flame's debug mode in dev builds to show bounding boxes and FPS;
+  toggle at runtime with the `D` key
 - Add a tiny `log()` helper around `debugPrint` so messages can be silenced in release
 
 ## 🔮 Future Ideas

--- a/TASKS.md
+++ b/TASKS.md
@@ -70,3 +70,4 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       `Esc` also closes it.
 - [x] HUD displays current and high scores alongside health.
 - [x] Limit player fire rate with a brief cooldown.
+- [x] Keyboard shortcut `D` toggles debug overlays.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -46,6 +46,7 @@ class SpaceGame extends FlameGame
   late final Timer _enemySpawnTimer;
   late final Timer _asteroidSpawnTimer;
   final Random _random = Random();
+  FpsTextComponent? _fpsText;
 
   /// Current score exposed to Flutter overlays.
   final ValueNotifier<int> score = ValueNotifier<int>(0);
@@ -77,7 +78,8 @@ class SpaceGame extends FlameGame
     );
     add(StarfieldComponent());
     if (kDebugMode) {
-      add(FpsTextComponent(position: Vector2.all(10)));
+      _fpsText = FpsTextComponent(position: Vector2.all(10));
+      await add(_fpsText!);
     }
     joystick = JoystickComponent(
       knob: CircleComponent(
@@ -301,6 +303,18 @@ class SpaceGame extends FlameGame
     pauseEngine();
   }
 
+  /// Toggles debug rendering and FPS overlay.
+  void toggleDebug() {
+    debugMode = !debugMode;
+    if (debugMode) {
+      if (_fpsText != null && !_fpsText!.isMounted) {
+        add(_fpsText!);
+      }
+    } else {
+      _fpsText?.removeFromParent();
+    }
+  }
+
   @override
   KeyEventResult onKeyEvent(
     KeyEvent event,
@@ -353,6 +367,9 @@ class SpaceGame extends FlameGame
         }
       } else if (event.logicalKey == LogicalKeyboardKey.keyH) {
         toggleHelp();
+        return KeyEventResult.handled;
+      } else if (event.logicalKey == LogicalKeyboardKey.keyD) {
+        toggleDebug();
         return KeyEventResult.handled;
       }
     }

--- a/test/debug_mode_toggle_test.dart
+++ b/test/debug_mode_toggle_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/audio_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('toggleDebug switches debugMode', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    expect(game.debugMode, isTrue);
+    game.toggleDebug();
+    expect(game.debugMode, isFalse);
+    game.toggleDebug();
+    expect(game.debugMode, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- allow toggling Flame debug overlays with the `D` key
- document debug toggle in plan and tasks
- cover debug toggle with a unit test

## Testing
- `npx markdownlint-cli '**/*.md'`
- `scripts/dartw analyze lib/game/space_game.dart test/debug_mode_toggle_test.dart`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68aae45836e8833094186de7106c4948