### PR TITLE
Fix analysis warnings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -80,7 +80,7 @@ tree spanning weapons and ship systems.
 ## Components
 
 - Player, enemy, asteroid and bullet components live under `lib/components/`.
-- Components mix in `HasGameRef<SpaceGame>` when they need game context.
+- Components mix in `HasGameReference<SpaceGame>` when they need game context.
 - Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and
   `HasCollisionDetection`.
 - An `EnemySpawner` system releases groups of enemies at timed intervals.

--- a/PLAN.md
+++ b/PLAN.md
@@ -132,7 +132,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   fonts so gameplay code never references file paths directly
 - Favor small composable components over inheritance
 - Components that need to access the game should mix in
-  `HasGameRef<SpaceGame>` instead of using global singletons
+  `HasGameReference<SpaceGame>` instead of using global singletons
 - Keep Flutter UI widgets separate from game state updates
 - If saving is needed later, add IDs and JSON‑serializable state
 - Fixed logical resolution scaled to device for consistent gameplay

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -3,7 +3,7 @@
 Gameplay entities and reusable pieces.
 
 - Includes player, enemy, asteroid and bullet components.
-- Each extends a Flame component and mixes in `HasGameRef<SpaceGame>`
+- Each extends a Flame component and mixes in `HasGameReference<SpaceGame>`
   when it needs game context.
 - Use simple hit boxes like `CircleHitbox` or `RectangleHitbox` with
   `HasCollisionDetection` on the game.

--- a/lib/components/asteroid.md
+++ b/lib/components/asteroid.md
@@ -11,6 +11,6 @@ Neutral obstacle that can be mined for score and minerals.
 - Starts with 4–6 health and grants `Constants.asteroidScore` points and
   `Constants.asteroidMinerals` minerals per mining laser hit.
 - Uses a small object pool to reuse instances.
-- Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
+- Uses `CircleHitbox` and `HasGameReference<SpaceGame>`.
 
 See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/asteroid_spawner.dart
+++ b/lib/components/asteroid_spawner.dart
@@ -6,7 +6,7 @@ import '../constants.dart';
 import '../game/space_game.dart';
 
 /// Spawns asteroids at timed intervals when started.
-class AsteroidSpawner extends Component with HasGameRef<SpaceGame> {
+class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
   AsteroidSpawner();
 
   final Random _random = Random();
@@ -29,10 +29,10 @@ class AsteroidSpawner extends Component with HasGameRef<SpaceGame> {
   }
 
   void _spawn() {
-    final x = _random.nextDouble() * gameRef.size.x;
+    final x = _random.nextDouble() * game.size.x;
     final vx = (_random.nextDouble() - 0.5) * Constants.asteroidSpeed;
-    gameRef.add(
-      gameRef.acquireAsteroid(
+    game.add(
+      game.acquireAsteroid(
         Vector2(x, -Constants.asteroidSize * Constants.asteroidScale),
         Vector2(vx, Constants.asteroidSpeed),
       ),

--- a/lib/components/bullet.md
+++ b/lib/components/bullet.md
@@ -11,6 +11,6 @@ Short-lived projectile fired by the player.
 - Uses sprite from `assets.dart` and speed from `constants.dart`.
 - Awards score on asteroid hits using values from `constants.dart`.
 - Reused through a simple object pool managed by `SpaceGame`.
-- Uses a `CircleHitbox` and `HasGameRef<SpaceGame>`.
+- Uses a `CircleHitbox` and `HasGameReference<SpaceGame>`.
 
 See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/enemy.md
+++ b/lib/components/enemy.md
@@ -10,7 +10,7 @@ Basic foe that drifts toward the player.
 - Sprites resolved through `assets.dart`; speeds and hit points from `constants.dart`.
 - Awards score when destroyed, using `Constants.enemyScore`.
 - Uses `CircleHitbox` or `RectangleHitbox` depending on art.
-- Mixes in `HasGameRef<SpaceGame>` for access to global state.
+- Mixes in `HasGameReference<SpaceGame>` for access to global state.
 - Uses a small object pool to reuse instances.
 
 See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -6,7 +6,7 @@ import '../constants.dart';
 import '../game/space_game.dart';
 
 /// Spawns enemies at timed intervals when started.
-class EnemySpawner extends Component with HasGameRef<SpaceGame> {
+class EnemySpawner extends Component with HasGameReference<SpaceGame> {
   EnemySpawner();
 
   final Random _random = Random();
@@ -31,9 +31,9 @@ class EnemySpawner extends Component with HasGameRef<SpaceGame> {
   }
 
   void _spawn() {
-    final x = _random.nextDouble() * gameRef.size.x;
-    gameRef.add(
-      gameRef.acquireEnemy(
+    final x = _random.nextDouble() * game.size.x;
+    game.add(
+      game.acquireEnemy(
         Vector2(x, -Constants.enemySize * Constants.enemyScale),
       ),
     );

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -10,6 +10,6 @@ Controllable ship for the player.
 - Colliding with enemies or asteroids reduces health via `SpaceGame.hitPlayer`.
 - When stationary, periodically rotates to face the nearest enemy within range.
 - Pulls sprites from `assets.dart` and tuning values from `constants.dart`.
-- Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.
+- Uses `CircleHitbox` and `HasGameReference<SpaceGame>`.
 
 See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/game/key_dispatcher.dart
+++ b/lib/game/key_dispatcher.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/input.dart';
 import 'package:flutter/services.dart';
 
 /// Maps keyboard keys to callbacks and tracks pressed state.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -12,7 +12,6 @@ import '../components/enemy.dart';
 import '../components/bullet.dart';
 import '../assets.dart';
 import '../components/player.dart';
-import '../components/starfield.dart';
 import '../components/mining_laser.dart';
 import '../components/enemy_spawner.dart';
 import '../components/asteroid_spawner.dart';
@@ -20,7 +19,6 @@ import '../game/key_dispatcher.dart';
 import '../game/game_state_machine.dart';
 import '../services/score_service.dart';
 import '../services/overlay_service.dart';
-import '../constants.dart';
 import '../services/storage_service.dart';
 import '../services/audio_service.dart';
 import '../ui/help_overlay.dart';
@@ -92,7 +90,6 @@ class SpaceGame extends FlameGame
 
   /// Tracks whether the game was playing when the help overlay opened.
   bool _helpWasPlaying = false;
-  ParallaxComponent? _starfield;
 
   @override
   Future<void> onLoad() async {

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -17,7 +17,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 - Use Flame's `JoystickComponent` and `ButtonComponent` for touch controls.
 - Keyboard input uses `KeyboardListenerComponent`.
-- Components mix in `HasGameRef<SpaceGame>` and use simple hit boxes.
+- Components mix in `HasGameReference<SpaceGame>` and use simple hit boxes.
 - Timer-based spawners generate enemies and asteroids.
 - Consider small object pools for bullets, asteroids and enemies to limit garbage.
 


### PR DESCRIPTION
## Summary
- replace deprecated `HasGameRef` mixins in spawners
- remove unused imports and fields
- update docs to reference `HasGameReference`

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a5a62f948330bc2680131e6c780e