### PR TITLE
Fix workflow PUB_CACHE path using workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   analyze-and-test:
     runs-on: ubuntu-latest
     env:
-      PUB_CACHE: ${{ env.HOME }}/.pub-cache
+      PUB_CACHE: ${{ github.workspace }}/.pub-cache
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     env:
-      PUB_CACHE: ${{ env.HOME }}/.pub-cache
+      PUB_CACHE: ${{ github.workspace }}/.pub-cache
     steps:
       - uses: actions/checkout@v5
       - name: Cache Flutter SDK


### PR DESCRIPTION
## Summary
- fix deploy and CI workflows to compute PUB_CACHE without env.HOME

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4bb77b98833092d01e88f77ebeea