### PR TITLE
Use F1 for debug toggling to avoid right-movement delay

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -217,7 +217,7 @@ in [TASKS.md](TASKS.md).
 - Use `PLAYTEST_CHECKLIST.md`, `MANUAL_TESTING.md`, and optional `playtest_logs/`
 - Follow `AGENTS.md` conventions when contributing
 - Enable Flame's debug mode in dev builds to show bounding boxes and FPS;
-  toggle at runtime with the `D` key
+  toggle at runtime with the `F1` key
 - Add a tiny `log()` helper around `debugPrint` so messages can be silenced in release
 
 ## 🔮 Future Ideas

--- a/TASKS.md
+++ b/TASKS.md
@@ -70,5 +70,5 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       `Esc` also closes it.
 - [x] HUD displays current and high scores alongside health.
 - [x] Limit player fire rate with a brief cooldown.
-- [x] Keyboard shortcut `D` toggles debug overlays.
+- [x] Keyboard shortcut `F1` toggles debug overlays.
 - [x] Menu includes button to reset the high score.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -379,7 +379,7 @@ class SpaceGame extends FlameGame
       } else if (event.logicalKey == LogicalKeyboardKey.keyH) {
         toggleHelp();
         return KeyEventResult.handled;
-      } else if (event.logicalKey == LogicalKeyboardKey.keyD) {
+      } else if (event.logicalKey == LogicalKeyboardKey.f1) {
         toggleDebug();
         return KeyEventResult.handled;
       }


### PR DESCRIPTION
## Summary
- free `D` key for player movement by mapping debug toggle to `F1`
- update docs to reflect new `F1` debug shortcut

## Testing
- `./scripts/markdownlint.sh PLAN.md TASKS.md`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac3f78332883309eba0072c631412e