### PR TITLE
Auto-scale overlay icons based on screen size

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import 'game_text.dart';
+import 'responsive.dart';
 
 /// Overlay displayed when the player dies.
 class GameOverOverlay extends StatelessWidget {
@@ -19,7 +20,7 @@ class GameOverOverlay extends StatelessWidget {
       builder: (context, constraints) {
         final shortestSide = constraints.biggest.shortestSide;
         final spacing = shortestSide * 0.02;
-        final iconSize = shortestSide * 0.05;
+        final iconSize = responsiveIconSize(constraints);
 
         return Center(
           child: Column(

--- a/lib/ui/game_over_overlay.md
+++ b/lib/ui/game_over_overlay.md
@@ -6,6 +6,7 @@ Flutter widget shown when the player dies.
 
 - Displays final score and the persisted high score.
 - Tapping restart resets `SpaceGame` to the `playing` state.
+- Icon sizes scale with screen size for consistency across devices.
 - Press `Enter` or `R` to restart without clicking the button.
 - Menu button returns to the title screen.
 - Press `Q` or `Esc` to return to the menu without clicking the button.

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import 'game_text.dart';
+import 'responsive.dart';
 
 /// Simple heads-up display shown during play.
 class HudOverlay extends StatelessWidget {
@@ -15,6 +16,7 @@ class HudOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final iconSize = responsiveIconSizeFromContext(context);
     return SafeArea(
       child: Align(
         alignment: Alignment.topCenter,
@@ -56,10 +58,12 @@ class HudOverlay extends StatelessWidget {
               Row(
                 children: [
                   IconButton(
+                    iconSize: iconSize,
                     icon: const Icon(Icons.gps_fixed, color: Colors.white),
                     onPressed: game.toggleAutoAimRadius,
                   ),
                   IconButton(
+                    iconSize: iconSize,
                     // Mirrors the H keyboard shortcut.
                     icon: const Icon(Icons.help_outline,
                         color: GameText.defaultColor),
@@ -68,6 +72,7 @@ class HudOverlay extends StatelessWidget {
                   ValueListenableBuilder<bool>(
                     valueListenable: game.audioService.muted,
                     builder: (context, muted, _) => IconButton(
+                      iconSize: iconSize,
                       // Mirrors the `M` keyboard shortcut.
                       icon: Icon(
                         muted ? Icons.volume_off : Icons.volume_up,
@@ -77,6 +82,7 @@ class HudOverlay extends StatelessWidget {
                     ),
                   ),
                   IconButton(
+                    iconSize: iconSize,
                     // Mirrors the Escape and P keyboard shortcuts.
                     icon: const Icon(Icons.pause, color: GameText.defaultColor),
                     onPressed: game.pauseGame,

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -7,6 +7,7 @@ Heads-up display shown during play.
 - Shows current score, high score and health using `ValueNotifier`s from `SpaceGame`.
 - Provides auto-aim radius toggle, help, mute and pause buttons bound to
   `SpaceGame` and `AudioService`.
+- Icon sizes scale with screen size for better usability on different devices.
 - `H` opens the help overlay showing controls; `Esc` closes it.
 - `M` key also toggles audio mute.
 - `Escape` or `P` keys also pause or resume.

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../game/space_game.dart';
 import '../assets.dart';
 import 'game_text.dart';
+import 'responsive.dart';
 
 /// Start screen shown before gameplay begins.
 class MenuOverlay extends StatelessWidget {
@@ -20,7 +21,7 @@ class MenuOverlay extends StatelessWidget {
       builder: (context, constraints) {
         final shortestSide = constraints.biggest.shortestSide;
         final spacing = shortestSide * 0.02;
-        final iconSize = shortestSide * 0.05;
+        final iconSize = responsiveIconSize(constraints);
 
         return Center(
           child: Column(

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import 'game_text.dart';
+import 'responsive.dart';
 
 /// Overlay shown when the game is paused.
 class PauseOverlay extends StatelessWidget {
@@ -19,7 +20,7 @@ class PauseOverlay extends StatelessWidget {
       builder: (context, constraints) {
         final shortestSide = constraints.biggest.shortestSide;
         final spacing = shortestSide * 0.02;
-        final iconSize = shortestSide * 0.05;
+        final iconSize = responsiveIconSize(constraints);
 
         return Center(
           child: Column(

--- a/lib/ui/pause_overlay.md
+++ b/lib/ui/pause_overlay.md
@@ -5,6 +5,7 @@ Overlay displayed when the game is paused.
 ## Features
 
 - Shows a "Paused" label with resume, restart, menu and mute buttons.
+- Icon sizes scale with screen size for consistency across devices.
 - Triggered from the HUD pause button or the Escape or `P` key.
 - Visible only while the game state is `paused`.
 - Press `R` to restart without using the button.

--- a/lib/ui/responsive.dart
+++ b/lib/ui/responsive.dart
@@ -1,0 +1,32 @@
+/// Utilities for responsive UI sizing.
+///
+/// Provides helpers to scale UI elements based on the current screen size so
+/// the game feels consistent on phones, tablets and desktops.
+import 'package:flutter/widgets.dart';
+
+const double _desktopBreakpoint = 900;
+const double _tabletBreakpoint = 600;
+
+/// Calculates an icon size that scales with the shortest side of [constraints].
+///
+/// Returns a `24` point icon on small phones, `48` on tablets and `72` on
+/// larger desktop displays. Breakpoints roughly match Material layout
+/// guidelines.
+///
+/// The returned size can be passed directly to [IconButton.iconSize].
+double responsiveIconSize(BoxConstraints constraints, {double base = 24}) {
+  final shortestSide = constraints.biggest.shortestSide;
+  if (shortestSide >= _desktopBreakpoint) {
+    return base * 3; // Desktop.
+  }
+  if (shortestSide >= _tabletBreakpoint) {
+    return base * 2; // Tablet.
+  }
+  return base; // Phone.
+}
+
+/// Variant that takes a [BuildContext] instead of [BoxConstraints].
+double responsiveIconSizeFromContext(BuildContext context, {double base = 24}) {
+  return responsiveIconSize(BoxConstraints.tight(MediaQuery.of(context).size),
+      base: base);
+}


### PR DESCRIPTION
## Summary
- add `responsiveIconSize` helper with phone/tablet/desktop breakpoints
- apply icon scaling to menu, pause, game over and HUD overlays for consistent sizing
- document that overlays now scale icon sizes across devices

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e956df74833082c0fde4b3c46d36