### PR TITLE
Fix service worker asset caching path

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -10,10 +10,11 @@ const CORE_ASSETS = [
 
 async function cacheAssets(cache, assets) {
   for (const asset of assets) {
+    const url = asset.startsWith("assets/") ? `assets/${asset}` : asset;
     try {
-      await cache.add(asset);
+      await cache.add(url);
     } catch (err) {
-      console.warn(`Failed to cache ${asset}`, err);
+      console.warn(`Failed to cache ${url}`, err);
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure service worker prefixes asset URLs so images/audio are cached correctly

## Testing
- `scripts/dartw format web/sw.js` *(fails: The '!==' operator is not supported...)*
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac3b669b58833088f833c523b8e33c