### PR TITLE
Add minerals stat to asteroid mining HUD

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,8 +72,8 @@ tree spanning weapons and ship systems.
   will slot in later milestones.
 - Flutter overlays handle menus and the HUD so UI stays outside the game loop.
 - A `GameState` enum tracks **menu → playing → paused → game over** transitions.
-- `SpaceGame` exposes `ValueNotifier`s for score, health and high score so
-  overlays can react without touching the game loop.
+- `SpaceGame` exposes `ValueNotifier`s for score, minerals, health and high
+  score so overlays can react without touching the game loop.
 - Asset paths live in a central `assets.dart` registry and tunable numbers live
   in `constants.dart` to avoid magic strings or numbers.
 
@@ -84,7 +84,7 @@ tree spanning weapons and ship systems.
 - Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and
   `HasCollisionDetection`.
 - An `EnemySpawner` system releases groups of enemies at timed intervals.
-- Asteroids drop mineral pickups when destroyed.
+- Damaging asteroids awards mineral pickups each time.
 - The player mounts two weapons: an auto-firing mining laser that targets
   asteroids in range and a primary cannon that locks onto the nearest enemy.
 - Bullets, asteroids and enemies use small object pools to limit garbage
@@ -126,7 +126,8 @@ tree spanning weapons and ship systems.
 - `SpaceGame` transitions to `playing` when the user taps start.
 - Players can pause the game from the HUD or with the Escape or `P` key,
   showing a pause overlay with resume, menu and mute buttons.
-- During play the HUD provides score, high score, health, pause and mute controls.
+- During play the HUD provides score, minerals, high score, health, pause and
+  mute controls.
 - On player death, a game over overlay appears with restart, menu and mute buttons.
 - A help overlay lists controls and can be toggled with the `H` key, pausing the
   game when opened mid-run. `Esc` also closes it without triggering pause.

--- a/PLAN.md
+++ b/PLAN.md
@@ -157,7 +157,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Asteroids drop minerals when mined with an auto-targeting laser; destroying
   enemies also grants points
 - Single endless level without progression for now
-- Player health and high score shown in the HUD with simple start/game‑over screens
+- Player health, minerals and high score shown in the HUD with simple
+  start/game‑over screens
 - Local high score stored on device (e.g., shared preferences)
 - Menu offers a reset button to clear the high score
 - Basic sound effects using `flame_audio` with mute toggle (button or `M` key)

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -13,8 +13,10 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score
+- [ ] Damaging an asteroid increases the on-screen minerals
 - [ ] Score resets when restarting the game
-- [ ] HUD shows current and high scores during play
+- [ ] Minerals reset when restarting the game
+- [ ] HUD shows current score, minerals and high score during play
 - [ ] Collisions reduce player health; game over when health reaches zero
 - [ ] Game states transition: menu → playing → paused → game over → restart or menu
 - [ ] Player can choose a ship from the menu before starting

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ dedicated server or NAT traversal.
   foe
 - Asteroids can be mined for mineral drops using an auto-targeting laser
 - Single endless level with quick restart
-- Player health and high score displayed in the HUD; health drops on collision
+- Player health, minerals and high score displayed in the HUD; health drops on
+  collision and minerals increase when damaging asteroids
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD, pause and game over
   screens, plus an `M` key shortcut

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -23,7 +23,7 @@ Gameplay entities and reusable pieces.
 - [BulletComponent](bullet.md) – short-lived projectile that deals one damage
   and is destroyed on hit or when leaving the screen.
 - [AsteroidComponent](asteroid.md) – floats randomly, requires four to six
-  damage pulses, and awards score on each hit.
+  damage pulses, and awards score and minerals on each hit.
 - [MiningLaserComponent](mining_laser.md) – auto-targets and mines nearby
   asteroids with a widening pulse beam.
 - [StarfieldComponent](starfield.md) – procedural three-layer background with

--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -10,7 +10,7 @@ import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
 
-/// Neutral obstacle that can be mined for score.
+/// Neutral obstacle that can be mined for score and minerals.
 ///
 /// Instances are pooled by [SpaceGame] to reduce garbage collection. Call
 /// [reset] before adding to the game to initialise position and velocity.
