### PR TITLE
Display health of enemies and asteroids in debug mode

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -1,8 +1,10 @@
 import 'dart:math' as math;
+import 'dart:ui';
 
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
+import 'package:flame/text.dart';
 
 import '../assets.dart';
 import '../constants.dart';
@@ -25,6 +27,13 @@ class AsteroidComponent extends SpriteComponent
   final Vector2 _velocity = Vector2.zero();
   static final _rand = math.Random();
   int _health = Constants.asteroidMaxHealth;
+
+  static final TextPaint _debugTextPaint = TextPaint(
+    style: const TextStyle(
+      color: Color(0xffffffff),
+      fontSize: 10,
+    ),
+  );
 
   /// Prepares the asteroid for reuse.
   void reset(Vector2 position, Vector2 velocity) {
@@ -49,6 +58,20 @@ class AsteroidComponent extends SpriteComponent
         position.x < -size.x ||
         position.x > game.size.x + size.x) {
       removeFromParent();
+    }
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    if (game.debugMode) {
+      final text = '$_health';
+      final tp = _debugTextPaint.toTextPainter(text);
+      final position = Vector2(
+        -tp.width / 2,
+        -size.y / 2 - tp.height,
+      );
+      _debugTextPaint.render(canvas, text, position);
     }
   }
 

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -1,6 +1,9 @@
+import 'dart:ui';
+
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
+import 'package:flame/text.dart';
 
 import '../assets.dart';
 import '../constants.dart';
@@ -21,6 +24,13 @@ class EnemyComponent extends SpriteComponent
         );
 
   int _health = Constants.enemyMaxHealth;
+
+  static final TextPaint _debugTextPaint = TextPaint(
+    style: const TextStyle(
+      color: Color(0xffffffff),
+      fontSize: 10,
+    ),
+  );
 
   /// Prepares the enemy for reuse.
   void reset(Vector2 position) {
@@ -43,6 +53,20 @@ class EnemyComponent extends SpriteComponent
         position.x < -size.x ||
         position.x > game.size.x + size.x) {
       removeFromParent();
+    }
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    if (game.debugMode) {
+      final text = '$_health';
+      final tp = _debugTextPaint.toTextPainter(text);
+      final position = Vector2(
+        -tp.width / 2,
+        -size.y / 2 - tp.height,
+      );
+      _debugTextPaint.render(canvas, text, position);
     }
   }
 


### PR DESCRIPTION
## Summary
- draw current health above asteroids while debug overlay is active
- show enemy health in debug mode to aid debugging

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f010895c83309b61bfad342e4573