### PR TITLE
Anchor HUD overlay to top of screen

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -16,14 +16,15 @@ class HudOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 8),
-              child: Column(
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   ValueListenableBuilder<int>(
@@ -52,33 +53,33 @@ class HudOverlay extends StatelessWidget {
                   ),
                 ],
               ),
-            ),
-            Row(
-              children: [
-                IconButton(
-                  // Mirrors the H keyboard shortcut.
-                  icon: const Icon(Icons.help_outline, color: Colors.white),
-                  onPressed: game.toggleHelp,
-                ),
-                ValueListenableBuilder<bool>(
-                  valueListenable: game.audioService.muted,
-                  builder: (context, muted, _) => IconButton(
-                    // Mirrors the `M` keyboard shortcut.
-                    icon: Icon(
-                      muted ? Icons.volume_off : Icons.volume_up,
-                      color: Colors.white,
-                    ),
-                    onPressed: game.audioService.toggleMute,
+              Row(
+                children: [
+                  IconButton(
+                    // Mirrors the H keyboard shortcut.
+                    icon: const Icon(Icons.help_outline, color: Colors.white),
+                    onPressed: game.toggleHelp,
                   ),
-                ),
-                IconButton(
-                  // Mirrors the Escape and P keyboard shortcuts.
-                  icon: const Icon(Icons.pause, color: Colors.white),
-                  onPressed: game.pauseGame,
-                ),
-              ],
-            ),
-          ],
+                  ValueListenableBuilder<bool>(
+                    valueListenable: game.audioService.muted,
+                    builder: (context, muted, _) => IconButton(
+                      // Mirrors the `M` keyboard shortcut.
+                      icon: Icon(
+                        muted ? Icons.volume_off : Icons.volume_up,
+                        color: Colors.white,
+                      ),
+                      onPressed: game.audioService.toggleMute,
+                    ),
+                  ),
+                  IconButton(
+                    // Mirrors the Escape and P keyboard shortcuts.
+                    icon: const Icon(Icons.pause, color: Colors.white),
+                    onPressed: game.pauseGame,
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- align HUD display to the top edge so info, volume and pause buttons no longer float mid-screen

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5171f76c83309c7e2a347c2748a1