### PR TITLE
Handle missing partial downloads in bootstrap script

### DIFF
--- a/scripts/bootstrap_flutter.ps1
+++ b/scripts/bootstrap_flutter.ps1
@@ -122,7 +122,12 @@ function Download-With-Http { param([string]$Url,[string]$Dest)
     Write-Progress -Activity "Downloading Flutter" -Completed
   } finally { $out.Dispose(); $in.Dispose(); $client.Dispose() }
 
-  Move-Item -Force $tmp $Dest
+  if (Test-Path $tmp) {
+    Move-Item -Force $tmp $Dest
+  } else {
+    Say "HttpClient download failed, falling back to Invoke-WebRequest"
+    Invoke-WebRequest -Uri $Url -OutFile $Dest -UseBasicParsing
+  }
 }
 
 function Download-With-Ranges { param([string]$Url,[string]$Dest,[int]$Parts=8)


### PR DESCRIPTION
## Summary
- fall back to `Invoke-WebRequest` when the streaming HttpClient download does not produce the expected `.partial` file

## Testing
- `pwsh -NoProfile -File scripts/bootstrap_flutter.ps1 -Force -Quiet` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c6c959e88330939da843e8a9b1d0