### PR TITLE
fix: resolve merge conflicts in player component

### DIFF
--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -44,6 +44,9 @@ class PlayerComponent extends SpriteComponent
   /// Angle the ship should currently rotate towards.
   double _targetAngle = 0;
 
+  /// Accumulates time between auto-aim updates when stationary.
+  double _autoAimTimer = 0;
+
   /// Whether to render the auto-aim radius around the player.
   bool showAutoAimRadius = false;
 
@@ -160,20 +163,25 @@ class PlayerComponent extends SpriteComponent
         Constants.worldSize - halfSize,
       );
       _targetAngle = math.atan2(input.y, input.x) + math.pi / 2;
+      _autoAimTimer = 0;
     } else {
-      final enemies = game.enemies.isNotEmpty
-          ? game.enemies
-          : game.children.whereType<EnemyComponent>();
-      final target = enemies.findClosest(
-        position,
-        Constants.playerAutoAimRange,
-      );
-      if (target != null) {
-        _targetAngle = math.atan2(
-              target.position.y - position.y,
-              target.position.x - position.x,
-            ) +
-            math.pi / 2;
+      _autoAimTimer += dt;
+      if (_autoAimTimer >= Constants.playerAutoAimInterval) {
+        _autoAimTimer = 0;
+        final enemies = game.enemies.isNotEmpty
+            ? game.enemies
+            : game.children.whereType<EnemyComponent>();
+        final target = enemies.findClosest(
+          position,
+          Constants.playerAutoAimRange,
+        );
+        if (target != null) {
+          _targetAngle = math.atan2(
+                target.position.y - position.y,
+                target.position.x - position.x,
+              ) +
+              math.pi / 2;
+        }
       }
     }
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -20,6 +20,9 @@ class Constants {
   /// Maximum distance to auto-aim enemies when stationary, in pixels.
   static const double playerAutoAimRange = 300;
 
+  /// Seconds between auto-aim direction updates when stationary.
+  static const double playerAutoAimInterval = 0.2;
+
   /// Maximum distance to auto-mine asteroids, in pixels.
   static const double playerMiningRange = playerAutoAimRange;
 


### PR DESCRIPTION
## Summary
- reinstate auto-aim interval constant and timer when merging with latest main
- keep mineral pickup collision handling after resolving player merge conflict

## Testing
- `scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68b3e68e6748833090eac2b9bdf2cc81