### PR TITLE
feat: enlarge player sprite

### DIFF
--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -14,7 +14,12 @@ import 'enemy.dart';
 class PlayerComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, KeyboardHandler, CollisionCallbacks {
   PlayerComponent({required this.joystick})
-      : super(size: Vector2.all(Constants.playerSize), anchor: Anchor.center);
+      : super(
+          size: Vector2.all(
+            Constants.playerSize * Constants.playerScale,
+          ),
+          anchor: Anchor.center,
+        );
 
   /// Reference to the on-screen joystick for touch input.
   final JoystickComponent joystick;

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -6,8 +6,11 @@ class Constants {
   /// Player rotation speed in radians per second.
   static const double playerRotationSpeed = 10;
 
-  /// Player sprite size in logical pixels.
+  /// Base player sprite size in logical pixels.
   static const double playerSize = 32;
+
+  /// Scale applied to the player sprite size.
+  static const double playerScale = 4;
 
   /// Starting health for the player.
   static const int playerMaxHealth = 3;

--- a/test/player_rotation_test.dart
+++ b/test/player_rotation_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
@@ -28,7 +29,9 @@ class _TestGame extends SpaceGame {
     );
     player = _TestPlayer(joystick: joystick);
     add(player);
-    onGameResize(Vector2.all(100));
+    onGameResize(
+      Vector2.all(Constants.playerSize * Constants.playerScale * 2),
+    );
   }
 }
 

--- a/test/player_shoot_cooldown_test.dart
+++ b/test/player_shoot_cooldown_test.dart
@@ -47,7 +47,9 @@ class _TestGame extends SpaceGame {
     );
     player = _TestPlayer(joystick: joystick);
     add(player);
-    onGameResize(Vector2.all(100));
+    onGameResize(
+      Vector2.all(Constants.playerSize * Constants.playerScale * 2),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- add `playerScale` constant to control ship sprite scaling
- apply `playerScale` to the player component for 4x larger sprite
- adjust tests to size game area using new scale constant

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d27140b88330b6560a0ba594cd4d