### PR TITLE
Fix duplicate starfield declaration

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -60,7 +60,6 @@ class SpaceGame extends FlameGame
   late final AsteroidSpawner asteroidSpawner;
   ParallaxComponent? _starfield;
   FpsTextComponent? _fpsText;
-  ParallaxComponent? _starfield;
 
   ValueNotifier<int> get score => scoreService.score;
   ValueNotifier<int> get highScore => scoreService.highScore;


### PR DESCRIPTION
## Summary
- remove duplicate `_starfield` field from `SpaceGame`

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ae870730833081bc1c766872f331