### PR TITLE
feat: auto aim and adjust player scale

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -7,6 +7,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Game loads on mobile and desktop browsers
 - [ ] Touch and keyboard controls move the player
 - [ ] Player can shoot and destroy a basic enemy
+- [ ] Bullets travel in the direction the ship is facing
+- [ ] When stationary, the ship rotates toward the nearest enemy within range
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Shooting an asteroid destroys it and increases the on-screen score
 - [ ] Score resets when restarting the game

--- a/TASKS.md
+++ b/TASKS.md
@@ -79,6 +79,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [ ] Add a mining laser that automatically targets and fires at nearby
       asteroids.
 - [ ] Drop mineral pickups from asteroids and track the player's total.
-- [ ] Auto-aim the primary weapon at the closest enemy.
+- [x] Auto-aim the primary weapon at the closest enemy when stationary.
+- [ ] Refine auto-aim targeting behaviour for smoother updates.
 - [ ] Design a broad upgrade system where minerals purchase new weapon and ship
       upgrades.

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
@@ -24,6 +26,7 @@ class BulletComponent extends SpriteComponent
     _direction
       ..setFrom(direction)
       ..normalize();
+    angle = math.atan2(_direction.y, _direction.x) + math.pi / 2;
   }
 
   @override
@@ -36,7 +39,10 @@ class BulletComponent extends SpriteComponent
   void update(double dt) {
     super.update(dt);
     position += _direction * Constants.bulletSpeed * dt;
-    if (position.y < -size.y || position.y > game.size.y + size.y) {
+    if (position.y < -size.y ||
+        position.y > game.size.y + size.y ||
+        position.x < -size.x ||
+        position.x > game.size.x + size.x) {
       removeFromParent();
     }
   }

--- a/lib/components/bullet.md
+++ b/lib/components/bullet.md
@@ -4,11 +4,12 @@ Short-lived projectile fired by the player.
 
 ## Behaviour
 
-- Travels in a straight line from the player's ship.
-- Destroyed on impact or after a brief lifetime.
+- Travels in a straight line from the player's ship, matching its current
+  orientation.
+- Removed on impact or when it exits the screen.
 - Uses sprite from `assets.dart` and speed from `constants.dart`.
 - Awards score on impact using values from `constants.dart`.
 - Reused through a simple object pool managed by `SpaceGame`.
-- Uses `RectangleHitbox` or `CircleHitbox` and `HasGameRef<SpaceGame>`.
+- Uses a `CircleHitbox` and `HasGameRef<SpaceGame>`.
 
 See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -6,8 +6,9 @@ Controllable ship for the player.
 
 - Moves via on-screen joystick or WASD keys.
 - Fires `BulletComponent`s with a short cooldown when the shoot button or space
-  bar is pressed.
+  bar is pressed, in the direction the ship is facing.
 - Colliding with enemies or asteroids reduces health via `SpaceGame.hitPlayer`.
+- When stationary, periodically rotates to face the nearest enemy within range.
 - Pulls sprites from `assets.dart` and tuning values from `constants.dart`.
 - Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -10,7 +10,13 @@ class Constants {
   static const double playerSize = 32;
 
   /// Scale applied to the player sprite size.
-  static const double playerScale = 4;
+  static const double playerScale = 3;
+
+  /// Maximum distance to auto-aim enemies when stationary, in pixels.
+  static const double playerAutoAimRange = 300;
+
+  /// Seconds between auto-aim direction updates when stationary.
+  static const double playerAutoAimInterval = 0.2;
 
   /// Starting health for the player.
   static const int playerMaxHealth = 3;

--- a/test/player_auto_aim_test.dart
+++ b/test/player_auto_aim_test.dart
@@ -1,0 +1,63 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/components/enemy.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+class _TestEnemy extends EnemyComponent {
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick});
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    player = _TestPlayer(joystick: joystick);
+    add(player);
+    onGameResize(
+      Vector2.all(Constants.playerSize * Constants.playerScale * 2),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('player auto-aims nearest enemy when stationary', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+
+    final enemy = _TestEnemy()..reset(game.player.position + Vector2(100, 0));
+    game.add(enemy);
+    game.update(0);
+
+    expect(game.player.angle, closeTo(0, 0.001));
+
+    game.update(Constants.playerAutoAimInterval);
+    expect(game.player.angle, closeTo(math.pi / 2, 0.001));
+  });
+}


### PR DESCRIPTION
## Summary
- rotate bullets to match ship heading and remove them once off-screen
- prevent auto-aim lookups from mutating the component tree and add a unit test
- document bullet hitbox usage

## Testing
- `./scripts/flutterw test`
- `./scripts/dartw analyze`


------
https://chatgpt.com/codex/tasks/task_e_68b2db82c5248330aa1a9a310d8ad58c