### PR TITLE
feat(web): replace deprecated break iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ doc/api/
 *.js.map
 # Keep custom service worker
 !web/sw.js
+!web/segmenter_polyfill.js
 
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,7 @@
         });
       }
     </script>
+    <script src="segmenter_polyfill.js"></script>
     <script src="flutter_bootstrap.js" async></script>
   </body>
 </html>

--- a/web/segmenter_polyfill.js
+++ b/web/segmenter_polyfill.js
@@ -1,0 +1,25 @@
+if (typeof Intl !== 'undefined' && Intl.Segmenter && !Intl.v8BreakIterator) {
+  Intl.v8BreakIterator = function (locale, options) {
+    const segmenter = new Intl.Segmenter(locale, options);
+    let segments = [];
+    let index = 0;
+    return {
+      adoptText(text) {
+        segments = Array.from(segmenter.segment(text), s => s.index);
+        segments.push(text.length);
+        index = 0;
+      },
+      first() {
+        index = 0;
+        return segments[0] ?? -1;
+      },
+      next() {
+        index++;
+        return index < segments.length ? segments[index] : -1;
+      },
+      current() {
+        return index < segments.length ? segments[index] : -1;
+      },
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add Intl.Segmenter-based polyfill for deprecated Intl.v8BreakIterator
- include polyfill in web app and track it in gitignore

## Testing
- `./scripts/dartw format web/index.html web/segmenter_polyfill.js` *(fails: Could not format because the source could not be parsed)*
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac3c8fe0ac8330962a98638ab64489