### PR TITLE
fix: ensure pub cache path resolves in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   analyze-and-test:
     runs-on: ubuntu-latest
     env:
-      PUB_CACHE: ~/.pub-cache
+      PUB_CACHE: ${{ env.HOME }}/.pub-cache
     steps:
       - uses: actions/checkout@v5
         with:
@@ -30,6 +30,8 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-pub-
+      - name: Install dependencies
+        run: mkdir -p $PUB_CACHE && ./scripts/flutterw pub get
       - name: Analyze
         run: |
           set -o pipefail

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     env:
-      PUB_CACHE: ~/.pub-cache
+      PUB_CACHE: ${{ env.HOME }}/.pub-cache
     steps:
       - uses: actions/checkout@v5
       - name: Cache Flutter SDK
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pub-
       - name: Install dependencies
-        run: ./scripts/flutterw pub get
+        run: mkdir -p $PUB_CACHE && ./scripts/flutterw pub get
       - name: Build web
         run: ./scripts/flutterw build web --release --base-href "/space-game/"
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- use explicit `$HOME/.pub-cache` path for cache
- install deps to populate cache before analysis/tests

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac43ef19208330a265eca045e5ccb0