### PR TITLE
feat: add enemy health and pulsing mining laser

### DIFF
--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -18,12 +18,14 @@ Gameplay entities and reusable pieces.
 
 - [PlayerComponent](player.md) – moves via joystick or keyboard, fires bullets
   with a short cooldown and tracks health.
-- [EnemyComponent](enemy.md) – drifts toward the player and is destroyed on
-  bullet impact, awarding score when defeated.
-- [BulletComponent](bullet.md) – short-lived projectile destroyed on hit or
-  when leaving the screen.
-- [AsteroidComponent](asteroid.md) – floats randomly and awards score when
-  destroyed.
+- [EnemyComponent](enemy.md) – drifts toward the player with a single health
+  point and awards score when defeated.
+- [BulletComponent](bullet.md) – short-lived projectile that deals one damage
+  and is destroyed on hit or when leaving the screen.
+- [AsteroidComponent](asteroid.md) – floats randomly, requires four to six
+  damage pulses, and awards score on each hit.
+- [MiningLaserComponent](mining_laser.md) – auto-targets and mines nearby
+  asteroids with a widening pulse beam.
 - [StarfieldComponent](starfield.md) – procedural three-layer background with
   parallax motion.
 

--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
@@ -21,12 +23,17 @@ class AsteroidComponent extends SpriteComponent
         );
 
   final Vector2 _velocity = Vector2.zero();
+  static final _rand = math.Random();
+  int _health = Constants.asteroidMaxHealth;
 
   /// Prepares the asteroid for reuse.
   void reset(Vector2 position, Vector2 velocity) {
     this.position..setFrom(position);
     _velocity..setFrom(velocity);
     sprite = Sprite(Flame.images.fromCache(Assets.randomAsteroid()));
+    _health = Constants.asteroidMinHealth +
+        _rand.nextInt(
+            Constants.asteroidMaxHealth - Constants.asteroidMinHealth + 1);
   }
 
   @override
@@ -49,5 +56,14 @@ class AsteroidComponent extends SpriteComponent
   void onRemove() {
     super.onRemove();
     game.releaseAsteroid(this);
+  }
+
+  /// Reduces health by [amount] and removes the asteroid when depleted.
+  void takeDamage(int amount) {
+    _health -= amount;
+    game.addScore(Constants.asteroidScore);
+    if (_health <= 0 && !isRemoving) {
+      removeFromParent();
+    }
   }
 }

--- a/lib/components/asteroid.md
+++ b/lib/components/asteroid.md
@@ -5,9 +5,9 @@ Neutral obstacle that can be mined for score.
 ## Behaviour
 
 - Spawns randomly and drifts across the play area.
-- Destroyed by bullets or mining action; awards score pickups.
+- Destroyed by repeated bullet or mining hits; awards score pickups each time.
 - Uses sprites from `assets.dart` and numbers from `constants.dart`.
-- Awards `Constants.asteroidScore` points when destroyed.
+- Starts with 4–6 health and grants `Constants.asteroidScore` points per hit.
 - Uses a small object pool to reuse instances.
 - Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -60,14 +60,12 @@ class BulletComponent extends SpriteComponent
   ) {
     super.onCollisionStart(intersectionPoints, other);
     if (other is EnemyComponent) {
-      other.removeFromParent();
+      other.takeDamage(Constants.bulletDamage);
       removeFromParent();
-      game.addScore(Constants.enemyScore);
     }
     if (other is AsteroidComponent) {
-      other.removeFromParent();
+      other.takeDamage(Constants.bulletDamage);
       removeFromParent();
-      game.addScore(Constants.asteroidScore);
     }
   }
 }

--- a/lib/components/bullet.md
+++ b/lib/components/bullet.md
@@ -7,6 +7,7 @@ Short-lived projectile fired by the player.
 - Travels in a straight line from the player's ship, matching its current
   orientation.
 - Removed on impact or when it exits the screen.
+- Deals one damage to enemies and asteroids.
 - Uses sprite from `assets.dart` and speed from `constants.dart`.
 - Awards score on impact using values from `constants.dart`.
 - Reused through a simple object pool managed by `SpaceGame`.

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -20,10 +20,13 @@ class EnemyComponent extends SpriteComponent
           anchor: Anchor.center,
         );
 
+  int _health = Constants.enemyMaxHealth;
+
   /// Prepares the enemy for reuse.
   void reset(Vector2 position) {
     this.position.setFrom(position);
     sprite = Sprite(Flame.images.fromCache(Assets.randomEnemy()));
+    _health = Constants.enemyMaxHealth;
   }
 
   @override
@@ -47,5 +50,14 @@ class EnemyComponent extends SpriteComponent
   void onRemove() {
     super.onRemove();
     game.releaseEnemy(this);
+  }
+
+  /// Reduces health by [amount] and removes the enemy when depleted.
+  void takeDamage(int amount) {
+    _health -= amount;
+    if (_health <= 0 && !isRemoving) {
+      game.addScore(Constants.enemyScore);
+      removeFromParent();
+    }
   }
 }

--- a/lib/components/enemy.md
+++ b/lib/components/enemy.md
@@ -5,7 +5,8 @@ Basic foe that drifts toward the player.
 ## Behaviour
 
 - Spawns at screen edges and moves toward the player ship.
