### PR TITLE
Orient enemies toward travel direction

### DIFF
--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
@@ -35,6 +37,7 @@ class EnemyComponent extends SpriteComponent
   void update(double dt) {
     super.update(dt);
     final direction = (game.player.position - position).normalized();
+    angle = math.atan2(direction.y, direction.x) + math.pi / 2;
     position += direction * Constants.enemySpeed * dt;
     if (position.y > game.size.y + size.y ||
         position.x < -size.x ||

--- a/test/enemy_direction_test.dart
+++ b/test/enemy_direction_test.dart
@@ -1,0 +1,60 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/enemy.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick})
+      : super(spritePath: 'players/player1.png');
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    player = _TestPlayer(joystick: joystick);
+    add(player);
+    onGameResize(
+      Vector2.all(Constants.playerSize * Constants.playerScale * 2),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('enemy faces movement direction', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.enemies]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+
+    final enemy = EnemyComponent()
+      ..game = game
+      ..reset(game.player.position + Vector2(-100, 0));
+    enemy.update(0);
+
+    expect(enemy.angle, closeTo(math.pi / 2, 0.001));
+  });
+}


### PR DESCRIPTION
## Summary
- Rotate enemies to face their movement direction
- Cover enemy orientation with a unit test

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef049d108330a38e5c8a70a428e9