### PR TITLE
feat: add upgrades menu overlay

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -18,7 +18,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Minerals reset when restarting the game
 - [ ] HUD shows current score, minerals and high score during play
 - [ ] Collisions reduce player health; game over when health reaches zero
-- [ ] Game states transition: menu → playing → paused → game over → restart or menu
+- [ ] Game states transition: menu → playing → upgrades → paused → game over
+      → restart or menu
 - [ ] Player can choose a ship from the menu before starting
 - [ ] Enter starts or restarts from the menu or game over; `R` restarts at any time
 - [ ] Escape or `P` key pauses or resumes the game; `Q` returns to the menu from
@@ -28,6 +29,8 @@ _Update this file whenever a player-facing feature is added or changed._
       or via the `M` key
 - [ ] Game can be paused, resumed and return to menu (including from game over)
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
+- [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
+      closes it
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -21,8 +21,8 @@ Core game class and shared systems.
 - Configure the world, including the parallax starfield background and
   camera.
 - Spawn the player and register component spawners.
-- Maintain `GameState` values (`menu`, `playing`, `gameOver`) and swap
-  overlays accordingly.
+- Maintain `GameState` values (`menu`, `playing`, `upgrades`, `paused`,
+  `gameOver`) and swap overlays accordingly.
 - Schedule the update tick and other timers.
 - Route input from joystick, fire button or keyboard to the player component.
 

--- a/lib/game/game_state.dart
+++ b/lib/game/game_state.dart
@@ -1,2 +1,2 @@
 /// Simple game lifecycle states.
-enum GameState { menu, playing, paused, gameOver }
+enum GameState { menu, playing, upgrades, paused, gameOver }

--- a/lib/game/game_state.md
+++ b/lib/game/game_state.md
@@ -6,6 +6,7 @@ Enum describing high-level game phases.
 
 - `menu` – initial overlay before play.
 - `playing` – active gameplay loop.
+- `upgrades` – upgrade selection overlay while gameplay is paused.
 - `paused` – gameplay halted with a pause overlay to resume or return to menu.
 - `gameOver` – player died; show overlay with restart, menu and mute options.
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -25,6 +25,7 @@ import '../ui/hud_overlay.dart';
 import '../ui/menu_overlay.dart';
 import '../ui/pause_overlay.dart';
 import '../ui/help_overlay.dart';
+import '../ui/upgrades_overlay.dart';
 import 'game_state.dart';
 
 /// Root Flame game handling the core loop.
@@ -209,6 +210,25 @@ class SpaceGame extends FlameGame
     _enemyPool.add(enemy);
   }
 
