### PR TITLE
docs: document GitHub Pages deployment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,4 +16,6 @@ release and deploys `build/web` to GitHub Pages:
 - `develop` → `gh-pages-staging` (preview)
 
 GitHub Pages serves the contents of `gh-pages` at
-`https://<your-GitHub-username>.github.io/space-game/`.
+`https://benhook1013.github.io/space-game/`. The `gh-pages-staging`
+branch is deployed to
+`https://benhook1013.github.io/space-game-staging/` for previews.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,3 +6,14 @@ CI/CD automation for the project.
 - `deploy.yml` – builds the web release and publishes it.
 
 Workflows follow the lightweight pipeline described in [../../PLAN.md](../../PLAN.md).
+
+### GitHub Pages Deployment
+
+`deploy.yml` runs on pushes to `main` and `develop`. It builds the web
+release and deploys `build/web` to GitHub Pages:
+
+- `main` → `gh-pages` (live site)
+- `develop` → `gh-pages-staging` (preview)
+
+GitHub Pages serves the contents of `gh-pages` at
+`https://<your-GitHub-username>.github.io/space-game/`.

--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ Pushes to `main` and `develop` trigger the [deploy workflow](.github/workflows/d
 which builds the web release and publishes it to GitHub Pages.
 
 - Commits on `main` update the `gh-pages` branch and appear at
-  `https://<your-GitHub-username>.github.io/space-game/`.
-- Commits on `develop` publish to `gh-pages-staging` for preview.
+  `https://benhook1013.github.io/space-game/`.
+- Commits on `develop` publish to `gh-pages-staging` for preview at
+  `https://benhook1013.github.io/space-game-staging/`.
 
 When building locally for GitHub Pages, run:
 

--- a/README.md
+++ b/README.md
@@ -144,4 +144,22 @@ The project also includes an `fvm_config.json` for those who prefer to use
 [FVM](https://fvm.app/). In that case, run `fvm install` once and then use
 `fvm flutter`/`fvm dart` for subsequent commands.
 
+## 🌐 GitHub Pages Deployment
+
+Pushes to `main` and `develop` trigger the [deploy workflow](.github/workflows/deploy.yml),
+which builds the web release and publishes it to GitHub Pages.
+
+- Commits on `main` update the `gh-pages` branch and appear at
+  `https://<your-GitHub-username>.github.io/space-game/`.
+- Commits on `develop` publish to `gh-pages-staging` for preview.
+
+When building locally for GitHub Pages, run:
+
+```bash
+fvm flutter build web --release --base-href /space-game/
+```
+
+Serve the generated `build/web` directory with any static file server (for example
+`python3 -m http.server`) to preview the site before pushing.
+
 The project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- explain deploy.yml GitHub Pages workflow and branch targets
- show how to build locally with the required --base-href and preview the generated site

## Testing
- `./scripts/dartw format lib test`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68aae77c5d508330b628e20456dfc26a