### PR TITLE
Prevent minerals from main weapon hits

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -84,7 +84,7 @@ tree spanning weapons and ship systems.
 - Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and
   `HasCollisionDetection`.
 - An `EnemySpawner` system releases groups of enemies at timed intervals.
-- Damaging asteroids awards mineral pickups each time.
+- Mining asteroids with the laser awards mineral pickups each time.
 - The player mounts two weapons: an auto-firing mining laser that targets
   asteroids in range and a primary cannon that locks onto the nearest enemy.
 - Bullets, asteroids and enemies use small object pools to limit garbage

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -13,7 +13,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score
-- [ ] Damaging an asteroid increases the on-screen minerals
+- [ ] Mining an asteroid increases the on-screen minerals
 - [ ] Score resets when restarting the game
 - [ ] Minerals reset when restarting the game
 - [ ] HUD shows current score, minerals and high score during play

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dedicated server or NAT traversal.
 - Asteroids can be mined for mineral drops using an auto-targeting laser
 - Single endless level with quick restart
 - Player health, minerals and high score displayed in the HUD; health drops on
-  collision and minerals increase when damaging asteroids
+  collision and minerals increase when mining asteroids
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD, pause and game over
   screens, plus an `M` key shortcut

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -23,7 +23,8 @@ Gameplay entities and reusable pieces.
 - [BulletComponent](bullet.md) – short-lived projectile that deals one damage
   and is destroyed on hit or when leaving the screen.
 - [AsteroidComponent](asteroid.md) – floats randomly, requires four to six
-  damage pulses, and awards score and minerals on each hit.
+  damage pulses, and awards score on each hit while only mining laser hits
+  grant minerals.
 - [MiningLaserComponent](mining_laser.md) – auto-targets and mines nearby
   asteroids with a widening pulse beam.
 - [StarfieldComponent](starfield.md) – procedural three-layer background with

--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -82,10 +82,16 @@ class AsteroidComponent extends SpriteComponent
   }
 
   /// Reduces health by [amount] and removes the asteroid when depleted.
-  void takeDamage(int amount) {
+  ///
+  /// When [awardMinerals] is true (the default) minerals are granted to the
+  /// player for each hit, simulating mining laser pulses. Bullet damage passes
+  /// `awardMinerals: false` to avoid granting minerals for the main attack.
+  void takeDamage(int amount, {bool awardMinerals = true}) {
     _health -= amount;
     game.addScore(Constants.asteroidScore);
-    game.addMinerals(Constants.asteroidMinerals);
+    if (awardMinerals) {
+      game.addMinerals(Constants.asteroidMinerals);
+    }
     if (_health <= 0 && !isRemoving) {
       removeFromParent();
     }

--- a/lib/components/asteroid.md
+++ b/lib/components/asteroid.md
@@ -5,11 +5,11 @@ Neutral obstacle that can be mined for score and minerals.
 ## Behaviour
 
 - Spawns randomly and drifts across the play area.
-- Destroyed by repeated bullet or mining hits; awards score and mineral pickups
-  each time.
+- Destroyed by repeated bullet or mining laser hits. Each hit awards score and
+  only mining laser hits award mineral pickups.
 - Uses sprites from `assets.dart` and numbers from `constants.dart`.
 - Starts with 4–6 health and grants `Constants.asteroidScore` points and
-  `Constants.asteroidMinerals` minerals per hit.
+  `Constants.asteroidMinerals` minerals per mining laser hit.
 - Uses a small object pool to reuse instances.
 - Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -64,7 +64,10 @@ class BulletComponent extends SpriteComponent
       removeFromParent();
     }
     if (other is AsteroidComponent) {
-      other.takeDamage(Constants.bulletDamage);
+      other.takeDamage(
+        Constants.bulletDamage,
+        awardMinerals: false,
+      );
       removeFromParent();
     }
   }

--- a/lib/components/bullet.md
+++ b/lib/components/bullet.md
@@ -9,7 +9,7 @@ Short-lived projectile fired by the player.
 - Removed on impact or when it exits the screen.
 - Deals one damage to enemies and asteroids.
 - Uses sprite from `assets.dart` and speed from `constants.dart`.
-- Awards score and minerals on asteroid hits using values from `constants.dart`.
+- Awards score on asteroid hits using values from `constants.dart`.
 - Reused through a simple object pool managed by `SpaceGame`.
 - Uses a `CircleHitbox` and `HasGameRef<SpaceGame>`.
 

--- a/test/asteroid_minerals_test.dart
+++ b/test/asteroid_minerals_test.dart
@@ -12,7 +12,7 @@ import 'package:space_game/constants.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('damaging asteroid increases minerals', () async {
+  test('mining asteroid increases minerals', () async {
     SharedPreferences.setMockInitialValues({});
     await Flame.images.loadAll(Assets.asteroids);
     final storage = await StorageService.create();
@@ -24,6 +24,21 @@ void main() {
     final initial = game.minerals.value;
     asteroid.takeDamage(1);
     expect(game.minerals.value, initial + Constants.asteroidMinerals);
+    game.releaseAsteroid(asteroid);
+  });
+
+  test('bullet damage does not increase minerals', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll(Assets.asteroids);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+
+    final asteroid = game.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    await game.add(asteroid);
+    final initial = game.minerals.value;
+    asteroid.takeDamage(1, awardMinerals: false);
+    expect(game.minerals.value, initial);
     game.releaseAsteroid(asteroid);
   });
 }


### PR DESCRIPTION
## Summary
- avoid granting minerals when bullets damage asteroids
- document that only mining laser hits yield mineral pickups
- add tests for bullet and mining laser mineral behavior

## Testing
- `./scripts/markdownlint.sh README.md DESIGN.md PLAYTEST_CHECKLIST.md lib/components/asteroid.md lib/components/bullet.md lib/components/README.md`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fed988f08330a8edaac61a99abce