### PR TITLE
Use theme text styles for overlay headings

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -18,9 +18,12 @@ class GameOverOverlay extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text(
+          Text(
             'Game Over',
-            style: TextStyle(fontSize: 32, color: Colors.white),
+            style: Theme.of(context)
+                .textTheme
+                .headlineMedium
+                ?.copyWith(color: Colors.white),
           ),
           const SizedBox(height: 20),
           ValueListenableBuilder<int>(

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -20,9 +20,12 @@ class HelpOverlay extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text(
+            Text(
               'Controls',
-              style: TextStyle(fontSize: 24, color: Colors.white),
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(color: Colors.white),
             ),
             const SizedBox(height: 20),
             const Text(

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -18,9 +18,12 @@ class MenuOverlay extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text(
+          Text(
             'Space Miner',
-            style: TextStyle(fontSize: 32, color: Colors.white),
+            style: Theme.of(context)
+                .textTheme
+                .headlineMedium
+                ?.copyWith(color: Colors.white),
           ),
           const SizedBox(height: 20),
           ValueListenableBuilder<int>(

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -18,9 +18,12 @@ class PauseOverlay extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text(
+          Text(
             'Paused',
-            style: TextStyle(fontSize: 32, color: Colors.white),
+            style: Theme.of(context)
+                .textTheme
+                .headlineMedium
+                ?.copyWith(color: Colors.white),
           ),
           const SizedBox(height: 20),
           Row(


### PR DESCRIPTION
## Summary
- Use Theme text styles for menu, pause, game-over, and help overlay titles so they scale with device text settings

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac350d171c83308b67fbd7b6eb199c