### PR TITLE
docs: clarify mining focus and upgrade plans

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,6 +17,14 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 [lib/game](lib/game/README.md), [lib/components](lib/components/README.md),
 [lib/ui](lib/ui/README.md) and [lib/services](lib/services/README.md).
 
+## Game Concept
+
+Space Miner focuses on hunting asteroids for mineral pickups while timed enemy
+groups add bursts of combat. The ship mounts an auto-firing mining laser that
+locks onto nearby rocks and a primary cannon that automatically targets the
+closest enemy. Minerals gathered during play will later fund a wide upgrade
+tree spanning weapons and ship systems.
+
 ## Design Principles
 
 - Keep the codebase small and understandable for a solo developer.

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,6 +17,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Solo-friendly workflow with minimal tooling
 - Core loop focused on mining asteroids for minerals while fending off enemy
   groups
+- Auto-firing mining laser targets asteroids while the main cannon locks onto
+  the closest enemy
+- Minerals feed a broad upgrade tree for weapons and ship systems in later
+  milestones
 
 ## 🚫 Non‑Goals
 
@@ -231,8 +235,8 @@ in [TASKS.md](TASKS.md).
 - **Multiplayer** (`networking.md`): host‑authoritative co‑op via WebSocket
 - **Backend (optional)**: local storage sync or Firebase
 - **Native deployment (optional)**: Codemagic, Play Store, TestFlight
-- Additional features: inventory, mineral-based upgrades, HUD, menus, shop UI,
-  save/load
+- Additional features: inventory, extensive mineral-based upgrade tree for
+  weapons and ship systems, HUD, menus, shop UI, save/load
 
 ## 🔁 Daily Loop
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -80,4 +80,5 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       asteroids.
 - [ ] Drop mineral pickups from asteroids and track the player's total.
 - [ ] Auto-aim the primary weapon at the closest enemy.
-- [ ] Draft an upgrade system that spends minerals on weapons and ship systems.
+- [ ] Design a broad upgrade system where minerals purchase new weapon and ship
+      upgrades.

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -20,3 +20,11 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - Components mix in `HasGameRef<SpaceGame>` and use simple hit boxes.
 - Timer-based spawners generate enemies and asteroids.
 - Consider small object pools for bullets, asteroids and enemies to limit garbage.
+
+## Next Steps
+
+- Spawn enemy groups in timed waves.
+- Equip the player with an auto-firing mining laser for nearby asteroids.
+- Drop minerals from mined asteroids and track the currency.
+- Auto-aim the main weapon at the closest enemy.
+- Outline a mineral-based upgrade system for weapons and ship systems.


### PR DESCRIPTION
## Summary
- Highlight mining-centric gameplay with auto-targeting weapons and enemy wave spawns
- Note future mineral-based upgrade tree in plan and tasks
- Track next steps for core loop and upgrade system

## Testing
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68b2cca60454833093305e3cef3494f1