### PR TITLE
Add cupertino icons dependency to resolve font warning

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  cupertino_icons:
+    dependency: "direct main"
+    description:
+      name: cupertino_icons
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flame: 1.30.1
   flame_audio: 2.11.8
   shared_preferences: 2.5.3
+  cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- include `cupertino_icons` package so Flutter web build bundles `CupertinoIcons` font
- update lockfile

## Testing
- `scripts/dartw format lib test`
- `scripts/flutterw analyze`
- `scripts/flutterw test`
- `scripts/flutterw build web --release --base-href "/space-game/"`


------
https://chatgpt.com/codex/tasks/task_e_68ac2e20b754833093b7934297737a89