### PR TITLE
feat: centralize overlay text styling

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -88,7 +88,7 @@ class GameOverOverlay extends StatelessWidget {
                       iconSize: iconSize,
                       icon: Icon(
                         muted ? Icons.volume_off : Icons.volume_up,
-                        color: Colors.white,
+                        color: GameText.defaultColor,
                       ),
                       // Mirrors the M keyboard shortcut.
                       onPressed: game.audioService.toggleMute,

--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 
 /// Displays text using a consistent style across game overlays.
 ///
-/// Defaults to white text with a modest font size but can be customised
+/// Defaults to yellow text with a modest font size but can be customised
 /// via [style], [maxLines] and [textAlign].
 class GameText extends StatelessWidget {
   const GameText(
@@ -12,6 +12,7 @@ class GameText extends StatelessWidget {
     this.style,
     this.maxLines,
     this.textAlign,
+    this.color,
   });
 
   /// String to display.
@@ -26,16 +27,21 @@ class GameText extends StatelessWidget {
   /// Alignment of the text within its bounds.
   final TextAlign? textAlign;
 
+  /// Explicit colour override for the text.
+  final Color? color;
+
+  /// Base colour used for in-game text.
+  static const Color defaultColor = Colors.yellow;
+
   static const _baseStyle = TextStyle(
-    color: Colors.white,
+    color: defaultColor,
     fontSize: 18,
   );
 
   @override
   Widget build(BuildContext context) {
-    final mergedStyle = style == null
-        ? _baseStyle
-        : _baseStyle.merge(style).copyWith(color: style?.color ?? Colors.white);
+    final mergedStyle =
+        _baseStyle.merge(style).copyWith(color: color ?? defaultColor);
     return AutoSizeText(
       data,
       maxLines: maxLines,

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -57,7 +57,8 @@ class HudOverlay extends StatelessWidget {
                 children: [
                   IconButton(
                     // Mirrors the H keyboard shortcut.
-                    icon: const Icon(Icons.help_outline, color: Colors.white),
+                    icon: const Icon(Icons.help_outline,
+                        color: GameText.defaultColor),
                     onPressed: game.toggleHelp,
                   ),
                   ValueListenableBuilder<bool>(
@@ -66,14 +67,14 @@ class HudOverlay extends StatelessWidget {
                       // Mirrors the `M` keyboard shortcut.
                       icon: Icon(
                         muted ? Icons.volume_off : Icons.volume_up,
-                        color: Colors.white,
+                        color: GameText.defaultColor,
                       ),
                       onPressed: game.audioService.toggleMute,
                     ),
                   ),
                   IconButton(
                     // Mirrors the Escape and P keyboard shortcuts.
-                    icon: const Icon(Icons.pause, color: Colors.white),
+                    icon: const Icon(Icons.pause, color: GameText.defaultColor),
                     onPressed: game.pauseGame,
                   ),
                 ],

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -66,7 +66,7 @@ class MenuOverlay extends StatelessWidget {
                           decoration: BoxDecoration(
                             border: Border.all(
                               color: selected == i
-                                  ? Colors.white
+                                  ? GameText.defaultColor
                                   : Colors.transparent,
                               width: 2,
                             ),
@@ -109,7 +109,7 @@ class MenuOverlay extends StatelessWidget {
                       iconSize: iconSize,
                       icon: Icon(
                         muted ? Icons.volume_off : Icons.volume_up,
-                        color: Colors.white,
+                        color: GameText.defaultColor,
                       ),
                       onPressed: game.audioService.toggleMute,
                     ),

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -80,7 +80,7 @@ class PauseOverlay extends StatelessWidget {
                       iconSize: iconSize,
                       icon: Icon(
                         muted ? Icons.volume_off : Icons.volume_up,
-                        color: Colors.white,
+                        color: GameText.defaultColor,
                       ),
                       // Mirrors the M keyboard shortcut.
                       onPressed: game.audioService.toggleMute,


### PR DESCRIPTION
## Summary
- add GameText.defaultColor to unify text styling
- update overlays to use shared GameText color for icons and borders

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e6defe3083309b60e8038a1cd897