### PR TITLE
Add manual preview deploy workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,8 +4,9 @@ CI/CD automation for the project.
 
 - `ci.yml` – formats code, runs static analysis and tests.
 - `deploy.yml` – builds the web release and publishes it.
+- `deploy-preview.yml` – manually builds the current branch and publishes it to a branch-specific preview path.
 
-Both workflows use concurrency groups to cancel in-progress runs when new
+All workflows use concurrency groups to cancel in-progress runs when new
 commits arrive.
 
 Workflows follow the lightweight pipeline described in [../../PLAN.md](../../PLAN.md).
@@ -17,6 +18,8 @@ release and deploys `build/web` to GitHub Pages:
 
 - `main` → `gh-pages` (live site)
 - `develop` → `gh-pages-staging` (preview)
+
+`deploy-preview.yml` can be run manually to build the current branch and publish it under `previews/<branch>` on `gh-pages`.
 
 GitHub Pages serves the contents of `gh-pages` at
 `https://benhook1013.github.io/space-game/`. The `gh-pages-staging`

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,44 @@
+name: Deploy Preview
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      PUB_CACHE: ${{ github.workspace }}/.pub-cache
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache Flutter SDK
+        uses: actions/cache@v4
+        with:
+          path: .tooling/flutter
+          key: ${{ runner.os }}-flutter-${{ hashFiles('scripts/bootstrap_flutter.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+      - name: Install dependencies
+        run: mkdir -p $PUB_CACHE && ./scripts/flutterw pub get
+      - name: Build web
+        run: ./scripts/flutterw build web --release --base-href "/${{ github.event.repository.name }}/previews/${{ github.ref_name }}/"
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: build/web
+          target-folder: previews/${{ github.ref_name }}
+          clean: false


### PR DESCRIPTION
## Summary
- add `deploy-preview.yml` to manually publish a branch under `gh-pages/previews/<branch>`
- document new workflow in `.github/workflows/README.md`

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b77d04b88330b4fe82073da132ab