### PR TITLE
Scale enemies and asteroids to match player

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -14,7 +14,9 @@ class AsteroidComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, CollisionCallbacks {
   AsteroidComponent()
       : super(
-          size: Vector2.all(Constants.asteroidSize),
+          size: Vector2.all(
+            Constants.asteroidSize * Constants.asteroidScale,
+          ),
           anchor: Anchor.center,
         );
 

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -14,7 +14,9 @@ class EnemyComponent extends SpriteComponent
     with HasGameReference<SpaceGame>, CollisionCallbacks {
   EnemyComponent()
       : super(
-          size: Vector2.all(Constants.enemySize),
+          size: Vector2.all(
+            Constants.enemySize * Constants.enemyScale,
+          ),
           anchor: Anchor.center,
         );
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -33,8 +33,11 @@ class Constants {
   /// Enemy movement speed in pixels per second.
   static const double enemySpeed = 100;
 
-  /// Enemy sprite size in logical pixels.
+  /// Base enemy sprite size in logical pixels.
   static const double enemySize = 32;
+
+  /// Scale applied to the enemy sprite size.
+  static const double enemyScale = 3;
 
   /// Seconds between enemy spawns.
   static const double enemySpawnInterval = 2;
@@ -42,8 +45,11 @@ class Constants {
   /// Asteroid movement speed in pixels per second.
   static const double asteroidSpeed = 50;
 
-  /// Asteroid sprite size in logical pixels.
+  /// Base asteroid sprite size in logical pixels.
   static const double asteroidSize = 24;
+
+  /// Scale applied to the asteroid sprite size.
+  static const double asteroidScale = 3;
 
   /// Seconds between asteroid spawns.
   static const double asteroidSpawnInterval = 3;

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -144,7 +144,11 @@ class SpaceGame extends FlameGame
 
   void _spawnEnemy() {
     final x = _random.nextDouble() * size.x;
-    add(acquireEnemy(Vector2(x, -Constants.enemySize)));
+    add(
+      acquireEnemy(
+        Vector2(x, -Constants.enemySize * Constants.enemyScale),
+      ),
+    );
   }
 
   void _spawnAsteroid() {
@@ -152,7 +156,7 @@ class SpaceGame extends FlameGame
     final vx = (_random.nextDouble() - 0.5) * Constants.asteroidSpeed;
     add(
       acquireAsteroid(
-        Vector2(x, -Constants.asteroidSize),
+        Vector2(x, -Constants.asteroidSize * Constants.asteroidScale),
         Vector2(vx, Constants.asteroidSpeed),
       ),
     );


### PR DESCRIPTION
## Summary
- add enemyScale and asteroidScale constants and use them to size sprites
- adjust spawn positions for scaled enemies and asteroids

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e71840f083309b023542e4cbf610