### PR TITLE
Flash player red when taking damage

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -18,6 +18,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Minerals reset when restarting the game
 - [ ] HUD shows current score, minerals and high score during play
 - [ ] Collisions reduce player health; game over when health reaches zero
+- [ ] Player ship flashes red when taking damage
 - [ ] Game states transition: menu → playing → upgrades → paused → game over
       → restart or menu
 - [ ] Player can choose a ship from the menu before starting

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -53,6 +53,12 @@ class PlayerComponent extends SpriteComponent
     ..color = const Color(0x66ffffff)
     ..style = PaintingStyle.stroke;
 
+  static const Color _normalColor = Color(0xffffffff);
+  static const Color _damageColor = Color(0xffff0000);
+
+  /// Remaining time for the damage flash effect.
+  double _damageFlashTime = 0;
+
   /// Sets the current sprite for the player.
   void setSprite(String path) {
     _spritePath = path;
@@ -73,6 +79,12 @@ class PlayerComponent extends SpriteComponent
     showAutoAimRadius = !showAutoAimRadius;
   }
 
+  /// Triggers a short red flash to indicate damage taken.
+  void flashDamage() {
+    _damageFlashTime = Constants.playerDamageFlashDuration;
+    paint.color = _damageColor;
+  }
+
   /// Fires a bullet from the player's current position.
   void shoot() {
     if (_shootCooldown > 0) {
@@ -89,6 +101,7 @@ class PlayerComponent extends SpriteComponent
   @override
   Future<void> onLoad() async {
     setSprite(_spritePath);
+    paint.color = _normalColor;
     add(CircleHitbox());
     keyDispatcher.register(LogicalKeyboardKey.space, onDown: shoot);
   }
@@ -102,6 +115,12 @@ class PlayerComponent extends SpriteComponent
   @override
   void update(double dt) {
     super.update(dt);
+    if (_damageFlashTime > 0) {
+      _damageFlashTime -= dt;
+      if (_damageFlashTime <= 0) {
+        paint.color = _normalColor;
+      }
+    }
     _keyboardDirection
       ..setZero()
       ..x += (keyDispatcher.isPressed(LogicalKeyboardKey.keyA) ||

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -7,7 +7,8 @@ Controllable ship for the player.
 - Moves via on-screen joystick or WASD keys.
 - Fires `BulletComponent`s with a short cooldown when the shoot button or space
   bar is pressed, in the direction the ship is facing.
-- Colliding with enemies or asteroids reduces health via `SpaceGame.hitPlayer`.
+- Colliding with enemies or asteroids reduces health via `SpaceGame.hitPlayer`
+  and briefly flashes the ship red.
 - When stationary, periodically rotates to face the nearest enemy within range.
 - Pulls sprites from `assets.dart` and tuning values from `constants.dart`.
 - Uses `CircleHitbox` and `HasGameRef<SpaceGame>`.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -30,6 +30,9 @@ class Constants {
   /// Starting health for the player.
   static const int playerMaxHealth = 3;
 
+  /// Seconds that the player sprite flashes red after taking damage.
+  static const double playerDamageFlashDuration = 0.2;
+
   /// Bullet travel speed in pixels per second.
   static const double bulletSpeed = 400;
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -237,6 +237,7 @@ class SpaceGame extends FlameGame
     if (stateMachine.state != GameState.playing) {
       return;
     }
+    player.flashDamage();
     if (scoreService.hitPlayer()) {
       stateMachine.gameOver();
     }

--- a/test/player_damage_flash_test.dart
+++ b/test/player_damage_flash_test.dart
@@ -1,0 +1,70 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/game/game_state_machine.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/overlay_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: 'players/player1.png');
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    overlayService = OverlayService(this);
+    stateMachine = GameStateMachine(
+      overlays: overlayService,
+      onStart: () {},
+      onPause: () {},
+      onResume: () {},
+      onGameOver: () {},
+      onMenu: () {},
+    )..state = GameState.playing;
+    final keyDispatcher = KeyDispatcher();
+    add(keyDispatcher);
+    joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    add(player);
+    onGameResize(Vector2.all(Constants.playerSize * Constants.playerScale * 2));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('player flashes red when hit', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+
+    expect(game.player.paint.color, const Color(0xffffffff));
+
+    game.hitPlayer();
+    expect(game.player.paint.color, const Color(0xffff0000));
+
+    game.player.update(Constants.playerDamageFlashDuration);
+    expect(game.player.paint.color, const Color(0xffffffff));
+  });
+}


### PR DESCRIPTION
## Summary
- add constant for damage flash duration
- flash player sprite red and reset after delay
- test the damage flash behavior and document it in player docs and checklist

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a6f7f97083308daaa20d0b828f36