### PR TITLE
Use Flame ParallaxComponent for starfield background

### DIFF
--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -27,8 +27,8 @@ Gameplay entities and reusable pieces.
   grant minerals.
 - [MiningLaserComponent](mining_laser.md) – auto-targets and mines nearby
   asteroids with a widening pulse beam.
-- [StarfieldComponent](starfield.md) – procedural three-layer background with
-  parallax motion.
+- [Starfield](starfield.md) – parallax background built with Flame's
+  `ParallaxComponent`.
 
 ## Planned Components
 

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -1,11 +1,10 @@
-# StarfieldComponent
+# Starfield
 
-Procedurally renders a simple three-layer starfield behind the game.
+Background starfield using Flame's `ParallaxComponent`.
 
-- Generates stars on the fly, so no image assets are required.
-- Each layer moves at a different speed defined in `constants.dart` to create a
-  basic parallax effect.
-- Stars vary in brightness for a subtle depth cue.
-- Regenerates the star positions whenever the game viewport changes size.
-- Added to `SpaceGame` with a negative priority so it always draws beneath
+- Generates three random star layers with speeds from `constants.dart` for
+  parallax depth.
+- Stars are rendered once into images and the parallax system manages scroll
+  and wrapping, so no per-frame star updates are needed.
+- Added to `SpaceGame` with a negative priority so it always renders beneath
   gameplay components.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -90,10 +90,10 @@ class SpaceGame extends FlameGame
 
   /// Tracks whether the game was playing when the help overlay opened.
   bool _helpWasPlaying = false;
+  ParallaxComponent? _starfield;
 
   @override
   Future<void> onLoad() async {
-    add(StarfieldComponent());
     if (kDebugMode) {
       _fpsText = FpsTextComponent(position: Vector2.all(10));
       await add(_fpsText!);
@@ -392,6 +392,17 @@ class SpaceGame extends FlameGame
   /// Toggles rendering of the player's auto-aim radius.
   void toggleAutoAimRadius() {
     player.toggleAutoAimRadius();
+  }
+
+  @override
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    if (_starfield == null && !size.isZero()) {
+      createStarfieldParallax(size).then((component) {
+        _starfield = component;
+        add(component);
+      });
+    }
   }
 
   @override

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -15,7 +15,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 ## Design Notes
 
-- A procedural `StarfieldComponent` supplies the parallax background.
+- A parallax starfield uses Flame's `ParallaxComponent` for the background.
 - Centralise audio assets in `assets.dart` and play them through a small
   audio service.
 - Persist the high score with `shared_preferences` using a lightweight storage


### PR DESCRIPTION
## Summary
- Replace custom starfield component with Flame's `ParallaxComponent`
- Generate three parallax layers with varying speeds for depth
- Document starfield parallax usage and update milestone notes

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b39c29aca48330a6849a2530be15f2