### PR TITLE
Support scrolling world and world-sized spawning

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -60,9 +60,9 @@ class AsteroidComponent extends SpriteComponent
   void update(double dt) {
     super.update(dt);
     position += _velocity * dt;
-    if (position.y > game.size.y + size.y ||
+    if (position.y > Constants.worldSize.y + size.y ||
         position.x < -size.x ||
-        position.x > game.size.x + size.x) {
+        position.x > Constants.worldSize.x + size.x) {
       removeFromParent();
     }
   }

--- a/lib/components/asteroid_spawner.dart
+++ b/lib/components/asteroid_spawner.dart
@@ -29,7 +29,7 @@ class AsteroidSpawner extends Component with HasGameRef<SpaceGame> {
   }
 
   void _spawn() {
-    final x = _random.nextDouble() * gameRef.size.x;
+    final x = _random.nextDouble() * Constants.worldSize.x;
     final vx = (_random.nextDouble() - 0.5) * Constants.asteroidSpeed;
     gameRef.add(
       gameRef.acquireAsteroid(

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -40,9 +40,9 @@ class BulletComponent extends SpriteComponent
     super.update(dt);
     position += _direction * Constants.bulletSpeed * dt;
     if (position.y < -size.y ||
-        position.y > game.size.y + size.y ||
+        position.y > Constants.worldSize.y + size.y ||
         position.x < -size.x ||
-        position.x > game.size.x + size.x) {
+        position.x > Constants.worldSize.x + size.x) {
       removeFromParent();
     }
   }

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -57,9 +57,9 @@ class EnemyComponent extends SpriteComponent
     final direction = (game.player.position - position).normalized();
     angle = math.atan2(direction.y, direction.x) + math.pi / 2;
     position += direction * Constants.enemySpeed * dt;
-    if (position.y > game.size.y + size.y ||
+    if (position.y > Constants.worldSize.y + size.y ||
         position.x < -size.x ||
-        position.x > game.size.x + size.x) {
+        position.x > Constants.worldSize.x + size.x) {
       removeFromParent();
     }
   }

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -31,7 +31,7 @@ class EnemySpawner extends Component with HasGameRef<SpaceGame> {
   }
 
   void _spawn() {
-    final x = _random.nextDouble() * gameRef.size.x;
+    final x = _random.nextDouble() * Constants.worldSize.x;
     gameRef.add(
       gameRef.acquireEnemy(
         Vector2(x, -Constants.enemySize * Constants.enemyScale),

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -61,7 +61,7 @@ class PlayerComponent extends SpriteComponent
 
   /// Resets the player to its default orientation and clears input state.
   void reset() {
-    position = game.size / 2;
+    position = Constants.worldSize / 2;
     angle = 0;
     _targetAngle = 0;
     _shootCooldown = 0;
@@ -96,7 +96,6 @@ class PlayerComponent extends SpriteComponent
   @override
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
-    position = size / 2;
   }
 
   @override
@@ -129,9 +128,10 @@ class PlayerComponent extends SpriteComponent
     if (!input.isZero()) {
       input = input.normalized();
       position += input * Constants.playerSpeed * dt;
+      final halfSize = Vector2.all(size.x / 2);
       position.clamp(
-        Vector2.all(size.x / 2),
-        game.size - Vector2.all(size.x / 2),
+        halfSize,
+        Constants.worldSize - halfSize,
       );
       _targetAngle = math.atan2(input.y, input.x) + math.pi / 2;
       _autoAimTimer = 0;

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,5 +1,10 @@
+import 'package:flame/components.dart';
+
 /// Centralised tunable values for the game.
 class Constants {
+  /// Dimensions of the playable world in pixels.
+  static final Vector2 worldSize = Vector2(2000, 2000);
+
   /// Player movement speed in pixels per second.
   static const double playerSpeed = 200;
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
+import 'package:flame/experimental.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart' show EdgeInsets;
 import 'package:flutter/services.dart' show LogicalKeyboardKey;
@@ -117,13 +118,27 @@ class SpaceGame extends FlameGame
     );
     add(joystick);
 
+    _starfield = await createStarfieldParallax(Constants.worldSize);
+    add(_starfield!);
+
     player = PlayerComponent(
       joystick: joystick,
       keyDispatcher: keyDispatcher,
       spritePath: selectedPlayerSprite,
     );
+    player.position = Constants.worldSize / 2;
     add(player);
-    camera.follow(player);
+    camera
+      ..setBounds(
+        Rectangle.fromLTWH(
+          0,
+          0,
+          Constants.worldSize.x,
+          Constants.worldSize.y,
+        ),
+        considerViewport: true,
+      )
+      ..follow(player);
     miningLaser = MiningLaserComponent(player: player);
     add(miningLaser);
 

--- a/test/player_reset_orientation_test.dart
+++ b/test/player_reset_orientation_test.dart
@@ -12,6 +12,7 @@ import 'package:space_game/ui/game_over_overlay.dart';
 import 'package:space_game/ui/hud_overlay.dart';
 import 'package:space_game/ui/menu_overlay.dart';
 import 'package:space_game/ui/pause_overlay.dart';
+import 'package:space_game/constants.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -42,11 +43,11 @@ void main() {
     // Starting a new game should reset orientation and position.
     game.startGame();
     expect(game.player.angle, 0);
-    expect(game.player.position, Vector2.all(50));
+    expect(game.player.position, Constants.worldSize / 2);
 
     // After update with no input, angle and position should remain unchanged.
     game.player.update(0.1);
     expect(game.player.angle, 0);
-    expect(game.player.position, Vector2.all(50));
+    expect(game.player.position, Constants.worldSize / 2);
   });
 }

--- a/test/player_respawn_test.dart
+++ b/test/player_respawn_test.dart
@@ -41,6 +41,6 @@ void main() {
     expect(game.stateMachine.state, GameState.gameOver);
 
     game.startGame();
-    expect(game.player.position, Vector2.all(50));
+    expect(game.player.position, Constants.worldSize / 2);
   });
 }


### PR DESCRIPTION
## Summary
- add `worldSize` to Constants and create a parallax starfield sized to it
- let the camera follow within world bounds instead of the viewport
- reset and clamp player movement using world coordinates; spawn enemies/asteroids across the world
- clean up bullets, enemies and asteroids when leaving world bounds

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a6b2efac8330a15d1eadd6fcf8ca