### PR TITLE
refactor: share debug health and nearest search, improve key input handling

### DIFF
--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -7,6 +7,8 @@ Gameplay entities and reusable pieces.
   when it needs game context.
 - Use simple hit boxes like `CircleHitbox` or `RectangleHitbox` with
   `HasCollisionDetection` on the game.
+- Shared mixins like `DebugHealthText` provide common behaviours such as
+  rendering health values while in debug mode.
 - Pull tunable values from `constants.dart` and asset references from
   `assets.dart`.
 - Bullet, asteroid and enemy components use small object pools to reduce

--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -4,18 +4,17 @@ import 'dart:ui';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
-import 'package:flame/text.dart';
-
 import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
+import 'debug_health_text.dart';
 
 /// Neutral obstacle that can be mined for score and minerals.
 ///
 /// Instances are pooled by [SpaceGame] to reduce garbage collection. Call
 /// [reset] before adding to the game to initialise position and velocity.
 class AsteroidComponent extends SpriteComponent
-    with HasGameReference<SpaceGame>, CollisionCallbacks {
+    with HasGameReference<SpaceGame>, CollisionCallbacks, DebugHealthText {
   AsteroidComponent()
       : super(
           size: Vector2.all(
@@ -27,13 +26,6 @@ class AsteroidComponent extends SpriteComponent
   final Vector2 _velocity = Vector2.zero();
   static final _rand = math.Random();
   int _health = Constants.asteroidMaxHealth;
-
-  static final TextPaint _debugTextPaint = TextPaint(
-    style: const TextStyle(
-      color: Color(0xffffffff),
-      fontSize: 10,
-    ),
-  );
 
   /// Prepares the asteroid for reuse.
   void reset(Vector2 position, Vector2 velocity) {
@@ -71,15 +63,7 @@ class AsteroidComponent extends SpriteComponent
   @override
   void render(Canvas canvas) {
     super.render(canvas);
-    if (game.debugMode) {
-      final text = '$_health';
-      final tp = _debugTextPaint.toTextPainter(text);
-      final position = Vector2(
-        -tp.width / 2,
-        -size.y / 2 - tp.height,
-      );
-      _debugTextPaint.render(canvas, text, position);
-    }
+    renderHealth(canvas, _health);
   }
 
   @override

--- a/lib/components/debug_health_text.dart
+++ b/lib/components/debug_health_text.dart
@@ -1,0 +1,29 @@
+import 'package:flame/components.dart';
+import 'package:flame/text.dart';
+import 'package:flutter/painting.dart';
+
+import '../game/space_game.dart';
+
+/// Mixin that renders component health when [SpaceGame.debugMode] is enabled.
+mixin DebugHealthText on PositionComponent, HasGameReference<SpaceGame> {
+  static final TextPaint _debugTextPaint = TextPaint(
+    style: const TextStyle(
+      color: Color(0xffffffff),
+      fontSize: 10,
+    ),
+  );
+
+  /// Renders [health] above the component when debug mode is active.
+  void renderHealth(Canvas canvas, int health) {
+    if (!game.debugMode) {
+      return;
+    }
+    final text = '$health';
+    final tp = _debugTextPaint.toTextPainter(text);
+    final position = Vector2(
+      -tp.width / 2,
+      -size.y / 2 - tp.height,
+    );
+    _debugTextPaint.render(canvas, text, position);
+  }
+}

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -4,18 +4,17 @@ import 'dart:math' as math;
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
-import 'package:flame/text.dart';
-
 import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
+import 'debug_health_text.dart';
 
 /// Basic foe that drifts toward the player.
 ///
 /// Instances are pooled by [SpaceGame] to reduce garbage collection. Call
 /// [reset] before adding to the game to initialise position.
 class EnemyComponent extends SpriteComponent
-    with HasGameReference<SpaceGame>, CollisionCallbacks {
+    with HasGameReference<SpaceGame>, CollisionCallbacks, DebugHealthText {
   EnemyComponent()
       : super(
           size: Vector2.all(
@@ -25,13 +24,6 @@ class EnemyComponent extends SpriteComponent
         );
 
   int _health = Constants.enemyMaxHealth;
-
-  static final TextPaint _debugTextPaint = TextPaint(
-    style: const TextStyle(
-      color: Color(0xffffffff),
-      fontSize: 10,
-    ),
-  );
 
   /// Prepares the enemy for reuse.
   void reset(Vector2 position) {
@@ -68,15 +60,7 @@ class EnemyComponent extends SpriteComponent
   @override
   void render(Canvas canvas) {
     super.render(canvas);
-    if (game.debugMode) {
-      final text = '$_health';
-      final tp = _debugTextPaint.toTextPainter(text);
-      final position = Vector2(
-        -tp.width / 2,
-        -size.y / 2 - tp.height,
-      );
-      _debugTextPaint.render(canvas, text, position);
-    }
+    renderHealth(canvas, _health);
   }
 
   @override

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -11,6 +11,7 @@ import '../game/space_game.dart';
 import '../game/key_dispatcher.dart';
 import 'asteroid.dart';
 import 'enemy.dart';
+import '../util/nearest_component.dart';
 
 /// Controllable player ship.
 class PlayerComponent extends SpriteComponent
@@ -122,20 +123,28 @@ class PlayerComponent extends SpriteComponent
     }
     _keyboardDirection
       ..setZero()
-      ..x += (keyDispatcher.isPressed(LogicalKeyboardKey.keyA) ||
-              keyDispatcher.isPressed(LogicalKeyboardKey.arrowLeft))
+      ..x += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyA,
+        LogicalKeyboardKey.arrowLeft,
+      ])
           ? -1
           : 0
-      ..x += (keyDispatcher.isPressed(LogicalKeyboardKey.keyD) ||
-              keyDispatcher.isPressed(LogicalKeyboardKey.arrowRight))
+      ..x += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyD,
+        LogicalKeyboardKey.arrowRight,
+      ])
           ? 1
           : 0
-      ..y += (keyDispatcher.isPressed(LogicalKeyboardKey.keyW) ||
-              keyDispatcher.isPressed(LogicalKeyboardKey.arrowUp))
+      ..y += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyW,
+        LogicalKeyboardKey.arrowUp,
+      ])
           ? -1
           : 0
-      ..y += (keyDispatcher.isPressed(LogicalKeyboardKey.keyS) ||
-              keyDispatcher.isPressed(LogicalKeyboardKey.arrowDown))
+      ..y += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyS,
+        LogicalKeyboardKey.arrowDown,
+      ])
           ? 1
           : 0;
 
