### PR TITLE
docs: reflect mining focus and enemy waves

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -75,6 +75,10 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 - Components mix in `HasGameRef<SpaceGame>` when they need game context.
 - Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and
   `HasCollisionDetection`.
+- An `EnemySpawner` system releases groups of enemies at timed intervals.
+- Asteroids drop mineral pickups when destroyed.
+- The player mounts two weapons: an auto-firing mining laser that targets
+  asteroids in range and a primary cannon that locks onto the nearest enemy.
 - Bullets, asteroids and enemies use small object pools to limit garbage
   collection, and unit tests verify pooled instances are reused.
 - The player loses health on collision with enemies or asteroids; the game ends
@@ -97,9 +101,19 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 - Use immutable data objects and pass dependencies via constructors.
 - Local save data will use `shared_preferences` in the MVP.
 - State is kept lightweight using plain classes or `ValueNotifier`s.
+- Track a mineral currency for mined resources and persist purchased upgrades.
+
+## Upgrades
+
+- Minerals earned from asteroids will fund weapon and ship upgrades in later
+  milestones.
+- Design upgrades to modify mining efficiency, combat power and utility systems
+  without bloating the core game loop.
 
 ## Game State Flow
 
+- Play centres on searching for asteroids to mine while surviving periodic enemy
+  waves.
 - The game starts in a menu overlay that also exposes a mute toggle.
 - `SpaceGame` transitions to `playing` when the user taps start.
 - Players can pause the game from the HUD or with the Escape or `P` key,

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,7 @@
 # 🚀 Space Miner Plan
 
-Tiny mobile‑first 2D shooter built with Flutter and Flame.
+Tiny mobile‑first 2D space miner built with Flutter and Flame. Players harvest
+minerals from asteroids while periodic enemy waves keep the action moving.
 Target is an offline PWA that a solo developer can iterate on quickly.
 See [DESIGN.md](DESIGN.md) for architecture details. All design docs are now
 in sync, and tasks are broken down in the milestone docs and consolidated in
@@ -14,6 +15,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Ship quickly and iterate in small increments
 - Responsive scaling so the same build works on phones, tablets and desktop
 - Solo-friendly workflow with minimal tooling
+- Core loop focused on mining asteroids for minerals while fending off enemy
+  groups
 
 ## 🚫 Non‑Goals
 
@@ -113,6 +116,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Components live in `lib/components/`
   (`player.dart`, `enemy.dart`, `asteroid.dart`, `bullet.dart`…)
 - Keep the core `SpaceGame` lean by delegating logic to small helper classes
+- An `EnemySpawner` emits groups on a timer, and the player mounts an auto-fire
+  mining laser plus a primary cannon that targets the nearest enemy.
 - On‑screen joystick and shoot button; WASD + Space mirror touch controls
 - Use Flame's built-in `JoystickComponent` and `ButtonComponent` for touch input
 - Keyboard support comes from `KeyboardListenerComponent`
@@ -144,8 +149,9 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 
 - Touch/joystick movement and shooting
 - Shooting uses a short cooldown to limit fire rate
-- One enemy type with collision and random spawns
-- Asteroids to mine for score; destroying enemies also grants points
+- Enemy groups spawn periodically; the main weapon auto-aims at the closest foe
+- Asteroids drop minerals when mined with an auto-targeting laser; destroying
+  enemies also grants points
 - Single endless level without progression for now
 - Player health and high score shown in the HUD with simple start/game‑over screens
 - Local high score stored on device (e.g., shared preferences)
@@ -225,7 +231,8 @@ in [TASKS.md](TASKS.md).
 - **Multiplayer** (`networking.md`): host‑authoritative co‑op via WebSocket
 - **Backend (optional)**: local storage sync or Firebase
 - **Native deployment (optional)**: Codemagic, Play Store, TestFlight
-- Additional features: inventory, upgrades, HUD, menus, shop UI, save/load
+- Additional features: inventory, mineral-based upgrades, HUD, menus, shop UI,
+  save/load
 
 ## 🔁 Daily Loop
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # 🚀 Space Miner PWA
 
-**Space Miner** is a mobile-first 2D space shooter where players fly around,
-mine asteroids and blast enemies — all built with **Flutter** and **Flame**.
+**Space Miner** is a mobile-first 2D space miner where players hunt for
+asteroids to harvest minerals while fending off periodic enemy waves — all
+built with **Flutter** and **Flame**. The ship sports an auto-firing mining
+laser for rocks and a main cannon that locks onto the closest threat.
 
 The aim is a light-hearted, cartoony game that runs smoothly on both mobile and
 desktop browsers using **Progressive Web App (PWA)** technology. You can
@@ -33,13 +35,14 @@ dedicated server or NAT traversal.
 ## 🧩 MVP Features
 
 - Touch/joystick movement and shooting
-- One enemy type with collision and random spawns
-- Asteroids to mine for score
+- Enemy groups spawn periodically and the main weapon auto-aims at the closest
+  foe
+- Asteroids can be mined for mineral drops using an auto-targeting laser
 - Single endless level with quick restart
 - Player health and high score displayed in the HUD; health drops on collision
 - Local high score stored on device using `shared_preferences`
-- Basic sound effects with a mute toggle on menu, HUD, pause
-  and game over screens, plus an `M` key shortcut
+- Basic sound effects with a mute toggle on menu, HUD, pause and game over
+  screens, plus an `M` key shortcut
 - Pause, resume or return to the menu via overlays (including game over screen)
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `Enter` starts or
@@ -54,7 +57,7 @@ dedicated server or NAT traversal.
 - Co-op multiplayer using WebSockets (host-authoritative)
 - Optional backend for saves or analytics
 - Native builds (Play Store/TestFlight) if needed later
-- Inventory, upgrades, menus, shop UI and save/load
+- Inventory, mineral-based upgrades, menus, shop UI and save/load
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -72,3 +72,12 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Limit player fire rate with a brief cooldown.
 - [x] Keyboard shortcut `F1` toggles debug overlays.
 - [x] Menu includes button to reset the high score.
+
+## Next Steps
+
+- [ ] Spawn enemy groups on a timer.
+- [ ] Add a mining laser that automatically targets and fires at nearby
+      asteroids.
+- [ ] Drop mineral pickups from asteroids and track the player's total.
+- [ ] Auto-aim the primary weapon at the closest enemy.
+- [ ] Draft an upgrade system that spends minerals on weapons and ship systems.


### PR DESCRIPTION
## Summary
- Emphasize mining-centric gameplay with auto-targeting lasers and periodic enemy waves
- Outline future mineral-based upgrades and add related tasks
- Refresh roadmap and README to match the new direction

## Testing
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `./scripts/flutterw test` *(fails: hangs loading enemy_pool_test.dart)*
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68b2c97a8c48833090d791329ee894e1