### PR TITLE
Ensure setup scripts restore original directory

### DIFF
--- a/scripts/bootstrap_flutter.ps1
+++ b/scripts/bootstrap_flutter.ps1
@@ -57,6 +57,7 @@ if ((Test-Path $flutterBat) -and -not $Force) {
 Say "Bootstrapping Flutter $FLUTTER_VERSION ($FLUTTER_CHANNEL)"
 New-Item -ItemType Directory -Force -Path '.tooling' | Out-Null
 Push-Location '.tooling'
+try {
 # --- Config & URL (keeps your env overrides) ---
 $BASE_URL  = if ($env:FLUTTER_DOWNLOAD_MIRROR) { $env:FLUTTER_DOWNLOAD_MIRROR.TrimEnd('/') } else { 'https://storage.googleapis.com/flutter_infra_release/releases' }
 $ARCHIVE   = "flutter_windows_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.zip"
@@ -278,8 +279,9 @@ try {
   $global:ProgressPreference = $ProgressPreferenceBak
 }
 Remove-Item $destZip -Force
-
-Pop-Location
+} finally {
+  Pop-Location
+}
 Say "Flutter SDK installed at $FLUTTER_DIR"
 
 # Put Flutter on PATH for this session

--- a/setup.ps1
+++ b/setup.ps1
@@ -2,6 +2,8 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Push-Location $PSScriptRoot
+try {
 Write-Host "[setup] Bootstrapping Flutter SDK"
 & "$PSScriptRoot/scripts/bootstrap_flutter.ps1"
 
@@ -123,3 +125,6 @@ if ($chromePath) {
 }
 
 Write-Host "[setup] Completed"
+} finally {
+  Pop-Location
+}


### PR DESCRIPTION
## Summary
- Keep `setup.ps1` in the repository root by pushing and popping the working location
- Safely wrap `bootstrap_flutter.ps1` directory change in `try/finally` so errors don't leave users in `.tooling`

## Testing
- `pwsh -NoLogo -Command '$env:FLUTTER_DOWNLOAD_MIRROR="http://localhost"; try { ./setup.ps1 } catch { Write-Host "err" }; Get-Location'`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc5ed37083308668c2255695900b