### PR TITLE
Spawn entities relative to camera viewport

### DIFF
--- a/lib/components/asteroid_spawner.dart
+++ b/lib/components/asteroid_spawner.dart
@@ -30,14 +30,15 @@ class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
 
   void _spawn() {
     final spawnDistance = Constants.asteroidSize * Constants.asteroidScale;
+    final rect = game.camera.visibleWorldRect;
     final edge = _random.nextInt(4);
     late Vector2 position;
     late Vector2 velocity;
     switch (edge) {
       case 0: // top
         position = Vector2(
-          _random.nextDouble() * Constants.worldSize.x,
-          -spawnDistance,
+          rect.left + _random.nextDouble() * rect.width,
+          rect.top - spawnDistance,
         );
         velocity = Vector2(
           (_random.nextDouble() - 0.5) * Constants.asteroidSpeed,
@@ -46,8 +47,8 @@ class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
         break;
       case 1: // bottom
         position = Vector2(
-          _random.nextDouble() * Constants.worldSize.x,
-          Constants.worldSize.y + spawnDistance,
+          rect.left + _random.nextDouble() * rect.width,
+          rect.bottom + spawnDistance,
         );
         velocity = Vector2(
           (_random.nextDouble() - 0.5) * Constants.asteroidSpeed,
@@ -56,8 +57,8 @@ class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
         break;
       case 2: // left
         position = Vector2(
-          -spawnDistance,
-          _random.nextDouble() * Constants.worldSize.y,
+          rect.left - spawnDistance,
+          rect.top + _random.nextDouble() * rect.height,
         );
         velocity = Vector2(
           Constants.asteroidSpeed,
@@ -66,14 +67,15 @@ class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
         break;
       default: // right
         position = Vector2(
-          Constants.worldSize.x + spawnDistance,
-          _random.nextDouble() * Constants.worldSize.y,
+          rect.right + spawnDistance,
+          rect.top + _random.nextDouble() * rect.height,
         );
         velocity = Vector2(
           -Constants.asteroidSpeed,
           (_random.nextDouble() - 0.5) * Constants.asteroidSpeed,
         );
     }
+    position.clamp(Vector2.zero(), Constants.worldSize);
     game.add(
       game.acquireAsteroid(position, velocity),
     );

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -32,33 +32,35 @@ class EnemySpawner extends Component with HasGameReference<SpaceGame> {
 
   void _spawn() {
     final spawnDistance = Constants.enemySize * Constants.enemyScale;
+    final rect = game.camera.visibleWorldRect;
     final edge = _random.nextInt(4);
     late Vector2 position;
     switch (edge) {
       case 0: // top
         position = Vector2(
-          _random.nextDouble() * Constants.worldSize.x,
-          -spawnDistance,
+          rect.left + _random.nextDouble() * rect.width,
+          rect.top - spawnDistance,
         );
         break;
       case 1: // bottom
         position = Vector2(
-          _random.nextDouble() * Constants.worldSize.x,
-          Constants.worldSize.y + spawnDistance,
+          rect.left + _random.nextDouble() * rect.width,
+          rect.bottom + spawnDistance,
         );
         break;
       case 2: // left
         position = Vector2(
-          -spawnDistance,
-          _random.nextDouble() * Constants.worldSize.y,
+          rect.left - spawnDistance,
+          rect.top + _random.nextDouble() * rect.height,
         );
         break;
       default: // right
         position = Vector2(
-          Constants.worldSize.x + spawnDistance,
-          _random.nextDouble() * Constants.worldSize.y,
+          rect.right + spawnDistance,
+          rect.top + _random.nextDouble() * rect.height,
         );
     }
+    position.clamp(Vector2.zero(), Constants.worldSize);
     game.add(
       game.acquireEnemy(position),
     );

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -60,7 +60,6 @@ class SpaceGame extends FlameGame
   late final AsteroidSpawner asteroidSpawner;
   ParallaxComponent? _starfield;
   FpsTextComponent? _fpsText;
-  ParallaxComponent? _starfield;
 
   ValueNotifier<int> get score => scoreService.score;
   ValueNotifier<int> get highScore => scoreService.highScore;


### PR DESCRIPTION
## Summary
- spawn enemies around the camera's visible area to keep encounters near the player
- spawn asteroids around the camera and clamp to world bounds
- remove duplicate starfield declaration in `SpaceGame`

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ad9e8c348330b2c54505fa41a6d9