@@ -158,10 +167,18 @@ class PlayerComponent extends SpriteComponent
       _autoAimTimer += dt;
       if (_autoAimTimer >= Constants.playerAutoAimInterval) {
         _autoAimTimer = 0;
-        final target = _findClosestEnemy();
+        final enemies = game.enemies.isNotEmpty
+            ? game.enemies
+            : game.children.whereType<EnemyComponent>();
+        final target = enemies.findClosest(
+          position,
+          Constants.playerAutoAimRange,
+        );
         if (target != null) {
-          _targetAngle = math.atan2(target.position.y - position.y,
-                  target.position.x - position.x) +
+          _targetAngle = math.atan2(
+                target.position.y - position.y,
+                target.position.x - position.x,
+              ) +
               math.pi / 2;
         }
       }
@@ -208,22 +225,5 @@ class PlayerComponent extends SpriteComponent
       a -= math.pi * 2;
     }
     return a;
-  }
-
-  EnemyComponent? _findClosestEnemy() {
-    EnemyComponent? closest;
-    var closestDistance = Constants.playerAutoAimRange;
-    Iterable<EnemyComponent> enemies = game.enemies;
-    if (enemies.isEmpty) {
-      enemies = game.children.whereType<EnemyComponent>();
-    }
-    for (final enemy in enemies) {
-      final distance = enemy.position.distanceTo(position);
-      if (distance <= closestDistance) {
-        closest = enemy;
-        closestDistance = distance;
-      }
-    }
-    return closest;
   }
 }

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -9,8 +9,9 @@ Core game class and shared systems.
 - Uses the default camera viewport so the game fills the available
   browser window.
 - Timer-based spawners generate enemies and asteroids.
-- Input uses Flame's `JoystickComponent`, `ButtonComponent` and
-  `KeyboardListenerComponent`.
+  - Input uses Flame's `JoystickComponent`, `ButtonComponent` and a
+    custom `KeyDispatcher` (via `KeyboardHandler`) that supports helpers like
+    `isAnyPressed` for grouped key queries.
 - Hooks exist for resource mining, inventory, networking and save/load in later
   milestones.
 - Keep this layer lean and delegate work to components or services.

