### PR TITLE
ci: cancel superseded runs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,6 +5,9 @@ CI/CD automation for the project.
 - `ci.yml` – formats code, runs static analysis and tests.
 - `deploy.yml` – builds the web release and publishes it.
 
+Both workflows use concurrency groups to cancel in-progress runs when new
+commits arrive.
+
 Workflows follow the lightweight pipeline described in [../../PLAN.md](../../PLAN.md).
 
 ### GitHub Pages Deployment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
       - develop
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary
- ensure CI runs cancel previous runs for the same branch or PR
- ensure deployments cancel superseded runs on main and develop

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac34df75248330b3028f6f422a74fc