### PR TITLE
Ensure player ship respawns at center after death

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -221,7 +221,6 @@ class SpaceGame extends FlameGame
     }
     health.value -= 1;
     if (health.value <= 0) {
-      player.removeFromParent();
       gameOver();
     }
   }

--- a/test/player_respawn_test.dart
+++ b/test/player_respawn_test.dart
@@ -1,0 +1,46 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('player respawns at center after death', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+
+    game.startGame();
+    game.player.position.setValues(20, 20);
+
+    for (var i = 0; i < Constants.playerMaxHealth; i++) {
+      game.hitPlayer();
+    }
+
+    expect(game.state, GameState.gameOver);
+
+    game.startGame();
+    expect(game.player.position, Vector2.all(50));
+  });
+}


### PR DESCRIPTION
## Summary
- prevent player component removal on death so restart respawns ship at screen center
- add regression test covering ship position after death

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e68978408330b0889c9f2712419c