### PR TITLE
Use AutoSizeText for responsive overlays

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -18,27 +19,30 @@ class GameOverOverlay extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
+          AutoSizeText(
             'Game Over',
             style: Theme.of(context)
                 .textTheme
                 .headlineMedium
                 ?.copyWith(color: Colors.white),
+            maxLines: 1,
           ),
           const SizedBox(height: 20),
           ValueListenableBuilder<int>(
             valueListenable: game.score,
-            builder: (context, value, _) => Text(
+            builder: (context, value, _) => AutoSizeText(
               'Final Score: $value',
               style: const TextStyle(color: Colors.white),
+              maxLines: 1,
             ),
           ),
           const SizedBox(height: 10),
           ValueListenableBuilder<int>(
             valueListenable: game.highScore,
-            builder: (context, value, _) => Text(
+            builder: (context, value, _) => AutoSizeText(
               'High Score: $value',
               style: const TextStyle(color: Colors.white),
+              maxLines: 1,
             ),
           ),
           const SizedBox(height: 20),
@@ -48,19 +52,19 @@ class GameOverOverlay extends StatelessWidget {
               ElevatedButton(
                 // Mirrors the Enter and R keyboard shortcuts.
                 onPressed: game.startGame,
-                child: const Text('Restart'),
+                child: const AutoSizeText('Restart', maxLines: 1),
               ),
               const SizedBox(width: 10),
               ElevatedButton(
                 // Mirrors the Q and Escape keyboard shortcuts.
                 onPressed: game.returnToMenu,
-                child: const Text('Menu'),
+                child: const AutoSizeText('Menu', maxLines: 1),
               ),
               const SizedBox(width: 10),
               ElevatedButton(
                 // Mirrors the H keyboard shortcut.
                 onPressed: game.toggleHelp,
-                child: const Text('Help'),
+                child: const AutoSizeText('Help', maxLines: 1),
               ),
               const SizedBox(width: 10),
               ValueListenableBuilder<bool>(

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -20,15 +21,16 @@ class HelpOverlay extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
+            AutoSizeText(
               'Controls',
               style: Theme.of(context)
                   .textTheme
                   .headlineSmall
                   ?.copyWith(color: Colors.white),
+              maxLines: 1,
             ),
             const SizedBox(height: 20),
-            const Text(
+            const AutoSizeText(
               'Move: WASD / Arrow keys\n'
               'Shoot: Space\n'
               'Mute: M\n'
@@ -43,7 +45,7 @@ class HelpOverlay extends StatelessWidget {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: game.toggleHelp,
-              child: const Text('Close'),
+              child: const AutoSizeText('Close', maxLines: 1),
             ),
           ],
         ),

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -27,23 +28,26 @@ class HudOverlay extends StatelessWidget {
                 children: [
                   ValueListenableBuilder<int>(
                     valueListenable: game.score,
-                    builder: (context, value, _) => Text(
+                    builder: (context, value, _) => AutoSizeText(
                       'Score: $value',
                       style: const TextStyle(color: Colors.white),
+                      maxLines: 1,
                     ),
                   ),
                   ValueListenableBuilder<int>(
                     valueListenable: game.highScore,
-                    builder: (context, value, _) => Text(
+                    builder: (context, value, _) => AutoSizeText(
                       'High: $value',
                       style: const TextStyle(color: Colors.white),
+                      maxLines: 1,
                     ),
                   ),
                   ValueListenableBuilder<int>(
                     valueListenable: game.health,
-                    builder: (context, value, _) => Text(
+                    builder: (context, value, _) => AutoSizeText(
                       'Health: $value',
                       style: const TextStyle(color: Colors.white),
+                      maxLines: 1,
                     ),
                   ),
                 ],

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -17,45 +18,43 @@ class MenuOverlay extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final shortestSide = constraints.biggest.shortestSide;
-        final titleFontSize = shortestSide * 0.08;
-        final uiFontSize = shortestSide * 0.04;
         final spacing = shortestSide * 0.02;
+        final iconSize = shortestSide * 0.05;
 
         return Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
+              AutoSizeText(
                 'Space Miner',
-                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      fontSize: titleFontSize,
-                      color: Colors.white,
-                    ),
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineMedium
+                    ?.copyWith(color: Colors.white),
+                maxLines: 1,
               ),
               SizedBox(height: spacing),
               ValueListenableBuilder<int>(
                 valueListenable: game.highScore,
                 builder: (context, value, _) => value > 0
-                    ? Text(
+                    ? AutoSizeText(
                         'High Score: $value',
-                        style: TextStyle(
+                        style: const TextStyle(
                           color: Colors.white,
-                          fontSize: uiFontSize,
                           fontWeight: FontWeight.bold,
                         ),
+                        maxLines: 1,
                       )
                     : const SizedBox.shrink(),
               ),
               SizedBox(height: spacing),
               TextButton(
                 onPressed: () => game.resetHighScore(),
-                style: TextButton.styleFrom(
-                  textStyle: TextStyle(
-                    fontSize: uiFontSize,
-                    fontWeight: FontWeight.bold,
-                  ),
+                child: const AutoSizeText(
+                  'Reset High Score',
+                  maxLines: 1,
+                  style: TextStyle(fontWeight: FontWeight.bold),
                 ),
-                child: const Text('Reset High Score'),
               ),
               SizedBox(height: spacing),
               Row(
@@ -63,31 +62,27 @@ class MenuOverlay extends StatelessWidget {
                 children: [
                   ElevatedButton(
                     onPressed: game.startGame,
-                    style: ElevatedButton.styleFrom(
-                      textStyle: TextStyle(
-                        fontSize: uiFontSize,
-                        fontWeight: FontWeight.bold,
-                      ),
+                    child: const AutoSizeText(
+                      'Start',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
                     ),
-                    child: const Text('Start'),
                   ),
                   SizedBox(width: spacing),
                   ElevatedButton(
                     // Mirrors the H keyboard shortcut.
                     onPressed: game.toggleHelp,
-                    style: ElevatedButton.styleFrom(
-                      textStyle: TextStyle(
-                        fontSize: uiFontSize,
-                        fontWeight: FontWeight.bold,
-                      ),
+                    child: const AutoSizeText(
+                      'Help',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
                     ),
-                    child: const Text('Help'),
                   ),
                   SizedBox(width: spacing),
                   ValueListenableBuilder<bool>(
                     valueListenable: game.audioService.muted,
                     builder: (context, muted, _) => IconButton(
-                      iconSize: uiFontSize * 1.2,
+                      iconSize: iconSize,
                       icon: Icon(
                         muted ? Icons.volume_off : Icons.volume_up,
                         color: Colors.white,

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -18,12 +19,13 @@ class PauseOverlay extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
+          AutoSizeText(
             'Paused',
             style: Theme.of(context)
                 .textTheme
                 .headlineMedium
                 ?.copyWith(color: Colors.white),
+            maxLines: 1,
           ),
           const SizedBox(height: 20),
           Row(
@@ -32,25 +34,25 @@ class PauseOverlay extends StatelessWidget {
               ElevatedButton(
                 // Mirrors the Escape and P keyboard shortcuts.
                 onPressed: game.resumeGame,
-                child: const Text('Resume'),
+                child: const AutoSizeText('Resume', maxLines: 1),
               ),
               const SizedBox(width: 10),
               ElevatedButton(
                 // Mirrors the R keyboard shortcut.
                 onPressed: game.startGame,
-                child: const Text('Restart'),
+                child: const AutoSizeText('Restart', maxLines: 1),
               ),
               const SizedBox(width: 10),
               ElevatedButton(
                 // Mirrors the Q keyboard shortcut.
                 onPressed: game.returnToMenu,
-                child: const Text('Menu'),
+                child: const AutoSizeText('Menu', maxLines: 1),
               ),
               const SizedBox(width: 10),
               ElevatedButton(
                 // Mirrors the H keyboard shortcut.
                 onPressed: game.toggleHelp,
-                child: const Text('Help'),
+                child: const AutoSizeText('Help', maxLines: 1),
               ),
               const SizedBox(width: 10),
               ValueListenableBuilder<bool>(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.1"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      sha256: "3f5261cd3fb5f2a9ab4e2fc3fba84fd9fcaac8821f20a1d4e71f557521b22599"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flame: 1.30.1
   flame_audio: 2.11.8
   shared_preferences: 2.5.3
+  auto_size_text: ^3.0.0
   cupertino_icons: ^1.0.8
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add auto_size_text dependency
- replace Text with AutoSizeText in menu, help, pause, game over, and HUD overlays for automatic sizing

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac456d7c44833086d2d29cd72fa403