### PR TITLE
Align HUD controls to top

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -16,69 +16,73 @@ class HudOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ValueListenableBuilder<int>(
+                      valueListenable: game.score,
+                      builder: (context, value, _) => AutoSizeText(
+                        'Score: $value',
+                        style: const TextStyle(color: Colors.white),
+                        maxLines: 1,
+                      ),
+                    ),
+                    ValueListenableBuilder<int>(
+                      valueListenable: game.highScore,
+                      builder: (context, value, _) => AutoSizeText(
+                        'High: $value',
+                        style: const TextStyle(color: Colors.white),
+                        maxLines: 1,
+                      ),
+                    ),
+                    ValueListenableBuilder<int>(
+                      valueListenable: game.health,
+                      builder: (context, value, _) => AutoSizeText(
+                        'Health: $value',
+                        style: const TextStyle(color: Colors.white),
+                        maxLines: 1,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Row(
                 children: [
-                  ValueListenableBuilder<int>(
-                    valueListenable: game.score,
-                    builder: (context, value, _) => AutoSizeText(
-                      'Score: $value',
-                      style: const TextStyle(color: Colors.white),
-                      maxLines: 1,
+                  IconButton(
+                    // Mirrors the H keyboard shortcut.
+                    icon: const Icon(Icons.help_outline, color: Colors.white),
+                    onPressed: game.toggleHelp,
+                  ),
+                  ValueListenableBuilder<bool>(
+                    valueListenable: game.audioService.muted,
+                    builder: (context, muted, _) => IconButton(
+                      // Mirrors the `M` keyboard shortcut.
+                      icon: Icon(
+                        muted ? Icons.volume_off : Icons.volume_up,
+                        color: Colors.white,
+                      ),
+                      onPressed: game.audioService.toggleMute,
                     ),
                   ),
-                  ValueListenableBuilder<int>(
-                    valueListenable: game.highScore,
-                    builder: (context, value, _) => AutoSizeText(
-                      'High: $value',
-                      style: const TextStyle(color: Colors.white),
-                      maxLines: 1,
-                    ),
-                  ),
-                  ValueListenableBuilder<int>(
-                    valueListenable: game.health,
-                    builder: (context, value, _) => AutoSizeText(
-                      'Health: $value',
-                      style: const TextStyle(color: Colors.white),
-                      maxLines: 1,
-                    ),
+                  IconButton(
+                    // Mirrors the Escape and P keyboard shortcuts.
+                    icon: const Icon(Icons.pause, color: Colors.white),
+                    onPressed: game.pauseGame,
                   ),
                 ],
               ),
-            ),
-            Row(
-              children: [
-                IconButton(
-                  // Mirrors the H keyboard shortcut.
-                  icon: const Icon(Icons.help_outline, color: Colors.white),
-                  onPressed: game.toggleHelp,
-                ),
-                ValueListenableBuilder<bool>(
-                  valueListenable: game.audioService.muted,
-                  builder: (context, muted, _) => IconButton(
-                    // Mirrors the `M` keyboard shortcut.
-                    icon: Icon(
-                      muted ? Icons.volume_off : Icons.volume_up,
-                      color: Colors.white,
-                    ),
-                    onPressed: game.audioService.toggleMute,
-                  ),
-                ),
-                IconButton(
-                  // Mirrors the Escape and P keyboard shortcuts.
-                  icon: const Icon(Icons.pause, color: Colors.white),
-                  onPressed: game.pauseGame,
-                ),
-              ],
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- keep HUD row pinned to the top so help, volume, and pause buttons no longer float midway down the screen

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bac8584c833097f8b01bf1c4f67b