### PR TITLE
feat: smooth player rotation

### DIFF
--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/services.dart';
@@ -22,6 +24,9 @@ class PlayerComponent extends SpriteComponent
 
   /// Remaining cooldown time before another shot can fire.
   double _shootCooldown = 0;
+
+  /// Angle the ship should currently rotate towards.
+  double _targetAngle = 0;
 
   /// Fires a bullet from the player's current position.
   void shoot() {
@@ -61,6 +66,15 @@ class PlayerComponent extends SpriteComponent
         Vector2.all(size.x / 2),
         game.size - Vector2.all(size.x / 2),
       );
+      _targetAngle = math.atan2(input.y, input.x) + math.pi / 2;
+    }
+
+    final rotationDelta = _normalizeAngle(_targetAngle - angle);
+    final maxDelta = Constants.playerRotationSpeed * dt;
+    if (rotationDelta.abs() <= maxDelta) {
+      angle = _targetAngle;
+    } else {
+      angle += maxDelta * rotationDelta.sign;
     }
   }
 
@@ -100,5 +114,15 @@ class PlayerComponent extends SpriteComponent
       other.removeFromParent();
       game.hitPlayer();
     }
+  }
+
+  double _normalizeAngle(double a) {
+    while (a <= -math.pi) {
+      a += math.pi * 2;
+    }
+    while (a > math.pi) {
+      a -= math.pi * 2;
+    }
+    return a;
   }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -3,6 +3,9 @@ class Constants {
   /// Player movement speed in pixels per second.
   static const double playerSpeed = 200;
 
+  /// Player rotation speed in radians per second.
+  static const double playerRotationSpeed = 10;
+
   /// Player sprite size in logical pixels.
   static const double playerSize = 32;
 

--- a/test/player_rotation_test.dart
+++ b/test/player_rotation_test.dart
@@ -1,0 +1,63 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/components/player.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick});
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    player = _TestPlayer(joystick: joystick);
+    add(player);
+    onGameResize(Vector2.all(100));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('player rotates smoothly toward movement direction', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+
+    // Move down; target angle is pi.
+    game.joystick.delta.setValues(0, 1);
+    game.player.update(0.05);
+    final angleAfterFirstUpdate = game.player.angle;
+
+    // Should have started rotating but not reached the target.
+    expect(angleAfterFirstUpdate, greaterThan(0));
+    expect(angleAfterFirstUpdate, lessThan(math.pi));
+
+    // Change direction upward before rotation completes.
+    game.joystick.delta.setValues(0, -1);
+    game.player.update(0.05);
+    expect(game.player.angle, lessThan(angleAfterFirstUpdate));
+
+    // Let it finish rotating to the new target.
+    game.player.update(1);
+    expect(game.player.angle, closeTo(0, 0.001));
+  });
+}


### PR DESCRIPTION
## Summary
- rotate player ship smoothly toward movement direction
- add constant for rotation speed
- cover rotation behavior with unit test

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b2cf8c366c8330955af2523acfb442