### PR TITLE
Add GameText widget for consistent overlay text styling

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -1,7 +1,7 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import 'game_text.dart';
 
 /// Overlay displayed when the player dies.
 class GameOverOverlay extends StatelessWidget {
@@ -25,36 +25,27 @@ class GameOverOverlay extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              AutoSizeText(
+              GameText(
                 'Game Over',
-                style: Theme.of(context)
-                    .textTheme
-                    .headlineMedium
-                    ?.copyWith(color: Colors.white),
+                style: Theme.of(context).textTheme.headlineMedium,
                 maxLines: 1,
               ),
               SizedBox(height: spacing),
               ValueListenableBuilder<int>(
                 valueListenable: game.score,
-                builder: (context, value, _) => AutoSizeText(
+                builder: (context, value, _) => GameText(
                   'Final Score: $value',
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold,
-                  ),
                   maxLines: 1,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
               ),
               SizedBox(height: spacing),
               ValueListenableBuilder<int>(
                 valueListenable: game.highScore,
-                builder: (context, value, _) => AutoSizeText(
+                builder: (context, value, _) => GameText(
                   'High Score: $value',
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold,
-                  ),
                   maxLines: 1,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
               ),
               SizedBox(height: spacing),
@@ -64,7 +55,7 @@ class GameOverOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the Enter and R keyboard shortcuts.
                     onPressed: game.startGame,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Restart',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),
@@ -74,7 +65,7 @@ class GameOverOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the Q and Escape keyboard shortcuts.
                     onPressed: game.returnToMenu,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Menu',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),
@@ -84,7 +75,7 @@ class GameOverOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the H keyboard shortcut.
                     onPressed: game.toggleHelp,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Help',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),

--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -1,0 +1,46 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+
+/// Displays text using a consistent style across game overlays.
+///
+/// Defaults to white text with a modest font size but can be customised
+/// via [style], [maxLines] and [textAlign].
+class GameText extends StatelessWidget {
+  const GameText(
+    this.data, {
+    super.key,
+    this.style,
+    this.maxLines,
+    this.textAlign,
+  });
+
+  /// String to display.
+  final String data;
+
+  /// Additional style information merged with the base style.
+  final TextStyle? style;
+
+  /// Optional maximum number of lines the text should occupy.
+  final int? maxLines;
+
+  /// Alignment of the text within its bounds.
+  final TextAlign? textAlign;
+
+  static const _baseStyle = TextStyle(
+    color: Colors.white,
+    fontSize: 18,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final mergedStyle = style == null
+        ? _baseStyle
+        : _baseStyle.merge(style).copyWith(color: style?.color ?? Colors.white);
+    return AutoSizeText(
+      data,
+      maxLines: maxLines,
+      textAlign: textAlign,
+      style: mergedStyle,
+    );
+  }
+}

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -1,7 +1,7 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import 'game_text.dart';
 
 /// Overlay listing available controls.
 class HelpOverlay extends StatelessWidget {
@@ -26,16 +26,13 @@ class HelpOverlay extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                AutoSizeText(
+                GameText(
                   'Controls',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headlineSmall
-                      ?.copyWith(color: Colors.white),
+                  style: Theme.of(context).textTheme.headlineSmall,
                   maxLines: 1,
                 ),
                 SizedBox(height: spacing),
-                const AutoSizeText(
+                const GameText(
                   'Move: WASD / Arrow keys\n'
                   'Shoot: Space\n'
                   'Mute: M\n'
@@ -44,13 +41,12 @@ class HelpOverlay extends StatelessWidget {
                   'Restart anytime: R\n'
                   'Menu: Q (pause/game over), Esc (game over)\n'
                   'Toggle Help: H or Esc',
-                  style: TextStyle(color: Colors.white),
                   textAlign: TextAlign.center,
                 ),
                 SizedBox(height: spacing),
                 ElevatedButton(
                   onPressed: game.toggleHelp,
-                  child: const AutoSizeText(
+                  child: const GameText(
                     'Close',
                     maxLines: 1,
                     style: TextStyle(fontWeight: FontWeight.bold),

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -1,7 +1,7 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import 'game_text.dart';
 
 /// Simple heads-up display shown during play.
 class HudOverlay extends StatelessWidget {
@@ -31,25 +31,22 @@ class HudOverlay extends StatelessWidget {
                   children: [
                     ValueListenableBuilder<int>(
                       valueListenable: game.score,
-                      builder: (context, value, _) => AutoSizeText(
+                      builder: (context, value, _) => GameText(
                         'Score: $value',
-                        style: const TextStyle(color: Colors.white),
                         maxLines: 1,
                       ),
                     ),
                     ValueListenableBuilder<int>(
                       valueListenable: game.highScore,
-                      builder: (context, value, _) => AutoSizeText(
+                      builder: (context, value, _) => GameText(
                         'High: $value',
-                        style: const TextStyle(color: Colors.white),
                         maxLines: 1,
                       ),
                     ),
                     ValueListenableBuilder<int>(
                       valueListenable: game.health,
-                      builder: (context, value, _) => AutoSizeText(
+                      builder: (context, value, _) => GameText(
                         'Health: $value',
-                        style: const TextStyle(color: Colors.white),
                         maxLines: 1,
                       ),
                     ),

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -1,7 +1,7 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import 'game_text.dart';
 
 /// Start screen shown before gameplay begins.
 class MenuOverlay extends StatelessWidget {
@@ -25,32 +25,26 @@ class MenuOverlay extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              AutoSizeText(
+              GameText(
                 'Space Miner',
-                style: Theme.of(context)
-                    .textTheme
-                    .headlineMedium
-                    ?.copyWith(color: Colors.white),
+                style: Theme.of(context).textTheme.headlineMedium,
                 maxLines: 1,
               ),
               SizedBox(height: spacing),
               ValueListenableBuilder<int>(
                 valueListenable: game.highScore,
                 builder: (context, value, _) => value > 0
-                    ? AutoSizeText(
+                    ? GameText(
                         'High Score: $value',
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                        ),
                         maxLines: 1,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
                       )
                     : const SizedBox.shrink(),
               ),
               SizedBox(height: spacing),
               TextButton(
                 onPressed: () => game.resetHighScore(),
-                child: const AutoSizeText(
+                child: const GameText(
                   'Reset High Score',
                   maxLines: 1,
                   style: TextStyle(fontWeight: FontWeight.bold),
@@ -62,7 +56,7 @@ class MenuOverlay extends StatelessWidget {
                 children: [
                   ElevatedButton(
                     onPressed: game.startGame,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Start',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),
@@ -72,7 +66,7 @@ class MenuOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the H keyboard shortcut.
                     onPressed: game.toggleHelp,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Help',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -1,7 +1,7 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import 'game_text.dart';
 
 /// Overlay shown when the game is paused.
 class PauseOverlay extends StatelessWidget {
@@ -25,12 +25,9 @@ class PauseOverlay extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              AutoSizeText(
+              GameText(
                 'Paused',
-                style: Theme.of(context)
-                    .textTheme
-                    .headlineMedium
-                    ?.copyWith(color: Colors.white),
+                style: Theme.of(context).textTheme.headlineMedium,
                 maxLines: 1,
               ),
               SizedBox(height: spacing),
@@ -40,7 +37,7 @@ class PauseOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the Escape and P keyboard shortcuts.
                     onPressed: game.resumeGame,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Resume',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),
@@ -50,7 +47,7 @@ class PauseOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the R keyboard shortcut.
                     onPressed: game.startGame,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Restart',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),
@@ -60,7 +57,7 @@ class PauseOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the Q keyboard shortcut.
                     onPressed: game.returnToMenu,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Menu',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),
@@ -70,7 +67,7 @@ class PauseOverlay extends StatelessWidget {
                   ElevatedButton(
                     // Mirrors the H keyboard shortcut.
                     onPressed: game.toggleHelp,
-                    child: const AutoSizeText(
+                    child: const GameText(
                       'Help',
                       maxLines: 1,
                       style: TextStyle(fontWeight: FontWeight.bold),


### PR DESCRIPTION
## Summary
- add reusable `GameText` widget to centralise overlay text styling
- use `GameText` across menu, pause, HUD, game-over and help overlays for consistent appearance

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c8d90bfc8330ac36788cb7e31039