### PR TITLE
Fix browser WASD input by propagating key events and auto-focusing GameWidget

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -27,8 +27,13 @@ import '../ui/help_overlay.dart';
 import 'game_state.dart';
 
 /// Root Flame game handling the core loop.
+///
+/// [HasKeyboardHandlerComponents] already exposes [KeyboardEvents] and
+/// propagates key presses to child components like the player. Mixing in the
+/// standalone [KeyboardEvents] here would prevent that propagation, so it is
+/// intentionally omitted.
 class SpaceGame extends FlameGame
-    with HasKeyboardHandlerComponents, HasCollisionDetection, KeyboardEvents {
+    with HasKeyboardHandlerComponents, HasCollisionDetection {
   SpaceGame({required this.storageService, required this.audioService}) {
     debugMode = kDebugMode;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,9 @@ Future<void> main() async {
     MaterialApp(
       home: GameWidget<SpaceGame>(
         game: game,
+        // Automatically request keyboard focus so web players can use WASD
+        // without tapping the canvas first.
+        autofocus: true,
         overlayBuilderMap: {
           MenuOverlay.id: (context, SpaceGame game) => MenuOverlay(game: game),
           HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),


### PR DESCRIPTION
## Summary
- ensure keyboard input reaches player by removing redundant `KeyboardEvents` mixin from `SpaceGame`
- automatically request keyboard focus on the `GameWidget` so browser players can use WASD without clicking first

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac342cc598833098dcb8f6d034e4b2