### PR TITLE
docs: mention F1 debug toggle in command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ dedicated server or NAT traversal.
   screens, plus an `M` key shortcut
 - Pause, resume or return to the menu via overlays (including game over screen)
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
-  shoot, `Escape` or `P` to pause or resume, `M` to mute, `Enter` starts or
-  restarts from the menu or game over, `R` restarts at any time, `Q` returns to
-  the menu from pause or game over, `Esc` also returns to the menu from game over,
-  `H` shows a help overlay that `Esc` also closes)
+  shoot, `Escape` or `P` to pause or resume, `M` to mute, `F1` toggles debug
+  overlays, `Enter` starts or restarts from the menu or game over, `R` restarts at
+  any time, `Q` returns to the menu from pause or game over, `Esc` also returns to
+  the menu from game over, `H` shows a help overlay that `Esc` also closes)
 - Game works offline after the first load
 - Parallax starfield background
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -21,10 +21,10 @@ Flutter overlays and HUD widgets.
   restart (button or `Enter`/`R`), menu, help and mute options.
 - [HelpOverlay](help_overlay.md) – lists all controls; toggled with `H` and
   pauses gameplay when opened mid-run; `Esc` also closes it.
-- The `M` key toggles mute in any overlay; `Enter` starts or restarts from the
-  menu or game over; `R` restarts at any time; `Escape` or `P` pauses or
-  resumes; `Q` returns to the menu from pause or game over and `Esc` also returns
-  to the menu from game over; `H` shows or hides the help overlay, and `Esc` also
-  closes it when visible.
+- The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
+  `Enter` starts or restarts from the menu or game over; `R` restarts at any
+  time; `Escape` or `P` pauses or resumes; `Q` returns to the menu from pause
+  or game over and `Esc` also returns to the menu from game over; `H` shows or
+  hides the help overlay, and `Esc` also closes it when visible.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -36,6 +36,7 @@ class HelpOverlay extends StatelessWidget {
                   'Move: WASD / Arrow keys\n'
                   'Shoot: Space\n'
                   'Mute: M\n'
+                  'Toggle Debug: F1\n'
                   'Auto-aim Radius: HUD button\n'
                   'Pause/Resume: Esc or P\n'
                   'Start/Restart: Enter\n'


### PR DESCRIPTION
## Summary
- include F1 debug toggle in in-game controls overlay
- document F1 debug shortcut in UI and project README

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2eed306ac833088227e65fe2f106e