### PR TITLE
Add collision resolution to push entities apart

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -8,13 +8,18 @@ import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
 import 'debug_health_text.dart';
+import '../util/collision_utils.dart';
 
 /// Neutral obstacle that can be mined for score and minerals.
 ///
 /// Instances are pooled by [SpaceGame] to reduce garbage collection. Call
 /// [reset] before adding to the game to initialise position and velocity.
 class AsteroidComponent extends SpriteComponent
-    with HasGameReference<SpaceGame>, CollisionCallbacks, DebugHealthText {
+    with
+        HasGameReference<SpaceGame>,
+        CollisionCallbacks,
+        DebugHealthText,
+        SolidBody {
   AsteroidComponent()
       : super(
           size: Vector2.all(
@@ -89,9 +94,6 @@ class AsteroidComponent extends SpriteComponent
       game.addScore(Constants.asteroidScore);
     }
     if (_health <= 0 && !isRemoving) {
-      final mineral = game.acquireMineral(position.clone());
-      game.mineralPickups.add(mineral);
-      game.add(mineral);
       removeFromParent();
     }
   }

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -8,13 +8,18 @@ import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
 import 'debug_health_text.dart';
+import '../util/collision_utils.dart';
 
 /// Basic foe that drifts toward the player.
 ///
 /// Instances are pooled by [SpaceGame] to reduce garbage collection. Call
 /// [reset] before adding to the game to initialise position.
 class EnemyComponent extends SpriteComponent
-    with HasGameReference<SpaceGame>, CollisionCallbacks, DebugHealthText {
+    with
+        HasGameReference<SpaceGame>,
+        CollisionCallbacks,
+        DebugHealthText,
+        SolidBody {
   EnemyComponent()
       : super(
           size: Vector2.all(

--- a/lib/components/mineral.dart
+++ b/lib/components/mineral.dart
@@ -4,13 +4,14 @@ import 'package:flame/components.dart';
 import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
+import '../util/collision_utils.dart';
 
 /// Collectible mineral dropped by destroyed asteroids.
 ///
 /// Instances are pooled by [SpaceGame] to avoid repeated allocations. Call
 /// [reset] before adding to the game to set its position and value.
 class MineralComponent extends SpriteComponent
-    with HasGameReference<SpaceGame>, CollisionCallbacks {
+    with HasGameReference<SpaceGame>, CollisionCallbacks, SolidBody {
   MineralComponent()
       : super(
           size: Vector2.all(

--- a/lib/util/collision_utils.dart
+++ b/lib/util/collision_utils.dart
@@ -1,0 +1,38 @@
+import 'dart:math' as math;
+
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+
+/// Mixin that prevents [PositionComponent]s from overlapping by
+/// pushing them away from each other when a collision occurs.
+mixin SolidBody on PositionComponent, CollisionCallbacks {
+  static final _rand = math.Random();
+
+  @override
+  void onCollision(
+    Set<Vector2> intersectionPoints,
+    PositionComponent other,
+  ) {
+    super.onCollision(intersectionPoints, other);
+    if (other is! SolidBody) {
+      return;
+    }
+    final diff = position - other.position;
+    var distance = diff.length;
+    if (distance == 0) {
+      // Components are exactly on top of each other; nudge in a random direction.
+      final angle = _rand.nextDouble() * math.pi * 2;
+      diff
+        ..x = math.cos(angle)
+        ..y = math.sin(angle);
+      distance = 0.0001;
+    }
+    final minDistance = (size.x + other.size.x) / 2;
+    final overlap = minDistance - distance;
+    if (overlap > 0) {
+      final push = diff.normalized() * (overlap / 2);
+      position.add(push);
+      other.position.sub(push);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `SolidBody` mixin to push overlapping components away
- apply `SolidBody` to asteroids, enemies, and minerals
- clean up asteroid damage so destruction doesn't spawn an extra mineral
- rename collision utility file to `collision_utils.dart`

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f2e4985c8330aaf18a5580a2c568