### PR TITLE
Standardize overlay text formatting

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -15,73 +15,100 @@ class GameOverOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          AutoSizeText(
-            'Game Over',
-            style: Theme.of(context)
-                .textTheme
-                .headlineMedium
-                ?.copyWith(color: Colors.white),
-            maxLines: 1,
-          ),
-          const SizedBox(height: 20),
-          ValueListenableBuilder<int>(
-            valueListenable: game.score,
-            builder: (context, value, _) => AutoSizeText(
-              'Final Score: $value',
-              style: const TextStyle(color: Colors.white),
-              maxLines: 1,
-            ),
-          ),
-          const SizedBox(height: 10),
-          ValueListenableBuilder<int>(
-            valueListenable: game.highScore,
-            builder: (context, value, _) => AutoSizeText(
-              'High Score: $value',
-              style: const TextStyle(color: Colors.white),
-              maxLines: 1,
-            ),
-          ),
-          const SizedBox(height: 20),
-          Row(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shortestSide = constraints.biggest.shortestSide;
+        final spacing = shortestSide * 0.02;
+        final iconSize = shortestSide * 0.05;
+
+        return Center(
+          child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              ElevatedButton(
-                // Mirrors the Enter and R keyboard shortcuts.
-                onPressed: game.startGame,
-                child: const AutoSizeText('Restart', maxLines: 1),
+              AutoSizeText(
+                'Game Over',
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineMedium
+                    ?.copyWith(color: Colors.white),
+                maxLines: 1,
               ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the Q and Escape keyboard shortcuts.
-                onPressed: game.returnToMenu,
-                child: const AutoSizeText('Menu', maxLines: 1),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the H keyboard shortcut.
-                onPressed: game.toggleHelp,
-                child: const AutoSizeText('Help', maxLines: 1),
-              ),
-              const SizedBox(width: 10),
-              ValueListenableBuilder<bool>(
-                valueListenable: game.audioService.muted,
-                builder: (context, muted, _) => IconButton(
-                  icon: Icon(
-                    muted ? Icons.volume_off : Icons.volume_up,
+              SizedBox(height: spacing),
+              ValueListenableBuilder<int>(
+                valueListenable: game.score,
+                builder: (context, value, _) => AutoSizeText(
+                  'Final Score: $value',
+                  style: const TextStyle(
                     color: Colors.white,
+                    fontWeight: FontWeight.bold,
                   ),
-                  // Mirrors the M keyboard shortcut.
-                  onPressed: game.audioService.toggleMute,
+                  maxLines: 1,
                 ),
+              ),
+              SizedBox(height: spacing),
+              ValueListenableBuilder<int>(
+                valueListenable: game.highScore,
+                builder: (context, value, _) => AutoSizeText(
+                  'High Score: $value',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  maxLines: 1,
+                ),
+              ),
+              SizedBox(height: spacing),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    // Mirrors the Enter and R keyboard shortcuts.
+                    onPressed: game.startGame,
+                    child: const AutoSizeText(
+                      'Restart',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  SizedBox(width: spacing),
+                  ElevatedButton(
+                    // Mirrors the Q and Escape keyboard shortcuts.
+                    onPressed: game.returnToMenu,
+                    child: const AutoSizeText(
+                      'Menu',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  SizedBox(width: spacing),
+                  ElevatedButton(
+                    // Mirrors the H keyboard shortcut.
+                    onPressed: game.toggleHelp,
+                    child: const AutoSizeText(
+                      'Help',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  SizedBox(width: spacing),
+                  ValueListenableBuilder<bool>(
+                    valueListenable: game.audioService.muted,
+                    builder: (context, muted, _) => IconButton(
+                      iconSize: iconSize,
+                      icon: Icon(
+                        muted ? Icons.volume_off : Icons.volume_up,
+                        color: Colors.white,
+                      ),
+                      // Mirrors the M keyboard shortcut.
+                      onPressed: game.audioService.toggleMute,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -15,41 +15,52 @@ class HelpOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.black54,
-      child: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            AutoSizeText(
-              'Controls',
-              style: Theme.of(context)
-                  .textTheme
-                  .headlineSmall
-                  ?.copyWith(color: Colors.white),
-              maxLines: 1,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shortestSide = constraints.biggest.shortestSide;
+        final spacing = shortestSide * 0.02;
+
+        return Container(
+          color: Colors.black54,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AutoSizeText(
+                  'Controls',
+                  style: Theme.of(context)
+                      .textTheme
+                      .headlineSmall
+                      ?.copyWith(color: Colors.white),
+                  maxLines: 1,
+                ),
+                SizedBox(height: spacing),
+                const AutoSizeText(
+                  'Move: WASD / Arrow keys\n'
+                  'Shoot: Space\n'
+                  'Mute: M\n'
+                  'Pause/Resume: Esc or P\n'
+                  'Start/Restart: Enter\n'
+                  'Restart anytime: R\n'
+                  'Menu: Q (pause/game over), Esc (game over)\n'
+                  'Toggle Help: H or Esc',
+                  style: TextStyle(color: Colors.white),
+                  textAlign: TextAlign.center,
+                ),
+                SizedBox(height: spacing),
+                ElevatedButton(
+                  onPressed: game.toggleHelp,
+                  child: const AutoSizeText(
+                    'Close',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 20),
-            const AutoSizeText(
-              'Move: WASD / Arrow keys\n'
-              'Shoot: Space\n'
-              'Mute: M\n'
-              'Pause/Resume: Esc or P\n'
-              'Start/Restart: Enter\n'
-              'Restart anytime: R\n'
-              'Menu: Q (pause/game over), Esc (game over)\n'
-              'Toggle Help: H or Esc',
-              style: TextStyle(color: Colors.white),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: game.toggleHelp,
-              child: const AutoSizeText('Close', maxLines: 1),
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -15,61 +15,86 @@ class PauseOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          AutoSizeText(
-            'Paused',
-            style: Theme.of(context)
-                .textTheme
-                .headlineMedium
-                ?.copyWith(color: Colors.white),
-            maxLines: 1,
-          ),
-          const SizedBox(height: 20),
-          Row(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shortestSide = constraints.biggest.shortestSide;
+        final spacing = shortestSide * 0.02;
+        final iconSize = shortestSide * 0.05;
+
+        return Center(
+          child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              ElevatedButton(
-                // Mirrors the Escape and P keyboard shortcuts.
-                onPressed: game.resumeGame,
-                child: const AutoSizeText('Resume', maxLines: 1),
+              AutoSizeText(
+                'Paused',
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineMedium
+                    ?.copyWith(color: Colors.white),
+                maxLines: 1,
               ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the R keyboard shortcut.
-                onPressed: game.startGame,
-                child: const AutoSizeText('Restart', maxLines: 1),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the Q keyboard shortcut.
-                onPressed: game.returnToMenu,
-                child: const AutoSizeText('Menu', maxLines: 1),
-              ),
-              const SizedBox(width: 10),
-              ElevatedButton(
-                // Mirrors the H keyboard shortcut.
-                onPressed: game.toggleHelp,
-                child: const AutoSizeText('Help', maxLines: 1),
-              ),
-              const SizedBox(width: 10),
-              ValueListenableBuilder<bool>(
-                valueListenable: game.audioService.muted,
-                builder: (context, muted, _) => IconButton(
-                  icon: Icon(
-                    muted ? Icons.volume_off : Icons.volume_up,
-                    color: Colors.white,
+              SizedBox(height: spacing),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    // Mirrors the Escape and P keyboard shortcuts.
+                    onPressed: game.resumeGame,
+                    child: const AutoSizeText(
+                      'Resume',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
                   ),
-                  // Mirrors the M keyboard shortcut.
-                  onPressed: game.audioService.toggleMute,
-                ),
+                  SizedBox(width: spacing),
+                  ElevatedButton(
+                    // Mirrors the R keyboard shortcut.
+                    onPressed: game.startGame,
+                    child: const AutoSizeText(
+                      'Restart',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  SizedBox(width: spacing),
+                  ElevatedButton(
+                    // Mirrors the Q keyboard shortcut.
+                    onPressed: game.returnToMenu,
+                    child: const AutoSizeText(
+                      'Menu',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  SizedBox(width: spacing),
+                  ElevatedButton(
+                    // Mirrors the H keyboard shortcut.
+                    onPressed: game.toggleHelp,
+                    child: const AutoSizeText(
+                      'Help',
+                      maxLines: 1,
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  SizedBox(width: spacing),
+                  ValueListenableBuilder<bool>(
+                    valueListenable: game.audioService.muted,
+                    builder: (context, muted, _) => IconButton(
+                      iconSize: iconSize,
+                      icon: Icon(
+                        muted ? Icons.volume_off : Icons.volume_up,
+                        color: Colors.white,
+                      ),
+                      // Mirrors the M keyboard shortcut.
+                      onPressed: game.audioService.toggleMute,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- align GameOver, Pause, and Help overlays with main menu layout
- compute spacing and icon size via LayoutBuilder for responsive scaling
- apply consistent bold styling to scores and buttons

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4b49bec08330863977ffcbd70cba