### PR TITLE
Include assets manifest in web build output

### DIFF
--- a/assets_manifest.md
+++ b/assets_manifest.md
@@ -7,4 +7,6 @@ Reference manifest tracking bundled asset files.
 - Update this file whenever assets are added, removed or renamed.
 - Keep entries sorted for readability.
 - The build pipeline and service worker can use this list to precache assets.
+- Copy this file into the `web/` directory (alongside `index.html`) so it is
+  available at runtime for the service worker.
 - See [PLAN.md](PLAN.md) for broader context.

--- a/web/README.md
+++ b/web/README.md
@@ -8,6 +8,8 @@ PWA configuration and static web files.
 - `index.html` bootstraps the Flutter app and registers `sw.js`.
 - `sw.js` precaches assets listed in `assets_manifest.json` and provides a
   simple cache-first strategy.
+- `assets_manifest.json` is copied here from the project root so the service
+  worker can fetch it at runtime. Keep both copies in sync when assets change.
 - See [../PLAN.md](../PLAN.md) for PWA goals and deployment guidelines.
 
 Build for release with:

--- a/web/assets_manifest.json
+++ b/web/assets_manifest.json
@@ -1,0 +1,12 @@
+{
+  "images": [
+    "assets/images/asteroid.png",
+    "assets/images/bullet.png",
+    "assets/images/enemy.png",
+    "assets/images/player.png"
+  ],
+  "audio": [
+    "assets/audio/shoot.wav"
+  ],
+  "fonts": []
+}


### PR DESCRIPTION
## Summary
- copy `assets_manifest.json` into the `web/` folder so it's shipped with the site
- document that `assets_manifest.json` must be in `web/` and kept in sync with the root copy

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac339999d0833096d3d657b5f5e805