### PR TITLE
Add auto-aim radius toggle

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -9,6 +9,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Player can shoot and destroy a basic enemy
 - [ ] Bullets travel in the direction the ship is facing
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
+- [ ] HUD button toggles auto-aim radius display
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:ui';
 
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
@@ -39,6 +40,14 @@ class PlayerComponent extends SpriteComponent
   /// Accumulates time between auto-aim updates when stationary.
   double _autoAimTimer = 0;
 
+  /// Whether to render the auto-aim radius around the player.
+  bool showAutoAimRadius = false;
+
+  /// Paint used when drawing the auto-aim radius.
+  final Paint _autoAimPaint = Paint()
+    ..color = const Color(0x66ffffff)
+    ..style = PaintingStyle.stroke;
+
   /// Sets the current sprite for the player.
   void setSprite(String path) {
     _spritePath = path;
@@ -52,6 +61,11 @@ class PlayerComponent extends SpriteComponent
     _targetAngle = 0;
     _shootCooldown = 0;
     _keyboardDirection.setZero();
+  }
+
+  /// Toggles visibility of the auto-aim radius.
+  void toggleAutoAimRadius() {
+    showAutoAimRadius = !showAutoAimRadius;
   }
 
   /// Fires a bullet from the player's current position.
@@ -115,6 +129,18 @@ class PlayerComponent extends SpriteComponent
       angle = _targetAngle;
     } else {
       angle += maxDelta * rotationDelta.sign;
+    }
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    if (showAutoAimRadius) {
+      canvas.drawCircle(
+        Offset(size.x / 2, size.y / 2),
+        Constants.playerAutoAimRange,
+        _autoAimPaint,
+      );
     }
   }
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -339,6 +339,11 @@ class SpaceGame extends FlameGame
     }
   }
 
+  /// Toggles rendering of the player's auto-aim radius.
+  void toggleAutoAimRadius() {
+    player.toggleAutoAimRadius();
+  }
+
   @override
   KeyEventResult onKeyEvent(
     KeyEvent event,

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -13,8 +13,8 @@ Flutter overlays and HUD widgets.
 
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
-- [HudOverlay](hud_overlay.md) – shows score, high score and health with help,
-  mute and pause buttons.
+- [HudOverlay](hud_overlay.md) – shows score, high score and health with
+  auto-aim radius toggle, help, mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displayed when the game is paused with
   resume, restart, menu, help and mute buttons.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -36,6 +36,7 @@ class HelpOverlay extends StatelessWidget {
                   'Move: WASD / Arrow keys\n'
                   'Shoot: Space\n'
                   'Mute: M\n'
+                  'Auto-aim Radius: HUD button\n'
                   'Pause/Resume: Esc or P\n'
                   'Start/Restart: Enter\n'
                   'Restart anytime: R\n'

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -56,6 +56,10 @@ class HudOverlay extends StatelessWidget {
               Row(
                 children: [
                   IconButton(
+                    icon: const Icon(Icons.gps_fixed, color: Colors.white),
+                    onPressed: game.toggleAutoAimRadius,
+                  ),
+                  IconButton(
                     // Mirrors the H keyboard shortcut.
                     icon: const Icon(Icons.help_outline, color: Colors.white),
                     onPressed: game.toggleHelp,

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -5,7 +5,8 @@ Heads-up display shown during play.
 ## Features
 
 - Shows current score, high score and health using `ValueNotifier`s from `SpaceGame`.
-- Provides help, mute and pause buttons bound to `SpaceGame` and `AudioService`.
+- Provides auto-aim radius toggle, help, mute and pause buttons bound to
+  `SpaceGame` and `AudioService`.
 - `H` opens the help overlay showing controls; `Esc` closes it.
 - `M` key also toggles audio mute.
 - `Escape` or `P` keys also pause or resume.

--- a/test/player_auto_aim_radius_toggle_test.dart
+++ b/test/player_auto_aim_radius_toggle_test.dart
@@ -1,0 +1,54 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick})
+      : super(spritePath: 'players/player1.png');
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    player = _TestPlayer(joystick: joystick);
+    add(player);
+    onGameResize(
+      Vector2.all(Constants.playerSize * Constants.playerScale * 2),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('toggle auto-aim radius', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+
+    expect(game.player.showAutoAimRadius, isFalse);
+    game.toggleAutoAimRadius();
+    expect(game.player.showAutoAimRadius, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- allow player to toggle auto-aim radius visualization
- expose toggle through HUD button and help text
- cover auto-aim radius toggle with unit test

## Testing
- `scripts/dartw format lib test`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e77d74e483309a19fd57d0208b43