### PR TITLE
fix: correct base paths for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           channel: stable
       - name: Build web
-        run: flutter build web --release
+        run: flutter build web --release --base-href "/space-game/"
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <base href="/">
+    <base href="/space-game/">
     <meta charset="UTF-8">
     <meta name="description" content="Space Miner PWA">
     <meta content="IE=Edge" http-equiv="X-UA-Compatible">

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Space Miner",
   "short_name": "SpaceMiner",
-  "start_url": "/",
+  "start_url": "/space-game/",
   "display": "standalone",
   "orientation": "landscape",
   "background_color": "#000000",

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,10 +1,10 @@
 const CACHE_NAME = 'space-game-cache-v1';
 const CORE_ASSETS = [
-  '/',
+  './',
   'index.html',
   'manifest.json',
   'assets_manifest.json',
-  'flutter.js',
+  'flutter_bootstrap.js',
   'main.dart.js',
 ];
 


### PR DESCRIPTION
## Summary
- fix web index and manifest to use `/space-game/` base path
- update service worker asset list for flutter_bootstrap and relative root
- build web in CI with `--base-href` for GitHub Pages

## Testing
- `./scripts/dartw format lib test`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68aaee40b7088330880fec0958868a8c