### PR TITLE
Align HUD buttons to top-right

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -20,6 +20,7 @@ class HudOverlay extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
               padding: const EdgeInsets.only(top: 8),


### PR DESCRIPTION
## Summary
- keep HUD controls anchored to the top-right by setting the row's cross axis alignment to start

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5171f76c83309c7e2a347c2748a1