### PR TITLE
Use AutoSizeText for responsive menus

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -15,68 +16,104 @@ class GameOverOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            'Game Over',
-            style: Theme.of(context)
-                .textTheme
-                .headlineMedium
-                ?.copyWith(color: Colors.white),
-          ),
-          const SizedBox(height: 20),
-          ValueListenableBuilder<int>(
-            valueListenable: game.score,
-            builder: (context, value, _) => Text(
-              'Final Score: $value',
-              style: const TextStyle(color: Colors.white),
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AutoSizeText(
+              'Game Over',
+              maxLines: 1,
+              textAlign: TextAlign.center,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: Colors.white),
             ),
-          ),
-          const SizedBox(height: 10),
-          ValueListenableBuilder<int>(
-            valueListenable: game.highScore,
-            builder: (context, value, _) => Text(
-              'High Score: $value',
-              style: const TextStyle(color: Colors.white),
-            ),
-          ),
-          const SizedBox(height: 20),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ElevatedButton(
-                // Mirrors the Enter and R keyboard shortcuts.
-                onPressed: game.startGame,
-                child: const Text('Restart'),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the Q and Escape keyboard shortcuts.
-                onPressed: game.returnToMenu,
-                child: const Text('Menu'),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the H keyboard shortcut.
-                onPressed: game.toggleHelp,
-                child: const Text('Help'),
-              ),
-              const SizedBox(width: 10),
-              ValueListenableBuilder<bool>(
-                valueListenable: game.audioService.muted,
-                builder: (context, muted, _) => IconButton(
-                  icon: Icon(
-                    muted ? Icons.volume_off : Icons.volume_up,
-                    color: Colors.white,
-                  ),
-                  // Mirrors the M keyboard shortcut.
-                  onPressed: game.audioService.toggleMute,
+            const SizedBox(height: 20),
+            ValueListenableBuilder<int>(
+              valueListenable: game.score,
+              builder: (context, value, _) => AutoSizeText(
+                'Final Score: $value',
+                maxLines: 1,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
-            ],
-          ),
-        ],
+            ),
+            const SizedBox(height: 10),
+            ValueListenableBuilder<int>(
+              valueListenable: game.highScore,
+              builder: (context, value, _) => AutoSizeText(
+                'High Score: $value',
+                maxLines: 1,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ElevatedButton(
+                  // Mirrors the Enter and R keyboard shortcuts.
+                  onPressed: game.startGame,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  child: const AutoSizeText(
+                    'Restart',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  // Mirrors the Q and Escape keyboard shortcuts.
+                  onPressed: game.returnToMenu,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  child: const AutoSizeText(
+                    'Menu',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  // Mirrors the H keyboard shortcut.
+                  onPressed: game.toggleHelp,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  child: const AutoSizeText(
+                    'Help',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ValueListenableBuilder<bool>(
+                  valueListenable: game.audioService.muted,
+                  builder: (context, muted, _) => IconButton(
+                    icon: Icon(
+                      muted ? Icons.volume_off : Icons.volume_up,
+                      color: Colors.white,
+                    ),
+                    // Mirrors the M keyboard shortcut.
+                    onPressed: game.audioService.toggleMute,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -17,35 +18,48 @@ class HelpOverlay extends StatelessWidget {
     return Container(
       color: Colors.black54,
       child: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              'Controls',
-              style: Theme.of(context)
-                  .textTheme
-                  .headlineSmall
-                  ?.copyWith(color: Colors.white),
-            ),
-            const SizedBox(height: 20),
-            const Text(
-              'Move: WASD / Arrow keys\n'
-              'Shoot: Space\n'
-              'Mute: M\n'
-              'Pause/Resume: Esc or P\n'
-              'Start/Restart: Enter\n'
-              'Restart anytime: R\n'
-              'Menu: Q (pause/game over), Esc (game over)\n'
-              'Toggle Help: H or Esc',
-              style: TextStyle(color: Colors.white),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: game.toggleHelp,
-              child: const Text('Close'),
-            ),
-          ],
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AutoSizeText(
+                'Controls',
+                maxLines: 1,
+                textAlign: TextAlign.center,
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineMedium
+                    ?.copyWith(color: Colors.white),
+              ),
+              const SizedBox(height: 20),
+              const AutoSizeText(
+                'Move: WASD / Arrow keys\n'
+                'Shoot: Space\n'
+                'Mute: M\n'
+                'Pause/Resume: Esc or P\n'
+                'Start/Restart: Enter\n'
+                'Restart anytime: R\n'
+                'Menu: Q (pause/game over), Esc (game over)\n'
+                'Toggle Help: H or Esc',
+                style: TextStyle(color: Colors.white),
+                textAlign: TextAlign.center,
+                maxLines: 9,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: game.toggleHelp,
+                style: ElevatedButton.styleFrom(
+                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                child: const AutoSizeText(
+                  'Close',
+                  maxLines: 1,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -14,93 +15,92 @@ class MenuOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final shortestSide = constraints.biggest.shortestSide;
-        final titleFontSize = shortestSide * 0.08;
-        final uiFontSize = shortestSide * 0.04;
-        final spacing = shortestSide * 0.02;
-
-        return Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'Space Miner',
-                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      fontSize: titleFontSize,
-                      color: Colors.white,
-                    ),
+    return Center(
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AutoSizeText(
+              'Space Miner',
+              maxLines: 1,
+              textAlign: TextAlign.center,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: Colors.white),
+            ),
+            const SizedBox(height: 20),
+            ValueListenableBuilder<int>(
+              valueListenable: game.highScore,
+              builder: (context, value, _) => value > 0
+                  ? AutoSizeText(
+                      'High Score: $value',
+                      maxLines: 1,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+            const SizedBox(height: 20),
+            TextButton(
+              onPressed: game.resetHighScore,
+              style: TextButton.styleFrom(
+                textStyle: const TextStyle(fontWeight: FontWeight.bold),
               ),
-              SizedBox(height: spacing),
-              ValueListenableBuilder<int>(
-                valueListenable: game.highScore,
-                builder: (context, value, _) => value > 0
-                    ? Text(
-                        'High Score: $value',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: uiFontSize,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      )
-                    : const SizedBox.shrink(),
+              child: const AutoSizeText(
+                'Reset High Score',
+                maxLines: 1,
+                textAlign: TextAlign.center,
               ),
-              SizedBox(height: spacing),
-              TextButton(
-                onPressed: () => game.resetHighScore(),
-                style: TextButton.styleFrom(
-                  textStyle: TextStyle(
-                    fontSize: uiFontSize,
-                    fontWeight: FontWeight.bold,
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ElevatedButton(
+                  onPressed: game.startGame,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  child: const AutoSizeText(
+                    'Start',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
                   ),
                 ),
-                child: const Text('Reset High Score'),
-              ),
-              SizedBox(height: spacing),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ElevatedButton(
-                    onPressed: game.startGame,
-                    style: ElevatedButton.styleFrom(
-                      textStyle: TextStyle(
-                        fontSize: uiFontSize,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    child: const Text('Start'),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  // Mirrors the H keyboard shortcut.
+                  onPressed: game.toggleHelp,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
                   ),
-                  SizedBox(width: spacing),
-                  ElevatedButton(
-                    // Mirrors the H keyboard shortcut.
-                    onPressed: game.toggleHelp,
-                    style: ElevatedButton.styleFrom(
-                      textStyle: TextStyle(
-                        fontSize: uiFontSize,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    child: const Text('Help'),
+                  child: const AutoSizeText(
+                    'Help',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
                   ),
-                  SizedBox(width: spacing),
-                  ValueListenableBuilder<bool>(
-                    valueListenable: game.audioService.muted,
-                    builder: (context, muted, _) => IconButton(
-                      iconSize: uiFontSize * 1.2,
-                      icon: Icon(
-                        muted ? Icons.volume_off : Icons.volume_up,
-                        color: Colors.white,
-                      ),
-                      onPressed: game.audioService.toggleMute,
+                ),
+                const SizedBox(width: 10),
+                ValueListenableBuilder<bool>(
+                  valueListenable: game.audioService.muted,
+                  builder: (context, muted, _) => IconButton(
+                    icon: Icon(
+                      muted ? Icons.volume_off : Icons.volume_up,
+                      color: Colors.white,
                     ),
+                    onPressed: game.audioService.toggleMute,
                   ),
-                ],
-              ),
-            ],
-          ),
-        );
-      },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
@@ -15,58 +16,91 @@ class PauseOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            'Paused',
-            style: Theme.of(context)
-                .textTheme
-                .headlineMedium
-                ?.copyWith(color: Colors.white),
-          ),
-          const SizedBox(height: 20),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ElevatedButton(
-                // Mirrors the Escape and P keyboard shortcuts.
-                onPressed: game.resumeGame,
-                child: const Text('Resume'),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the R keyboard shortcut.
-                onPressed: game.startGame,
-                child: const Text('Restart'),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the Q keyboard shortcut.
-                onPressed: game.returnToMenu,
-                child: const Text('Menu'),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the H keyboard shortcut.
-                onPressed: game.toggleHelp,
-                child: const Text('Help'),
-              ),
-              const SizedBox(width: 10),
-              ValueListenableBuilder<bool>(
-                valueListenable: game.audioService.muted,
-                builder: (context, muted, _) => IconButton(
-                  icon: Icon(
-                    muted ? Icons.volume_off : Icons.volume_up,
-                    color: Colors.white,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AutoSizeText(
+              'Paused',
+              maxLines: 1,
+              textAlign: TextAlign.center,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: Colors.white),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ElevatedButton(
+                  // Mirrors the Escape and P keyboard shortcuts.
+                  onPressed: game.resumeGame,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
                   ),
-                  // Mirrors the M keyboard shortcut.
-                  onPressed: game.audioService.toggleMute,
+                  child: const AutoSizeText(
+                    'Resume',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  // Mirrors the R keyboard shortcut.
+                  onPressed: game.startGame,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  child: const AutoSizeText(
+                    'Restart',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  // Mirrors the Q keyboard shortcut.
+                  onPressed: game.returnToMenu,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  child: const AutoSizeText(
+                    'Menu',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ElevatedButton(
+                  // Mirrors the H keyboard shortcut.
+                  onPressed: game.toggleHelp,
+                  style: ElevatedButton.styleFrom(
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  child: const AutoSizeText(
+                    'Help',
+                    maxLines: 1,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                ValueListenableBuilder<bool>(
+                  valueListenable: game.audioService.muted,
+                  builder: (context, muted, _) => IconButton(
+                    icon: Icon(
+                      muted ? Icons.volume_off : Icons.volume_up,
+                      color: Colors.white,
+                    ),
+                    // Mirrors the M keyboard shortcut.
+                    onPressed: game.audioService.toggleMute,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.1"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      sha256: "3f5261cd3fb5f2a9ab4e2fc3fba84fd9fcaac8821f20a1d4e71f557521b22599"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flame_audio: 2.11.8
   shared_preferences: 2.5.3
   cupertino_icons: ^1.0.8
+  auto_size_text: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- center overlay titles and text to mirror the main menu
- apply consistent bold button styling across pause, game-over, and help overlays

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac456d7c44833086d2d29cd72fa403