### PR TITLE
refactor: unify overlay widgets

### DIFF
--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import 'game_text.dart';
-import 'responsive.dart';
+import 'overlay_widgets.dart';
 
 /// Overlay displayed when the player dies.
 class GameOverOverlay extends StatelessWidget {
@@ -16,89 +16,64 @@ class GameOverOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final shortestSide = constraints.biggest.shortestSide;
-        final spacing = shortestSide * 0.02;
-        final iconSize = responsiveIconSize(constraints);
-
-        return Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              GameText(
-                'Game Over',
-                style: Theme.of(context).textTheme.headlineMedium,
+    return OverlayLayout(
+      builder: (context, spacing, iconSize) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GameText(
+              'Game Over',
+              style: Theme.of(context).textTheme.headlineMedium,
+              maxLines: 1,
+            ),
+            SizedBox(height: spacing),
+            ValueListenableBuilder<int>(
+              valueListenable: game.score,
+              builder: (context, value, _) => GameText(
+                'Final Score: $value',
                 maxLines: 1,
+                style: const TextStyle(fontWeight: FontWeight.bold),
               ),
-              SizedBox(height: spacing),
-              ValueListenableBuilder<int>(
-                valueListenable: game.score,
-                builder: (context, value, _) => GameText(
-                  'Final Score: $value',
-                  maxLines: 1,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: spacing),
+            ValueListenableBuilder<int>(
+              valueListenable: game.highScore,
+              builder: (context, value, _) => GameText(
+                'High Score: $value',
+                maxLines: 1,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+            SizedBox(height: spacing),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ElevatedButton(
+                  // Mirrors the Enter and R keyboard shortcuts.
+                  onPressed: game.startGame,
+                  child: const GameText(
+                    'Restart',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
                 ),
-              ),
-              SizedBox(height: spacing),
-              ValueListenableBuilder<int>(
-                valueListenable: game.highScore,
-                builder: (context, value, _) => GameText(
-                  'High Score: $value',
-                  maxLines: 1,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+                SizedBox(width: spacing),
+                ElevatedButton(
+                  // Mirrors the Q and Escape keyboard shortcuts.
+                  onPressed: game.returnToMenu,
+                  child: const GameText(
+                    'Menu',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
                 ),
-              ),
-              SizedBox(height: spacing),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ElevatedButton(
-                    // Mirrors the Enter and R keyboard shortcuts.
-                    onPressed: game.startGame,
-                    child: const GameText(
-                      'Restart',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  SizedBox(width: spacing),
-                  ElevatedButton(
-                    // Mirrors the Q and Escape keyboard shortcuts.
-                    onPressed: game.returnToMenu,
-                    child: const GameText(
-                      'Menu',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  SizedBox(width: spacing),
-                  ElevatedButton(
-                    // Mirrors the H keyboard shortcut.
-                    onPressed: game.toggleHelp,
-                    child: const GameText(
-                      'Help',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  SizedBox(width: spacing),
-                  ValueListenableBuilder<bool>(
-                    valueListenable: game.audioService.muted,
-                    builder: (context, muted, _) => IconButton(
-                      iconSize: iconSize,
-                      icon: Icon(
-                        muted ? Icons.volume_off : Icons.volume_up,
-                        color: GameText.defaultColor,
-                      ),
-                      // Mirrors the M keyboard shortcut.
-                      onPressed: game.audioService.toggleMute,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
+                SizedBox(width: spacing),
+                HelpButton(game: game),
+                SizedBox(width: spacing),
+                MuteButton(game: game, iconSize: iconSize),
+              ],
+            ),
+          ],
         );
       },
     );

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import 'game_text.dart';
+import 'overlay_widgets.dart';
 
 /// Overlay listing available controls.
 class HelpOverlay extends StatelessWidget {
@@ -15,48 +16,41 @@ class HelpOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final shortestSide = constraints.biggest.shortestSide;
-        final spacing = shortestSide * 0.02;
-
-        return Container(
-          color: Colors.black54,
-          child: Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                GameText(
-                  'Controls',
-                  style: Theme.of(context).textTheme.headlineSmall,
-                  maxLines: 1,
-                ),
-                SizedBox(height: spacing),
-                const GameText(
-                  'Move: WASD / Arrow keys\n'
-                  'Shoot: Space\n'
-                  'Mute: M\n'
-                  'Toggle Debug: F1\n'
-                  'Auto-aim Radius: HUD button\n'
-                  'Pause/Resume: Esc or P\n'
-                  'Start/Restart: Enter\n'
-                  'Restart anytime: R\n'
-                  'Menu: Q (pause/game over), Esc (game over)\n'
-                  'Toggle Help: H or Esc',
-                  textAlign: TextAlign.center,
-                ),
-                SizedBox(height: spacing),
-                ElevatedButton(
-                  onPressed: game.toggleHelp,
-                  child: const GameText(
-                    'Close',
-                    maxLines: 1,
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-              ],
+    return OverlayLayout(
+      dimmed: true,
+      builder: (context, spacing, iconSize) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GameText(
+              'Controls',
+              style: Theme.of(context).textTheme.headlineSmall,
+              maxLines: 1,
             ),
-          ),
+            SizedBox(height: spacing),
+            const GameText(
+              'Move: WASD / Arrow keys\n'
+              'Shoot: Space\n'
+              'Mute: M\n'
+              'Toggle Debug: F1\n'
+              'Auto-aim Radius: HUD button\n'
+              'Pause/Resume: Esc or P\n'
+              'Start/Restart: Enter\n'
+              'Restart anytime: R\n'
+              'Menu: Q (pause/game over), Esc (game over)\n'
+              'Toggle Help: H or Esc',
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: spacing),
+            ElevatedButton(
+              onPressed: game.toggleHelp,
+              child: const GameText(
+                'Close',
+                maxLines: 1,
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ],
         );
       },
     );

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../game/space_game.dart';
 import 'game_text.dart';
 import 'responsive.dart';
+import 'overlay_widgets.dart';
 
 /// Simple heads-up display shown during play.
 class HudOverlay extends StatelessWidget {
@@ -69,32 +70,9 @@ class HudOverlay extends StatelessWidget {
                     icon: const Icon(Icons.gps_fixed, color: Colors.white),
                     onPressed: game.toggleAutoAimRadius,
                   ),
-                  IconButton(
-                    iconSize: iconSize,
-                    // Mirrors the U keyboard shortcut.
-                    icon:
-                        const Icon(Icons.upgrade, color: GameText.defaultColor),
-                    onPressed: game.toggleUpgrades,
-                  ),
-                  IconButton(
-                    iconSize: iconSize,
-                    // Mirrors the H keyboard shortcut.
-                    icon: const Icon(Icons.help_outline,
-                        color: GameText.defaultColor),
-                    onPressed: game.toggleHelp,
-                  ),
-                  ValueListenableBuilder<bool>(
-                    valueListenable: game.audioService.muted,
-                    builder: (context, muted, _) => IconButton(
-                      iconSize: iconSize,
-                      // Mirrors the `M` keyboard shortcut.
-                      icon: Icon(
-                        muted ? Icons.volume_off : Icons.volume_up,
-                        color: GameText.defaultColor,
-                      ),
-                      onPressed: game.audioService.toggleMute,
-                    ),
-                  ),
+                  UpgradeButton(game: game, iconSize: iconSize),
+                  HelpButton(game: game, iconSize: iconSize),
+                  MuteButton(game: game, iconSize: iconSize),
                   IconButton(
                     iconSize: iconSize,
                     // Mirrors the Escape and P keyboard shortcuts.

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../game/space_game.dart';
 import '../assets.dart';
 import 'game_text.dart';
-import 'responsive.dart';
+import 'overlay_widgets.dart';
 
 /// Start screen shown before gameplay begins.
 class MenuOverlay extends StatelessWidget {
@@ -17,108 +17,85 @@ class MenuOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final shortestSide = constraints.biggest.shortestSide;
-        final spacing = shortestSide * 0.02;
-        final iconSize = responsiveIconSize(constraints);
-
-        return Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              GameText(
-                'Space Miner',
-                style: Theme.of(context).textTheme.headlineMedium,
+    return OverlayLayout(
+      builder: (context, spacing, iconSize) {
+        final shortestSide = spacing / 0.02;
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GameText(
+              'Space Miner',
+              style: Theme.of(context).textTheme.headlineMedium,
+              maxLines: 1,
+            ),
+            SizedBox(height: spacing),
+            ValueListenableBuilder<int>(
+              valueListenable: game.highScore,
+              builder: (context, value, _) => value > 0
+                  ? GameText(
+                      'High Score: $value',
+                      maxLines: 1,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+            SizedBox(height: spacing),
+            TextButton(
+              onPressed: () => game.resetHighScore(),
+              child: const GameText(
+                'Reset High Score',
                 maxLines: 1,
+                style: TextStyle(fontWeight: FontWeight.bold),
               ),
-              SizedBox(height: spacing),
-              ValueListenableBuilder<int>(
-                valueListenable: game.highScore,
-                builder: (context, value, _) => value > 0
-                    ? GameText(
-                        'High Score: $value',
-                        maxLines: 1,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      )
-                    : const SizedBox.shrink(),
-              ),
-              SizedBox(height: spacing),
-              TextButton(
-                onPressed: () => game.resetHighScore(),
-                child: const GameText(
-                  'Reset High Score',
-                  maxLines: 1,
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                ),
-              ),
-              SizedBox(height: spacing),
-              ValueListenableBuilder<int>(
-                valueListenable: game.selectedPlayerIndex,
-                builder: (context, selected, _) => Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (var i = 0; i < Assets.players.length; i++)
-                      GestureDetector(
-                        onTap: () => game.selectPlayer(i),
-                        child: Container(
-                          margin: EdgeInsets.all(spacing),
-                          padding: EdgeInsets.all(spacing / 2),
-                          decoration: BoxDecoration(
-                            border: Border.all(
-                              color: selected == i
-                                  ? GameText.defaultColor
-                                  : Colors.transparent,
-                              width: 2,
-                            ),
-                          ),
-                          child: Image.asset(
-                            'assets/images/${Assets.players[i]}',
-                            width: shortestSide * 0.1,
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-              SizedBox(height: spacing),
-              Row(
+            ),
+            SizedBox(height: spacing),
+            ValueListenableBuilder<int>(
+              valueListenable: game.selectedPlayerIndex,
+              builder: (context, selected, _) => Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  ElevatedButton(
-                    onPressed: game.startGame,
-                    child: const GameText(
-                      'Start',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  SizedBox(width: spacing),
-                  ElevatedButton(
-                    // Mirrors the H keyboard shortcut.
-                    onPressed: game.toggleHelp,
-                    child: const GameText(
-                      'Help',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  SizedBox(width: spacing),
-                  ValueListenableBuilder<bool>(
-                    valueListenable: game.audioService.muted,
-                    builder: (context, muted, _) => IconButton(
-                      iconSize: iconSize,
-                      icon: Icon(
-                        muted ? Icons.volume_off : Icons.volume_up,
-                        color: GameText.defaultColor,
+                  for (var i = 0; i < Assets.players.length; i++)
+                    GestureDetector(
+                      onTap: () => game.selectPlayer(i),
+                      child: Container(
+                        margin: EdgeInsets.all(spacing),
+                        padding: EdgeInsets.all(spacing / 2),
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: selected == i
+                                ? GameText.defaultColor
+                                : Colors.transparent,
+                            width: 2,
+                          ),
+                        ),
+                        child: Image.asset(
+                          'assets/images/${Assets.players[i]}',
+                          width: shortestSide * 0.1,
+                        ),
                       ),
-                      onPressed: game.audioService.toggleMute,
                     ),
-                  ),
                 ],
               ),
-            ],
-          ),
+            ),
+            SizedBox(height: spacing),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ElevatedButton(
+                  onPressed: game.startGame,
+                  child: const GameText(
+                    'Start',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                SizedBox(width: spacing),
+                HelpButton(game: game),
+                SizedBox(width: spacing),
+                MuteButton(game: game, iconSize: iconSize),
+              ],
+            ),
+          ],
         );
       },
     );

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+import '../game/space_game.dart';
+import 'game_text.dart';
+import 'responsive.dart';
+
+/// Signature for builders used with [OverlayLayout].
+typedef OverlayChildBuilder = Widget Function(
+    BuildContext context, double spacing, double iconSize);
+
+/// Provides a common responsive layout for overlays.
+///
+/// Calculates `spacing` and `iconSize` based on screen size and optionally
+/// adds a dimmed background. The [builder] creates the actual overlay content.
+class OverlayLayout extends StatelessWidget {
+  const OverlayLayout({
+    super.key,
+    required this.builder,
+    this.dimmed = false,
+  });
+
+  /// Builds the overlay content given responsive values.
+  final OverlayChildBuilder builder;
+
+  /// Whether to draw a translucent background behind the overlay.
+  final bool dimmed;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shortestSide = constraints.biggest.shortestSide;
+        final spacing = shortestSide * 0.02;
+        final iconSize = responsiveIconSize(constraints);
+
+        Widget child = Center(child: builder(context, spacing, iconSize));
+        if (dimmed) {
+          child = Container(color: Colors.black54, child: child);
+        }
+        return child;
+      },
+    );
+  }
+}
+
+/// Icon button that toggles the game's mute state.
+class MuteButton extends StatelessWidget {
+  const MuteButton({super.key, required this.game, required this.iconSize});
+
+  final SpaceGame game;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: game.audioService.muted,
+      builder: (context, muted, _) => IconButton(
+        iconSize: iconSize,
+        icon: Icon(
+          muted ? Icons.volume_off : Icons.volume_up,
+          color: GameText.defaultColor,
+        ),
+        onPressed: game.audioService.toggleMute,
+      ),
+    );
+  }
+}
+
+/// Button that opens the help overlay.
+///
+/// Uses an icon when [iconSize] is provided, otherwise renders as an
+/// [ElevatedButton] with text.
+class HelpButton extends StatelessWidget {
+  const HelpButton({super.key, required this.game, this.iconSize});
+
+  final SpaceGame game;
+  final double? iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    if (iconSize != null) {
+      return IconButton(
+        iconSize: iconSize,
+        icon: const Icon(Icons.help_outline, color: GameText.defaultColor),
+        onPressed: game.toggleHelp,
+      );
+    }
+    return ElevatedButton(
+      onPressed: game.toggleHelp,
+      child: const GameText(
+        'Help',
+        maxLines: 1,
+        style: TextStyle(fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+}
+
+/// Icon button that opens the upgrades overlay.
+class UpgradeButton extends StatelessWidget {
+  const UpgradeButton({super.key, required this.game, required this.iconSize});
+
+  final SpaceGame game;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      iconSize: iconSize,
+      icon: const Icon(Icons.upgrade, color: GameText.defaultColor),
+      onPressed: game.toggleUpgrades,
+    );
+  }
+}

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import 'game_text.dart';
-import 'responsive.dart';
+import 'overlay_widgets.dart';
 
 /// Overlay shown when the game is paused.
 class PauseOverlay extends StatelessWidget {
@@ -16,81 +16,56 @@ class PauseOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final shortestSide = constraints.biggest.shortestSide;
-        final spacing = shortestSide * 0.02;
-        final iconSize = responsiveIconSize(constraints);
-
-        return Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              GameText(
-                'Paused',
-                style: Theme.of(context).textTheme.headlineMedium,
-                maxLines: 1,
-              ),
-              SizedBox(height: spacing),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ElevatedButton(
-                    // Mirrors the Escape and P keyboard shortcuts.
-                    onPressed: game.resumeGame,
-                    child: const GameText(
-                      'Resume',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
+    return OverlayLayout(
+      builder: (context, spacing, iconSize) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GameText(
+              'Paused',
+              style: Theme.of(context).textTheme.headlineMedium,
+              maxLines: 1,
+            ),
+            SizedBox(height: spacing),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ElevatedButton(
+                  // Mirrors the Escape and P keyboard shortcuts.
+                  onPressed: game.resumeGame,
+                  child: const GameText(
+                    'Resume',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
                   ),
-                  SizedBox(width: spacing),
-                  ElevatedButton(
-                    // Mirrors the R keyboard shortcut.
-                    onPressed: game.startGame,
-                    child: const GameText(
-                      'Restart',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
+                ),
+                SizedBox(width: spacing),
+                ElevatedButton(
+                  // Mirrors the R keyboard shortcut.
+                  onPressed: game.startGame,
+                  child: const GameText(
+                    'Restart',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
                   ),
-                  SizedBox(width: spacing),
-                  ElevatedButton(
-                    // Mirrors the Q keyboard shortcut.
-                    onPressed: game.returnToMenu,
-                    child: const GameText(
-                      'Menu',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
+                ),
+                SizedBox(width: spacing),
+                ElevatedButton(
+                  // Mirrors the Q keyboard shortcut.
+                  onPressed: game.returnToMenu,
+                  child: const GameText(
+                    'Menu',
+                    maxLines: 1,
+                    style: TextStyle(fontWeight: FontWeight.bold),
                   ),
-                  SizedBox(width: spacing),
-                  ElevatedButton(
-                    // Mirrors the H keyboard shortcut.
-                    onPressed: game.toggleHelp,
-                    child: const GameText(
-                      'Help',
-                      maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  SizedBox(width: spacing),
-                  ValueListenableBuilder<bool>(
-                    valueListenable: game.audioService.muted,
-                    builder: (context, muted, _) => IconButton(
-                      iconSize: iconSize,
-                      icon: Icon(
-                        muted ? Icons.volume_off : Icons.volume_up,
-                        color: GameText.defaultColor,
-                      ),
-                      // Mirrors the M keyboard shortcut.
-                      onPressed: game.audioService.toggleMute,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
+                ),
+                SizedBox(width: spacing),
+                HelpButton(game: game),
+                SizedBox(width: spacing),
+                MuteButton(game: game, iconSize: iconSize),
+              ],
+            ),
+          ],
         );
       },
     );

--- a/lib/ui/upgrades_overlay.dart
+++ b/lib/ui/upgrades_overlay.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import 'game_text.dart';
-import 'responsive.dart';
+import 'overlay_widgets.dart';
 
 /// Overlay shown for choosing upgrades.
 class UpgradesOverlay extends StatelessWidget {
@@ -16,54 +16,35 @@ class UpgradesOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final shortestSide = constraints.biggest.shortestSide;
-        final spacing = shortestSide * 0.02;
-        final iconSize = responsiveIconSize(constraints);
-
-        return Container(
-          color: Colors.black54,
-          child: Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                GameText(
-                  'Upgrades',
-                  style: Theme.of(context).textTheme.headlineSmall,
-                  maxLines: 1,
-                ),
-                SizedBox(height: spacing),
-                const GameText(
-                  'Coming soon',
-                  maxLines: 1,
-                ),
-                SizedBox(height: spacing),
-                ElevatedButton(
-                  // Mirrors the U and Escape keyboard shortcuts.
-                  onPressed: game.toggleUpgrades,
-                  child: const GameText(
-                    'Resume',
-                    maxLines: 1,
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-                SizedBox(height: spacing),
-                ValueListenableBuilder<bool>(
-                  valueListenable: game.audioService.muted,
-                  builder: (context, muted, _) => IconButton(
-                    iconSize: iconSize,
-                    icon: Icon(
-                      muted ? Icons.volume_off : Icons.volume_up,
-                      color: GameText.defaultColor,
-                    ),
-                    // Mirrors the M keyboard shortcut.
-                    onPressed: game.audioService.toggleMute,
-                  ),
-                ),
-              ],
+    return OverlayLayout(
+      dimmed: true,
+      builder: (context, spacing, iconSize) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GameText(
+              'Upgrades',
+              style: Theme.of(context).textTheme.headlineSmall,
+              maxLines: 1,
             ),
-          ),
+            SizedBox(height: spacing),
+            const GameText(
+              'Coming soon',
+              maxLines: 1,
+            ),
+            SizedBox(height: spacing),
+            ElevatedButton(
+              // Mirrors the U and Escape keyboard shortcuts.
+              onPressed: game.toggleUpgrades,
+              child: const GameText(
+                'Resume',
+                maxLines: 1,
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+            SizedBox(height: spacing),
+            MuteButton(game: game, iconSize: iconSize),
+          ],
         );
       },
     );


### PR DESCRIPTION
## Summary
- add reusable overlay layout, mute, help, and upgrade buttons
- refactor game overlays to use shared components

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b39c2e877c83309265bf2dcbdd6dfd