@@ -85,6 +85,7 @@ class AsteroidComponent extends SpriteComponent
   void takeDamage(int amount) {
     _health -= amount;
     game.addScore(Constants.asteroidScore);
+    game.addMinerals(Constants.asteroidMinerals);
     if (_health <= 0 && !isRemoving) {
       removeFromParent();
     }

--- a/lib/components/asteroid.md
+++ b/lib/components/asteroid.md
@@ -1,13 +1,15 @@
 # AsteroidComponent
 
-Neutral obstacle that can be mined for score.
+Neutral obstacle that can be mined for score and minerals.
 
 ## Behaviour
 
 - Spawns randomly and drifts across the play area.
-- Destroyed by repeated bullet or mining hits; awards score pickups each time.
+- Destroyed by repeated bullet or mining hits; awards score and mineral pickups
+  each time.
 - Uses sprites from `assets.dart` and numbers from `constants.dart`.
-- Starts with 4–6 health and grants `Constants.asteroidScore` points per hit.
+- Starts with 4–6 health and grants `Constants.asteroidScore` points and
+  `Constants.asteroidMinerals` minerals per hit.
 - Uses a small object pool to reuse instances.
 - Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/lib/components/bullet.md
+++ b/lib/components/bullet.md
@@ -9,7 +9,7 @@ Short-lived projectile fired by the player.
 - Removed on impact or when it exits the screen.
 - Deals one damage to enemies and asteroids.
 - Uses sprite from `assets.dart` and speed from `constants.dart`.
-- Awards score on impact using values from `constants.dart`.
+- Awards score and minerals on asteroid hits using values from `constants.dart`.
 - Reused through a simple object pool managed by `SpaceGame`.
 - Uses a `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -81,6 +81,9 @@ class Constants {
   /// Score awarded for mining an asteroid.
   static const int asteroidScore = 1;
 
+  /// Minerals gained for each hit on an asteroid.
+  static const int asteroidMinerals = 1;
+
   /// Number of stars spawned per parallax layer.
   static const int starsPerLayer = 30;
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -61,6 +61,9 @@ class SpaceGame extends FlameGame
   /// Highest score persisted across sessions.
   final ValueNotifier<int> highScore = ValueNotifier<int>(0);
 
+  /// Minerals collected from asteroids.
+  final ValueNotifier<int> minerals = ValueNotifier<int>(0);
+
   /// Player health exposed for HUD rendering.
   final ValueNotifier<int> health = ValueNotifier<int>(
     Constants.playerMaxHealth,
@@ -238,6 +241,11 @@ class SpaceGame extends FlameGame
     score.value += value;
   }
 
+  /// Adds [value] to the current mineral count.
+  void addMinerals(int value) {
+    minerals.value += value;
+  }
+
   @override
   void update(double dt) {
     super.update(dt);
@@ -288,6 +296,7 @@ class SpaceGame extends FlameGame
   void startGame() {
     state = GameState.playing;
     score.value = 0;
+    minerals.value = 0;
     health.value = Constants.playerMaxHealth;
     children.whereType<EnemyComponent>().forEach((e) => e.removeFromParent());
     children.whereType<AsteroidComponent>().forEach(

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -20,8 +20,9 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 - Expose helpers to pause, resume or return to the menu.
 - Drive the update cycle while delegating work to components and services.
 - Persist and load the high score through `StorageService`.
-- Exposes `ValueNotifier<int>`s for the current score, health and persisted high
-  score so Flutter overlays can render values without touching the game loop.
+- Exposes `ValueNotifier<int>`s for the current score, minerals, health and
+  persisted high score so Flutter overlays can render values without touching
+  the game loop.
 - Provide access to `AudioService` for playing sound effects and toggling mute.
 - Offers a method to reset the saved high score.
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -13,7 +13,7 @@ Flutter overlays and HUD widgets.
 
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
-- [HudOverlay](hud_overlay.md) – shows score, high score and health with
+- [HudOverlay](hud_overlay.md) – shows score, high score, minerals and health with
   auto-aim radius toggle, help, mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displayed when the game is paused with
   resume, restart, menu, help and mute buttons.

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -46,6 +46,13 @@ class HudOverlay extends StatelessWidget {
                       ),
                     ),
                     ValueListenableBuilder<int>(
+                      valueListenable: game.minerals,
+                      builder: (context, value, _) => GameText(
+                        'Minerals: $value',
+                        maxLines: 1,
+                      ),
+                    ),
+                    ValueListenableBuilder<int>(
                       valueListenable: game.health,
                       builder: (context, value, _) => GameText(
                         'Health: $value',

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -4,7 +4,8 @@ Heads-up display shown during play.
 
 ## Features
 
-- Shows current score, high score and health using `ValueNotifier`s from `SpaceGame`.
+- Shows current score, high score, minerals and health using `ValueNotifier`s from
+  `SpaceGame`.
 - Provides auto-aim radius toggle, help, mute and pause buttons bound to
   `SpaceGame` and `AudioService`.
 - Icon sizes scale with screen size for better usability on different devices.

--- a/test/asteroid_minerals_test.dart
+++ b/test/asteroid_minerals_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/assets.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/constants.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('damaging asteroid increases minerals', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll(Assets.asteroids);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+
+    final asteroid = game.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    await game.add(asteroid);
+    final initial = game.minerals.value;
+    asteroid.takeDamage(1);
+    expect(game.minerals.value, initial + Constants.asteroidMinerals);
+    game.releaseAsteroid(asteroid);
+  });
+}


### PR DESCRIPTION
## Summary
- track minerals from asteroid mining
- show minerals in HUD alongside score and health
- document and test new minerals stat

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f2cf764c8330aaf7f8db093b609f