-- Damages the player on contact and is destroyed when hit by a bullet.
+- Damages the player on contact and has a single health point.
+- Destroyed when hit by a bullet, awarding score on defeat.
 - Sprites resolved through `assets.dart`; speeds and hit points from `constants.dart`.
 - Awards score when destroyed, using `Constants.enemyScore`.
 - Uses `CircleHitbox` or `RectangleHitbox` depending on art.

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -1,0 +1,73 @@
+import 'package:flame/components.dart';
+import 'package:flutter/painting.dart';
+
+import '../constants.dart';
+import '../game/space_game.dart';
+import 'asteroid.dart';
+import 'player.dart';
+
+/// Automatically mines the nearest asteroid within range.
+class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
+  MiningLaserComponent({required this.player});
+
+  final PlayerComponent player;
+  AsteroidComponent? _target;
+  final Paint _paint = Paint()..color = const Color(0x66ffffff);
+  double _pulseTimer = 0;
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (!player.isMounted) return;
+
+    if (_target == null ||
+        !_target!.isMounted ||
+        _target!.position.distanceTo(player.position) >
+            Constants.playerMiningRange) {
+      _target = _findClosestAsteroid();
+      _pulseTimer = 0;
+    }
+
+    if (_target != null) {
+      _pulseTimer += dt;
+      final progress =
+          (_pulseTimer / Constants.miningPulseInterval).clamp(0, 1).toDouble();
+      _paint.strokeWidth = 2 + 2 * progress;
+      if (_pulseTimer >= Constants.miningPulseInterval) {
+        _pulseTimer = 0;
+        _paint.strokeWidth = 2;
+        _target!.takeDamage(Constants.miningPulseDamage);
+        if (!_target!.isMounted) {
+          _target = null;
+        }
+      }
+    } else {
+      _paint.strokeWidth = 2;
+    }
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    if (_target == null || !_target!.isMounted) return;
+    canvas.drawLine(
+      player.position.toOffset(),
+      _target!.position.toOffset(),
+      _paint,
+    );
+  }
+
+  AsteroidComponent? _findClosestAsteroid() {
+    AsteroidComponent? closest;
+    var closestDistance = Constants.playerMiningRange;
+    final asteroids = game.children.whereType<AsteroidComponent>().toList();
+    for (final asteroid in asteroids) {
+      final distance = asteroid.position.distanceTo(player.position);
+      if (distance <= closestDistance) {
+        closest = asteroid;
+        closestDistance = distance;
+      }
+    }
+    return closest;
+  }
+}

--- a/lib/components/mining_laser.md
+++ b/lib/components/mining_laser.md
@@ -1,0 +1,11 @@
+# MiningLaserComponent
+
+Automatically targets the nearest asteroid within range and mines it with
+discrete pulses.
+
+- Searches for the closest `AsteroidComponent` within
+  `Constants.playerMiningRange`.
+- Fires a pulse every `Constants.miningPulseInterval` seconds that deals
+  `Constants.miningPulseDamage` damage.
+- Renders a line between the player and target that widens as the pulse
+  charges.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -18,6 +18,15 @@ class Constants {
   /// Seconds between auto-aim direction updates when stationary.
   static const double playerAutoAimInterval = 0.2;
 
+  /// Maximum distance to auto-mine asteroids, in pixels.
+  static const double playerMiningRange = playerAutoAimRange;
+
+  /// Damage dealt by each mining laser pulse.
+  static const int miningPulseDamage = 1;
+
+  /// Seconds between mining laser pulses.
+  static const double miningPulseInterval = 0.5;
+
   /// Starting health for the player.
   static const int playerMaxHealth = 3;
 
@@ -29,6 +38,9 @@ class Constants {
 
   /// Minimum time between player shots in seconds.
   static const double bulletCooldown = 0.2;
+
+  /// Damage dealt by player bullets.
+  static const int bulletDamage = 1;
 
   /// Enemy movement speed in pixels per second.
   static const double enemySpeed = 100;
@@ -42,6 +54,9 @@ class Constants {
   /// Seconds between enemy spawns.
   static const double enemySpawnInterval = 2;
 
+  /// Maximum health for an enemy.
+  static const int enemyMaxHealth = 1;
+
   /// Asteroid movement speed in pixels per second.
   static const double asteroidSpeed = 50;
 
@@ -50,6 +65,12 @@ class Constants {
 
   /// Scale applied to the asteroid sprite size.
   static const double asteroidScale = 3;
+
+  /// Minimum health for an asteroid.
+  static const int asteroidMinHealth = 4;
+
+  /// Maximum health for an asteroid.
+  static const int asteroidMaxHealth = 6;
 
   /// Seconds between asteroid spawns.
   static const double asteroidSpawnInterval = 3;

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -16,6 +16,7 @@ import '../components/bullet.dart';
 import '../assets.dart';
 import '../components/player.dart';
 import '../components/starfield.dart';
+import '../components/mining_laser.dart';
 import '../constants.dart';
 import '../services/storage_service.dart';
 import '../services/audio_service.dart';
@@ -46,6 +47,7 @@ class SpaceGame extends FlameGame
 
   GameState state = GameState.menu;
   late final PlayerComponent player;
+  late final MiningLaserComponent miningLaser;
   late final JoystickComponent joystick;
   late final HudButtonComponent fireButton;
   late final Timer _enemySpawnTimer;
@@ -109,6 +111,8 @@ class SpaceGame extends FlameGame
         PlayerComponent(joystick: joystick, spritePath: selectedPlayerSprite);
     add(player);
     camera.follow(player);
+    miningLaser = MiningLaserComponent(player: player);
+    add(miningLaser);
 
     fireButton = HudButtonComponent(
       button: CircleComponent(


### PR DESCRIPTION
## Summary
- add pulsing mining laser that widens before each hit
- give enemies and asteroids configurable health with 1-damage bullets
- award asteroid score on every mining pulse

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ea9e4d388330a2bc6c7460fe7e97