### PR TITLE
feat: make menu responsive

### DIFF
--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -14,61 +14,93 @@ class MenuOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            'Space Miner',
-            style: Theme.of(context)
-                .textTheme
-                .headlineMedium
-                ?.copyWith(color: Colors.white),
-          ),
-          const SizedBox(height: 20),
-          ValueListenableBuilder<int>(
-            valueListenable: game.highScore,
-            builder: (context, value, _) => value > 0
-                ? Text(
-                    'High Score: $value',
-                    style: const TextStyle(color: Colors.white),
-                  )
-                : const SizedBox.shrink(),
-          ),
-          const SizedBox(height: 20),
-          TextButton(
-            onPressed: () => game.resetHighScore(),
-            child: const Text('Reset High Score'),
-          ),
-          const SizedBox(height: 20),
-          Row(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shortestSide = constraints.biggest.shortestSide;
+        final titleFontSize = shortestSide * 0.08;
+        final uiFontSize = shortestSide * 0.04;
+        final spacing = shortestSide * 0.02;
+
+        return Center(
+          child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              ElevatedButton(
-                onPressed: game.startGame,
-                child: const Text('Start'),
+              Text(
+                'Space Miner',
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      fontSize: titleFontSize,
+                      color: Colors.white,
+                    ),
               ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the H keyboard shortcut.
-                onPressed: game.toggleHelp,
-                child: const Text('Help'),
+              SizedBox(height: spacing),
+              ValueListenableBuilder<int>(
+                valueListenable: game.highScore,
+                builder: (context, value, _) => value > 0
+                    ? Text(
+                        'High Score: $value',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: uiFontSize,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      )
+                    : const SizedBox.shrink(),
               ),
-              const SizedBox(width: 10),
-              ValueListenableBuilder<bool>(
-                valueListenable: game.audioService.muted,
-                builder: (context, muted, _) => IconButton(
-                  icon: Icon(
-                    muted ? Icons.volume_off : Icons.volume_up,
-                    color: Colors.white,
+              SizedBox(height: spacing),
+              TextButton(
+                onPressed: () => game.resetHighScore(),
+                style: TextButton.styleFrom(
+                  textStyle: TextStyle(
+                    fontSize: uiFontSize,
+                    fontWeight: FontWeight.bold,
                   ),
-                  onPressed: game.audioService.toggleMute,
                 ),
+                child: const Text('Reset High Score'),
+              ),
+              SizedBox(height: spacing),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    onPressed: game.startGame,
+                    style: ElevatedButton.styleFrom(
+                      textStyle: TextStyle(
+                        fontSize: uiFontSize,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    child: const Text('Start'),
+                  ),
+                  SizedBox(width: spacing),
+                  ElevatedButton(
+                    // Mirrors the H keyboard shortcut.
+                    onPressed: game.toggleHelp,
+                    style: ElevatedButton.styleFrom(
+                      textStyle: TextStyle(
+                        fontSize: uiFontSize,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    child: const Text('Help'),
+                  ),
+                  SizedBox(width: spacing),
+                  ValueListenableBuilder<bool>(
+                    valueListenable: game.audioService.muted,
+                    builder: (context, muted, _) => IconButton(
+                      iconSize: uiFontSize * 1.2,
+                      icon: Icon(
+                        muted ? Icons.volume_off : Icons.volume_up,
+                        color: Colors.white,
+                      ),
+                      onPressed: game.audioService.toggleMute,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/menu_overlay.md
+++ b/lib/ui/menu_overlay.md
@@ -14,5 +14,6 @@ Flutter widget shown before gameplay starts.
 - Help button (or `H` key) lists all controls without starting the game; `Esc`
   closes it.
 - Reset button clears the stored high score.
+- Responsive layout scales fonts, spacing, and icons relative to screen size.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- scale menu layout and fonts relative to screen size
- document responsive menu behavior

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac3f1c4d1c83308ba99ad21c24c835