+  /// Toggles the upgrades overlay and pauses/resumes the game.
+  void toggleUpgrades() {
+    if (overlays.isActive(UpgradesOverlay.id)) {
+      overlays.remove(UpgradesOverlay.id);
+      state = GameState.playing;
+      overlays.add(HudOverlay.id);
+      resumeEngine();
+    } else {
+      if (state != GameState.playing) {
+        return;
+      }
+      state = GameState.upgrades;
+      overlays
+        ..remove(HudOverlay.id)
+        ..add(UpgradesOverlay.id);
+      pauseEngine();
+    }
+  }
+
   /// Toggles the help overlay and pauses/resumes if entering from gameplay.
   void toggleHelp() {
     if (overlays.isActive(HelpOverlay.id)) {
@@ -380,7 +400,12 @@ class SpaceGame extends FlameGame
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     if (event is KeyDownEvent) {
-      if (overlays.isActive(HelpOverlay.id) &&
+      if (overlays.isActive(UpgradesOverlay.id) &&
+          (event.logicalKey == LogicalKeyboardKey.escape ||
+              event.logicalKey == LogicalKeyboardKey.keyU)) {
+        toggleUpgrades();
+        return KeyEventResult.handled;
+      } else if (overlays.isActive(HelpOverlay.id) &&
           (event.logicalKey == LogicalKeyboardKey.escape ||
               event.logicalKey == LogicalKeyboardKey.keyH)) {
         toggleHelp();
@@ -426,6 +451,9 @@ class SpaceGame extends FlameGame
         }
       } else if (event.logicalKey == LogicalKeyboardKey.keyH) {
         toggleHelp();
+        return KeyEventResult.handled;
+      } else if (event.logicalKey == LogicalKeyboardKey.keyU) {
+        toggleUpgrades();
         return KeyEventResult.handled;
       } else if (event.logicalKey == LogicalKeyboardKey.f1) {
         toggleDebug();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'ui/hud_overlay.dart';
 import 'ui/menu_overlay.dart';
 import 'ui/pause_overlay.dart';
 import 'ui/help_overlay.dart';
+import 'ui/upgrades_overlay.dart';
 import 'services/storage_service.dart';
 import 'services/audio_service.dart';
 
@@ -33,6 +34,8 @@ Future<void> main() async {
           GameOverOverlay.id: (context, SpaceGame game) =>
               GameOverOverlay(game: game),
           HelpOverlay.id: (context, SpaceGame game) => HelpOverlay(game: game),
+          UpgradesOverlay.id: (context, SpaceGame game) =>
+              UpgradesOverlay(game: game),
         },
       ),
     ),

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -14,17 +14,20 @@ Flutter overlays and HUD widgets.
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
 - [HudOverlay](hud_overlay.md) – shows score, high score, minerals and health with
-  auto-aim radius toggle, help, mute and pause buttons.
+    auto-aim radius toggle, help, upgrades, mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displayed when the game is paused with
   resume, restart, menu, help and mute buttons.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with
   restart (button or `Enter`/`R`), menu, help and mute options.
 - [HelpOverlay](help_overlay.md) – lists all controls; toggled with `H` and
   pauses gameplay when opened mid-run; `Esc` also closes it.
+- [UpgradesOverlay](upgrades_overlay.md) – placeholder screen for future ship
+  upgrades; opened with `U` and pauses gameplay.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `Q` returns to the menu from pause
   or game over and `Esc` also returns to the menu from game over; `H` shows or
-  hides the help overlay, and `Esc` also closes it when visible.
+  hides the help overlay, `U` opens upgrades, and `Esc` also closes overlays
+  when visible.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -71,6 +71,13 @@ class HudOverlay extends StatelessWidget {
                   ),
                   IconButton(
                     iconSize: iconSize,
+                    // Mirrors the U keyboard shortcut.
+                    icon:
+                        const Icon(Icons.upgrade, color: GameText.defaultColor),
+                    onPressed: game.toggleUpgrades,
+                  ),
+                  IconButton(
+                    iconSize: iconSize,
                     // Mirrors the H keyboard shortcut.
                     icon: const Icon(Icons.help_outline,
                         color: GameText.defaultColor),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -6,9 +6,10 @@ Heads-up display shown during play.
 
 - Shows current score, high score, minerals and health using `ValueNotifier`s from
   `SpaceGame`.
-- Provides auto-aim radius toggle, help, mute and pause buttons bound to
-  `SpaceGame` and `AudioService`.
+- Provides auto-aim radius toggle, upgrades, help, mute and pause buttons bound
+  to `SpaceGame` and `AudioService`.
 - Icon sizes scale with screen size for better usability on different devices.
+- `U` opens the upgrades overlay; `Esc` closes it.
 - `H` opens the help overlay showing controls; `Esc` closes it.
 - `M` key also toggles audio mute.
 - `Escape` or `P` keys also pause or resume.

--- a/lib/ui/upgrades_overlay.dart
+++ b/lib/ui/upgrades_overlay.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../game/space_game.dart';
+import 'game_text.dart';
+import 'responsive.dart';
+
+/// Overlay shown for choosing upgrades.
+class UpgradesOverlay extends StatelessWidget {
+  const UpgradesOverlay({super.key, required this.game});
+
+  /// Reference to the running game.
+  final SpaceGame game;
+
+  /// Overlay identifier used by [GameWidget].
+  static const String id = 'upgradesOverlay';
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shortestSide = constraints.biggest.shortestSide;
+        final spacing = shortestSide * 0.02;
+        final iconSize = responsiveIconSize(constraints);
+
+        return Container(
+          color: Colors.black54,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                GameText(
+                  'Upgrades',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                  maxLines: 1,
+                ),
+                SizedBox(height: spacing),
+                const GameText(
+                  'Coming soon',
+                  maxLines: 1,
+                ),
+                SizedBox(height: spacing),
+                ElevatedButton(
+                  // Mirrors the U and Escape keyboard shortcuts.
+                  onPressed: game.toggleUpgrades,
+                  child: const GameText(
+                    'Resume',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                SizedBox(height: spacing),
+                ValueListenableBuilder<bool>(
+                  valueListenable: game.audioService.muted,
+                  builder: (context, muted, _) => IconButton(
+                    iconSize: iconSize,
+                    icon: Icon(
+                      muted ? Icons.volume_off : Icons.volume_up,
+                      color: GameText.defaultColor,
+                    ),
+                    // Mirrors the M keyboard shortcut.
+                    onPressed: game.audioService.toggleMute,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/upgrades_overlay.md
+++ b/lib/ui/upgrades_overlay.md
@@ -1,0 +1,12 @@
+# UpgradesOverlay
+
+Placeholder overlay for future ship and ability upgrades.
+
+## Features
+
+- Displays a temporary "Coming soon" message.
+- Pauses gameplay when opened from a run and resumes when closed.
+- Activated via the `U` key or HUD button.
+- Dismiss with the on-screen resume button or by pressing `U` or `Esc`.
+
+See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/test/upgrades_overlay_test.dart
+++ b/test/upgrades_overlay_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/upgrades_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('toggleUpgrades pauses and resumes the game', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays
+      ..addEntry(UpgradesOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(HudOverlay.id, (_, __) => const SizedBox());
+
+    game.state = GameState.playing;
+    expect(game.overlays.isActive(UpgradesOverlay.id), isFalse);
+    expect(game.paused, isFalse);
+
+    game.toggleUpgrades();
+    expect(game.overlays.isActive(UpgradesOverlay.id), isTrue);
+    expect(game.paused, isTrue);
+
+    game.toggleUpgrades();
+    expect(game.overlays.isActive(UpgradesOverlay.id), isFalse);
+    expect(game.paused, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add placeholder Upgrades overlay and HUD button
- pause the game when opening upgrades menu
- document upgrades overlay and hotkey

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ff23806483308276585a78d7e5aa