### PR TITLE
ci: ignore completed preview deploy runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,11 +34,18 @@ jobs:
               status: 'in_progress'
             });
             for (const run of runs.data.workflow_runs) {
-              await github.rest.actions.cancelWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: run.id
-              });
+              try {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id
+                });
+              } catch (error) {
+                // Ignore 409 errors for runs that have already completed
+                if (error.status !== 409) {
+                  throw error;
+                }
+              }
             }
       - name: Cache Flutter SDK
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- avoid failing deploy workflow when preview run already completed

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fdcf58cc8330b96ba932d96c0bf6