### PR TITLE
Fix variable expansion in bootstrap Flutter script

### DIFF
--- a/scripts/bootstrap_flutter.ps1
+++ b/scripts/bootstrap_flutter.ps1
@@ -102,7 +102,7 @@ function Download-With-BITS { param([string]$Url,[string]$Dest)
       return
     } catch {
       $attempt++; if ($attempt -ge 3) { throw }
-      Say "BITS retry $attempt…"; Start-Sleep -Seconds (2*$attempt)
+      Say "BITS retry ${attempt}..."; Start-Sleep -Seconds (2*$attempt)
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix BITS retry message in PowerShell bootstrap script to avoid undefined variable

## Testing
- ❌ `pwsh -NoLogo -Command '$PSVersionTable'` *(missing: `pwsh`)*

------
https://chatgpt.com/codex/tasks/task_e_68aae93e4f6c833081df713b45da4096