### PR TITLE
Fix HUD overlay alignment for control buttons

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -20,6 +20,7 @@ class HudOverlay extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
               padding: const EdgeInsets.only(top: 8),


### PR DESCRIPTION
## Summary
- ensure HUD buttons align with top of screen by setting Row crossAxisAlignment to start

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bac8584c833097f8b01bf1c4f67b