### PR TITLE
fix: correct asset paths for Flame

### DIFF
--- a/lib/assets.dart
+++ b/lib/assets.dart
@@ -3,12 +3,14 @@ import 'package:flame_audio/flame_audio.dart';
 
 /// Central registry for asset paths and preloading.
 class Assets {
-  static const String player = 'assets/images/player.png';
-  static const String enemy = 'assets/images/enemy.png';
-  static const String asteroid = 'assets/images/asteroid.png';
-  static const String bullet = 'assets/images/bullet.png';
+  // Flame automatically prefixes these with `assets/images/` when loading.
+  static const String player = 'player.png';
+  static const String enemy = 'enemy.png';
+  static const String asteroid = 'asteroid.png';
+  static const String bullet = 'bullet.png';
 
-  static const String shootSfx = 'assets/audio/shoot.wav';
+  // FlameAudio uses `assets/audio/` as the default base path.
+  static const String shootSfx = 'shoot.wav';
 
   /// Preloads all images and audio assets.
   static Future<void> load() async {

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,7 @@
     <title>Space Miner</title>
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
   </head>


### PR DESCRIPTION
## Summary
- fix duplicated asset paths by using relative names for images and audio
- document default Flame prefixes in asset registry
- add mobile-web-app-capable meta tag to silence Chrome's deprecation warning

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ebd43d883308b1763a0958fea3e