### PR TITLE
Optimize entity targeting with cached lists

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -51,6 +51,12 @@ class AsteroidComponent extends SpriteComponent
   }
 
   @override
+  void onMount() {
+    super.onMount();
+    game.asteroids.add(this);
+  }
+
+  @override
   void update(double dt) {
     super.update(dt);
     position += _velocity * dt;
@@ -78,6 +84,7 @@ class AsteroidComponent extends SpriteComponent
   @override
   void onRemove() {
     super.onRemove();
+    game.asteroids.remove(this);
     game.releaseAsteroid(this);
   }
 

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -46,6 +46,12 @@ class EnemyComponent extends SpriteComponent
   }
 
   @override
+  void onMount() {
+    super.onMount();
+    game.enemies.add(this);
+  }
+
+  @override
   void update(double dt) {
     super.update(dt);
     final direction = (game.player.position - position).normalized();
@@ -75,6 +81,7 @@ class EnemyComponent extends SpriteComponent
   @override
   void onRemove() {
     super.onRemove();
+    game.enemies.remove(this);
     game.releaseEnemy(this);
   }
 

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -60,7 +60,10 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
   AsteroidComponent? _findClosestAsteroid() {
     AsteroidComponent? closest;
     var closestDistance = Constants.playerMiningRange;
-    final asteroids = game.children.whereType<AsteroidComponent>().toList();
+    Iterable<AsteroidComponent> asteroids = game.asteroids;
+    if (asteroids.isEmpty) {
+      asteroids = game.children.whereType<AsteroidComponent>();
+    }
     for (final asteroid in asteroids) {
       final distance = asteroid.position.distanceTo(player.position);
       if (distance <= closestDistance) {

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -195,7 +195,10 @@ class PlayerComponent extends SpriteComponent
   EnemyComponent? _findClosestEnemy() {
     EnemyComponent? closest;
     var closestDistance = Constants.playerAutoAimRange;
-    final enemies = game.children.whereType<EnemyComponent>().toList();
+    Iterable<EnemyComponent> enemies = game.enemies;
+    if (enemies.isEmpty) {
+      enemies = game.children.whereType<EnemyComponent>();
+    }
     for (final enemy in enemies) {
       final distance = enemy.position.distanceTo(position);
       if (distance <= closestDistance) {

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -88,6 +88,14 @@ class SpaceGame extends FlameGame
   /// Pool of reusable enemies.
   final List<EnemyComponent> _enemyPool = [];
 
+  /// Active enemies tracked for quick lookup.
+  final List<EnemyComponent> enemies = [];
+
+  /// Active asteroids tracked for quick lookup.
+  final List<AsteroidComponent> asteroids = [];
+
+  /// TODO: Investigate spatial partitioning (e.g., quad trees) if counts grow.
+
   /// Tracks whether the game was playing when the help overlay opened.
   bool _helpWasPlaying = false;
 
@@ -318,10 +326,12 @@ class SpaceGame extends FlameGame
     score.value = 0;
     minerals.value = 0;
     health.value = Constants.playerMaxHealth;
-    children.whereType<EnemyComponent>().forEach((e) => e.removeFromParent());
-    children.whereType<AsteroidComponent>().forEach(
-          (a) => a.removeFromParent(),
-        );
+    for (final enemy in enemies.toList()) {
+      enemy.removeFromParent();
+    }
+    for (final asteroid in asteroids.toList()) {
+      asteroid.removeFromParent();
+    }
     children.whereType<BulletComponent>().forEach((b) => b.removeFromParent());
     if (!player.isMounted) {
       add(player);


### PR DESCRIPTION
## Summary
- maintain cached enemy and asteroid lists on the game
- track enemies and asteroids in onMount/onRemove hooks
- target mining laser and auto-aim using cached lists

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b39c2368188330aea63f0668a5f3ff