### PR TITLE
chore: cache Flutter SDK and pub deps in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,13 +12,28 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      PUB_CACHE: ~/.pub-cache
     steps:
       - uses: actions/checkout@v5
-      - uses: subosito/flutter-action@v2
+      - name: Cache Flutter SDK
+        uses: actions/cache@v4
         with:
-          channel: stable
+          path: .tooling/flutter
+          key: ${{ runner.os }}-flutter-${{ hashFiles('scripts/bootstrap_flutter.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+      - name: Install dependencies
+        run: ./scripts/flutterw pub get
       - name: Build web
-        run: flutter build web --release --base-href "/space-game/"
+        run: ./scripts/flutterw build web --release --base-href "/space-game/"
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
## Summary
- cache Flutter SDK using actions/cache
- cache pub packages
- build via flutterw to reuse pinned SDK

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac32c1cfc88330803110dc4ef434cd