--- a/lib/game/key_dispatcher.dart
+++ b/lib/game/key_dispatcher.dart
@@ -24,6 +24,16 @@ class KeyDispatcher extends Component with KeyboardHandler {
   /// Returns whether [key] is currently pressed.
   bool isPressed(LogicalKeyboardKey key) => _pressed.contains(key);
 
+  /// Returns whether any of [keys] are currently pressed.
+  bool isAnyPressed(Iterable<LogicalKeyboardKey> keys) {
+    for (final key in keys) {
+      if (_pressed.contains(key)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @override
   bool onKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
     final key = event.logicalKey;
@@ -34,6 +44,7 @@ class KeyDispatcher extends Component with KeyboardHandler {
       _pressed.remove(key);
       _up[key]?.call();
     }
-    return true;
+    // Allow other handlers to receive the event as well.
+    return false;
   }
 }

--- a/lib/util/nearest_component.dart
+++ b/lib/util/nearest_component.dart
@@ -1,0 +1,20 @@
+import 'package:flame/components.dart';
+
+/// Extension providing nearest-component search utilities.
+extension NearestComponent<T extends PositionComponent> on Iterable<T> {
+  /// Finds the closest component to [origin] within [maxDistance].
+  ///
+  /// Returns `null` if no component is within the distance threshold.
+  T? findClosest(Vector2 origin, double maxDistance) {
+    T? closest;
+    var closestDistanceSquared = maxDistance * maxDistance;
+    for (final component in this) {
+      final distanceSquared = component.position.distanceToSquared(origin);
+      if (distanceSquared < closestDistanceSquared) {
+        closest = component;
+        closestDistanceSquared = distanceSquared;
+      }
+    }
+    return closest;
+  }
+}

--- a/test/key_dispatcher_any_pressed_test.dart
+++ b/test/key_dispatcher_any_pressed_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/game/key_dispatcher.dart';
+
+void main() {
+  test('isAnyPressed reports true when any key is pressed', () {
+    final dispatcher = KeyDispatcher();
+    dispatcher.onKeyEvent(
+      const KeyDownEvent(
+        logicalKey: LogicalKeyboardKey.keyA,
+        physicalKey: PhysicalKeyboardKey.keyA,
+        timeStamp: Duration.zero,
+      ),
+      {LogicalKeyboardKey.keyA},
+    );
+    expect(
+      dispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyA,
+        LogicalKeyboardKey.keyB,
+      ]),
+      isTrue,
+    );
+  });
+
+  test('isAnyPressed reports false when none of the keys are pressed', () {
+    final dispatcher = KeyDispatcher();
+    dispatcher.onKeyEvent(
+      const KeyDownEvent(
+        logicalKey: LogicalKeyboardKey.keyA,
+        physicalKey: PhysicalKeyboardKey.keyA,
+        timeStamp: Duration.zero,
+      ),
+      {LogicalKeyboardKey.keyA},
+    );
+    dispatcher.onKeyEvent(
+      const KeyUpEvent(
+        logicalKey: LogicalKeyboardKey.keyA,
+        physicalKey: PhysicalKeyboardKey.keyA,
+        timeStamp: Duration.zero,
+      ),
+      <LogicalKeyboardKey>{},
+    );
+    expect(
+      dispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyA,
+        LogicalKeyboardKey.keyB,
+      ]),
+      isFalse,
+    );
+  });
+}

--- a/test/key_dispatcher_propagation_test.dart
+++ b/test/key_dispatcher_propagation_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/game/key_dispatcher.dart';
+
+void main() {
+  test('KeyDispatcher does not consume events', () {
+    final dispatcher = KeyDispatcher();
+    final event = KeyDownEvent(
+      logicalKey: LogicalKeyboardKey.space,
+      physicalKey: PhysicalKeyboardKey.space,
+      timeStamp: Duration.zero,
+    );
+    final handled = dispatcher.onKeyEvent(event, {LogicalKeyboardKey.space});
+    expect(handled, isFalse);
+  });
+}

--- a/test/nearest_component_test.dart
+++ b/test/nearest_component_test.dart
@@ -1,0 +1,38 @@
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/util/nearest_component.dart';
+
+class _TestComponent extends PositionComponent {
+  _TestComponent(Vector2 position) {
+    this.position = position;
+  }
+}
+
+void main() {
+  test('findClosestComponent returns nearest within range', () {
+    final components = [
+      _TestComponent(Vector2(10, 0)),
+      _TestComponent(Vector2(5, 0)),
+    ];
+    final origin = Vector2.zero();
+    final result = components.findClosest(
+      origin,
+      8,
+    );
+    expect(result, equals(components[1]));
+  });
+
+  test('findClosestComponent returns null when none in range', () {
+    final components = [
+      _TestComponent(Vector2(10, 0)),
+      _TestComponent(Vector2(5, 0)),
+    ];
+    final origin = Vector2.zero();
+    final result = components.findClosest(
+      origin,
+      4,
+    );
+    expect(result, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- refactor nearest-component lookup into an extension using distance squared
- simplify DebugHealthText API and update asteroid/enemy implementations
- allow KeyDispatcher to propagate events and add regression test
- add `isAnyPressed` helper and update player to use grouped key queries

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3aeaa188330b2d116a51c4dbf8a