### PR TITLE
Cancel preview deploys when running main deploy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,10 +6,12 @@ CI/CD automation for the project.
 - `deploy.yml` – builds the web release and publishes it. It runs on
   pushes to `main` and `develop` and can be triggered manually from the
   GitHub Actions tab.
-- `deploy-preview.yml` – manually builds the current branch and publishes it to a branch-specific preview path.
+- `deploy-preview.yml` – builds the current branch on pull requests or
+  manual triggers and publishes it to a branch-specific preview path.
 
-All workflows use concurrency groups to cancel in-progress runs when new
-commits arrive.
+Workflows avoid interfering with each other by using concurrency groups.
+The main deploy workflow also cancels any running preview deployments
+before starting.
 
 Workflows follow the lightweight pipeline described in [../../PLAN.md](../../PLAN.md).
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   build-and-deploy:
@@ -23,6 +24,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Cancel preview deployments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner,
+                repo,
+                workflow_id: 'deploy-preview.yml',
+                status: 'in_progress',
+              }
+            );
+            for (const run of runs) {
+              await github.rest.actions.cancelWorkflowRun({
+                owner,
+                repo,
+                run_id: run.id,
+              });
+            }
       - name: Cache Flutter SDK
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- cancel any in-progress preview deployments before main deploy runs
- document preview deploy cancellation in workflow README

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3de04a8d4833089f75e7591b61622