### PR TITLE
Refactor pooling with event bus and simplified lifecycle

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -7,10 +7,12 @@ import 'package:flame/flame.dart';
 import 'package:meta/meta.dart';
 import '../assets.dart';
 import '../constants.dart';
+import '../game/event_bus.dart';
 import '../game/space_game.dart';
 import 'debug_health_text.dart';
 import '../util/collision_utils.dart';
 import 'damageable.dart';
+import 'mineral.dart';
 
 /// Neutral obstacle that can be mined for score and minerals.
 ///
@@ -57,7 +59,7 @@ class AsteroidComponent extends SpriteComponent
   @override
   void onMount() {
     super.onMount();
-    game.pools.trackAsteroid(this);
+    game.eventBus.emit(ComponentSpawnEvent<AsteroidComponent>(this));
   }
 
   @override
@@ -83,8 +85,7 @@ class AsteroidComponent extends SpriteComponent
   @override
   void onRemove() {
     super.onRemove();
-    game.pools.untrackAsteroid(this);
-    game.pools.releaseAsteroid(this);
+    game.eventBus.emit(ComponentRemoveEvent<AsteroidComponent>(this));
   }
 
   /// Reduces health by [amount], dropping a limited number of minerals and
@@ -98,8 +99,8 @@ class AsteroidComponent extends SpriteComponent
       final distance = _rand.nextDouble() * Constants.mineralDropRadius;
       final offset = Vector2(math.cos(angle), math.sin(angle))..scale(distance);
       final mineral = game.pools.acquireMineral(position + offset);
-      game.pools.mineralPickups.add(mineral);
       game.add(mineral);
+      game.eventBus.emit(ComponentSpawnEvent<MineralComponent>(mineral));
       game.addScore(Constants.asteroidScore);
     }
     if (_health <= 0 && !isRemoving) {

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -5,6 +5,7 @@ import 'package:flame/components.dart';
 
 import '../assets.dart';
 import '../constants.dart';
+import '../game/event_bus.dart';
 import '../game/space_game.dart';
 import 'damageable.dart';
 
@@ -35,6 +36,12 @@ class BulletComponent extends SpriteComponent
   }
 
   @override
+  void onMount() {
+    super.onMount();
+    game.eventBus.emit(ComponentSpawnEvent<BulletComponent>(this));
+  }
+
+  @override
   void update(double dt) {
     super.update(dt);
     position += _direction * Constants.bulletSpeed * dt;
@@ -49,7 +56,7 @@ class BulletComponent extends SpriteComponent
   @override
   void onRemove() {
     super.onRemove();
-    game.pools.releaseBullet(this);
+    game.eventBus.emit(ComponentRemoveEvent<BulletComponent>(this));
   }
 
   @override

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -6,6 +6,7 @@ import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
 import '../assets.dart';
 import '../constants.dart';
+import '../game/event_bus.dart';
 import '../game/space_game.dart';
 import 'debug_health_text.dart';
 import '../util/collision_utils.dart';
@@ -48,7 +49,7 @@ class EnemyComponent extends SpriteComponent
   @override
   void onMount() {
     super.onMount();
-    game.pools.enemies.add(this);
+    game.eventBus.emit(ComponentSpawnEvent<EnemyComponent>(this));
   }
 
   @override
@@ -74,8 +75,7 @@ class EnemyComponent extends SpriteComponent
   @override
   void onRemove() {
     super.onRemove();
-    game.pools.enemies.remove(this);
-    game.pools.releaseEnemy(this);
+    game.eventBus.emit(ComponentRemoveEvent<EnemyComponent>(this));
   }
 
   /// Reduces health by [amount] and removes the enemy when depleted.

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -9,15 +9,7 @@ import '../util/nearest_component.dart';
 
 /// Automatically mines the nearest asteroid within range.
 class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
-  MiningLaserComponent({required this.player});
-
-  final PlayerComponent player;
-  AsteroidComponent? _target;
-  final Paint _paint = Paint()..color = const Color(0x66ffffff);
-  final Timer _pulseTimer = Timer(Constants.miningPulseInterval, repeat: true);
-
-  @override
-  Future<void> onLoad() async {
+  MiningLaserComponent({required this.player}) {
     _pulseTimer.onTick = () {
       _paint.strokeWidth = 2;
       _target?.takeDamage(Constants.miningPulseDamage);
@@ -25,8 +17,12 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
         _target = null;
       }
     };
-    return super.onLoad();
   }
+
+  final PlayerComponent player;
+  AsteroidComponent? _target;
+  final Paint _paint = Paint()..color = const Color(0x66ffffff);
+  final Timer _pulseTimer = Timer(Constants.miningPulseInterval, repeat: true);
 
   @override
   void update(double dt) {

--- a/lib/game/event_bus.dart
+++ b/lib/game/event_bus.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+/// Simple event bus for broadcasting game lifecycle events.
+class GameEventBus {
+  final StreamController<Object> _controller =
+      StreamController<Object>.broadcast(sync: true);
+
+  /// Emits an [event] to all listeners.
+  void emit(Object event) => _controller.add(event);
+
+  /// Returns a stream of events of type [T].
+  Stream<T> on<T>() => _controller.stream.where((e) => e is T).cast<T>();
+
+  /// Closes the underlying stream controller.
+  void dispose() => _controller.close();
+}
+
+/// Event fired when a component is spawned.
+class ComponentSpawnEvent<T> {
+  ComponentSpawnEvent(this.component);
+  final T component;
+}
+
+/// Event fired when a component is removed.
+class ComponentRemoveEvent<T> {
+  ComponentRemoveEvent(this.component);
+  final T component;
+}

--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -1,7 +1,3 @@
-import '../components/asteroid.dart';
-import '../components/bullet.dart';
-import '../components/mineral.dart';
-import '../components/enemy.dart';
 import '../game/space_game.dart';
 
 /// Handles start, menu, and game over transitions.
@@ -12,18 +8,7 @@ class LifecycleManager {
 
   void onStart() {
     game.scoreService.reset();
-    for (final enemy in game.pools.enemies.toList()) {
-      enemy.removeFromParent();
-    }
-    for (final asteroid in game.pools.asteroids.toList()) {
-      asteroid.removeFromParent();
-    }
-    for (final mineral in game.pools.mineralPickups.toList()) {
-      mineral.removeFromParent();
-    }
-    game.children
-        .whereType<BulletComponent>()
-        .forEach((b) => b.removeFromParent());
+    game.pools.clear();
     if (!game.player.isMounted) {
       game.add(game.player);
       game.camera.follow(game.player);

--- a/lib/game/pool_manager.dart
+++ b/lib/game/pool_manager.dart
@@ -5,21 +5,62 @@ import '../components/bullet.dart';
 import '../components/enemy.dart';
 import '../components/mineral.dart';
 import '../constants.dart';
+import '../util/object_pool.dart';
 import '../util/spatial_grid.dart';
+import 'event_bus.dart';
+import 'space_game.dart';
 
 /// Manages pooled game components to reduce allocations.
 class PoolManager {
-  /// Pool of reusable bullets.
-  final List<BulletComponent> _bulletPool = [];
+  PoolManager({required SpaceGame game, required GameEventBus events})
+      : _game = game,
+        _events = events {
+    _events.on<ComponentSpawnEvent<EnemyComponent>>().listen((event) {
+      enemies.add(event.component);
+    });
+    _events.on<ComponentRemoveEvent<EnemyComponent>>().listen((event) {
+      enemies.remove(event.component);
+      releaseEnemy(event.component);
+    });
+    _events.on<ComponentSpawnEvent<AsteroidComponent>>().listen((event) {
+      asteroids.add(event.component);
+      _asteroidGrid.add(event.component);
+    });
+    _events.on<ComponentRemoveEvent<AsteroidComponent>>().listen((event) {
+      asteroids.remove(event.component);
+      _asteroidGrid.remove(event.component);
+      releaseAsteroid(event.component);
+    });
+    _events.on<ComponentSpawnEvent<MineralComponent>>().listen((event) {
+      mineralPickups.add(event.component);
+    });
+    _events.on<ComponentRemoveEvent<MineralComponent>>().listen((event) {
+      mineralPickups.remove(event.component);
+      releaseMineral(event.component);
+    });
+    _events.on<ComponentSpawnEvent<BulletComponent>>().listen((event) {
+      bullets.add(event.component);
+    });
+    _events.on<ComponentRemoveEvent<BulletComponent>>().listen((event) {
+      bullets.remove(event.component);
+      releaseBullet(event.component);
+    });
+  }
 
-  /// Pool of reusable asteroids.
-  final List<AsteroidComponent> _asteroidPool = [];
+  final SpaceGame _game;
+  final GameEventBus _events;
 
-  /// Pool of reusable enemies.
-  final List<EnemyComponent> _enemyPool = [];
+  final ObjectPool<BulletComponent> _bulletPool =
+      ObjectPool(() => BulletComponent());
+  final ObjectPool<AsteroidComponent> _asteroidPool =
+      ObjectPool(() => AsteroidComponent());
+  final ObjectPool<EnemyComponent> _enemyPool =
+      ObjectPool(() => EnemyComponent());
+  final ObjectPool<MineralComponent> _mineralPool =
+      ObjectPool(() => MineralComponent());
 
-  /// Pool of reusable mineral pickups.
-  final List<MineralComponent> _mineralPool = [];
+  /// Active bullets tracked for cleanup.
+  final List<BulletComponent> bullets = [];
 
   /// Active enemies tracked for quick lookup.
   final List<EnemyComponent> enemies = [];
@@ -34,41 +75,34 @@ class PoolManager {
   final List<MineralComponent> mineralPickups = [];
 
   /// Retrieves a bullet from the pool or creates a new one.
-  BulletComponent acquireBullet(Vector2 position, Vector2 direction) {
-    final bullet =
-        _bulletPool.isNotEmpty ? _bulletPool.removeLast() : BulletComponent();
-    bullet.reset(position, direction);
-    return bullet;
-  }
+  BulletComponent acquireBullet(Vector2 position, Vector2 direction) =>
+      _bulletPool.acquire((bullet) => bullet.reset(position, direction));
 
   /// Returns [bullet] to the pool for reuse.
-  void releaseBullet(BulletComponent bullet) {
-    _bulletPool.add(bullet);
-  }
+  void releaseBullet(BulletComponent bullet) => _bulletPool.release(bullet);
 
   /// Retrieves an asteroid from the pool or creates a new one.
-  AsteroidComponent acquireAsteroid(Vector2 position, Vector2 velocity) {
-    final asteroid = _asteroidPool.isNotEmpty
-        ? _asteroidPool.removeLast()
-        : AsteroidComponent();
-    asteroid.reset(position, velocity);
-    return asteroid;
-  }
+  AsteroidComponent acquireAsteroid(Vector2 position, Vector2 velocity) =>
+      _asteroidPool.acquire((asteroid) => asteroid.reset(position, velocity));
 
   /// Returns [asteroid] to the pool for reuse.
-  void releaseAsteroid(AsteroidComponent asteroid) {
-    _asteroidPool.add(asteroid);
-  }
+  void releaseAsteroid(AsteroidComponent asteroid) =>
+      _asteroidPool.release(asteroid);
 
-  void trackAsteroid(AsteroidComponent asteroid) {
-    asteroids.add(asteroid);
-    _asteroidGrid.add(asteroid);
-  }
+  /// Retrieves an enemy from the pool or creates a new one.
+  EnemyComponent acquireEnemy(Vector2 position) =>
+      _enemyPool.acquire((enemy) => enemy.reset(position));
 
-  void untrackAsteroid(AsteroidComponent asteroid) {
-    asteroids.remove(asteroid);
-    _asteroidGrid.remove(asteroid);
-  }
+  /// Returns [enemy] to the pool for reuse.
+  void releaseEnemy(EnemyComponent enemy) => _enemyPool.release(enemy);
+
+  /// Retrieves a mineral from the pool or creates a new one.
+  MineralComponent acquireMineral(Vector2 position) =>
+      _mineralPool.acquire((mineral) => mineral.reset(position));
+
+  /// Returns [mineral] to the pool for reuse.
+  void releaseMineral(MineralComponent mineral) =>
+      _mineralPool.release(mineral);
 
   void updateAsteroidPosition(
     AsteroidComponent asteroid,
@@ -83,30 +117,24 @@ class PoolManager {
   ) =>
       _asteroidGrid.query(position, radius);
 
-  /// Retrieves an enemy from the pool or creates a new one.
-  EnemyComponent acquireEnemy(Vector2 position) {
-    final enemy =
-        _enemyPool.isNotEmpty ? _enemyPool.removeLast() : EnemyComponent();
-    enemy.reset(position);
-    return enemy;
-  }
-
-  /// Returns [enemy] to the pool for reuse.
-  void releaseEnemy(EnemyComponent enemy) {
-    _enemyPool.add(enemy);
-  }
-
-  /// Retrieves a mineral from the pool or creates a new one.
-  MineralComponent acquireMineral(Vector2 position) {
-    final mineral = _mineralPool.isNotEmpty
-        ? _mineralPool.removeLast()
-        : MineralComponent();
-    mineral.reset(position);
-    return mineral;
-  }
-
-  /// Returns [mineral] to the pool for reuse.
-  void releaseMineral(MineralComponent mineral) {
-    _mineralPool.add(mineral);
+  /// Removes all active components and resets tracking structures.
+  void clear() {
+    for (final enemy in enemies.toList()) {
+      enemy.removeFromParent();
+    }
+    for (final asteroid in asteroids.toList()) {
+      asteroid.removeFromParent();
+    }
+    for (final mineral in mineralPickups.toList()) {
+      mineral.removeFromParent();
+    }
+    for (final bullet in bullets.toList()) {
+      bullet.removeFromParent();
+    }
+    enemies.clear();
+    asteroids.clear();
+    mineralPickups.clear();
+    bullets.clear();
+    _asteroidGrid.clear();
   }
 }

--- a/lib/util/object_pool.dart
+++ b/lib/util/object_pool.dart
@@ -1,0 +1,25 @@
+import 'package:meta/meta.dart';
+
+/// Generic object pool to minimise allocations by reusing instances.
+class ObjectPool<T> {
+  ObjectPool(this._create);
+
+  final T Function() _create;
+  final List<T> _items = [];
+
+  /// Retrieves an instance from the pool, applying [reset] if provided.
+  @visibleForTesting
+  List<T> get items => _items;
+
+  T acquire([void Function(T)? reset]) {
+    final obj = _items.isNotEmpty ? _items.removeLast() : _create();
+    reset?.call(obj);
+    return obj;
+  }
+
+  /// Returns [obj] to the pool for future reuse.
+  void release(T obj) => _items.add(obj);
+
+  /// Clears all cached instances.
+  void clear() => _items.clear();
+}

--- a/lib/util/spatial_grid.dart
+++ b/lib/util/spatial_grid.dart
@@ -61,4 +61,7 @@ class SpatialGrid<T extends PositionComponent> {
       }
     }
   }
+
+  /// Removes all components from the grid.
+  void clear() => _cells.clear();
 }

--- a/test/asteroid_damage_limit_test.dart
+++ b/test/asteroid_damage_limit_test.dart
@@ -54,16 +54,18 @@ void main() {
     final game = _TestGame(storageService: storage, audioService: audio);
     await game.onLoad();
 
-    final asteroid = game.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    final asteroid = game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
     await game.add(asteroid);
     game.update(0);
     final initialHealth = asteroid.health;
 
     asteroid.takeDamage(initialHealth + 5);
+    game.update(0);
+    game.update(0);
 
     expect(asteroid.health, 0);
     expect(
-      game.mineralPickups.length,
+      game.pools.mineralPickups.length,
       math.min(initialHealth, Constants.asteroidMineralDropMax),
     );
   });

--- a/test/asteroid_pool_test.dart
+++ b/test/asteroid_pool_test.dart
@@ -18,9 +18,11 @@ void main() {
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);
 
-    final asteroid1 = game.acquireAsteroid(Vector2.zero(), Vector2.zero());
-    game.releaseAsteroid(asteroid1);
-    final asteroid2 = game.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    final asteroid1 =
+        game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    game.pools.releaseAsteroid(asteroid1);
+    final asteroid2 =
+        game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
     expect(identical(asteroid1, asteroid2), isTrue);
   });
 }

--- a/test/asteroid_spatial_lookup_test.dart
+++ b/test/asteroid_spatial_lookup_test.dart
@@ -7,6 +7,8 @@ import 'package:space_game/assets.dart';
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/components/asteroid.dart';
+import 'package:space_game/game/event_bus.dart';
 
 class _TestGame extends SpaceGame {
   _TestGame({required StorageService storage, required AudioService audio})
@@ -29,9 +31,14 @@ void main() {
     final a1 = game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
     final a2 = game.pools.acquireAsteroid(Vector2(100, 0), Vector2.zero());
     final a3 = game.pools.acquireAsteroid(Vector2(500, 500), Vector2.zero());
-    game.pools.trackAsteroid(a1);
-    game.pools.trackAsteroid(a2);
-    game.pools.trackAsteroid(a3);
+    await game.add(a1);
+    await game.add(a2);
+    await game.add(a3);
+    game.update(0);
+    game.update(0);
+    game.eventBus.emit(ComponentSpawnEvent<AsteroidComponent>(a1));
+    game.eventBus.emit(ComponentSpawnEvent<AsteroidComponent>(a2));
+    game.eventBus.emit(ComponentSpawnEvent<AsteroidComponent>(a3));
 
     final nearby = game.pools.nearbyAsteroids(Vector2.zero(), 150).toList();
     expect(nearby.contains(a1), isTrue);

--- a/test/bullet_pool_test.dart
+++ b/test/bullet_pool_test.dart
@@ -15,9 +15,9 @@ void main() {
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);
 
-    final bullet1 = game.acquireBullet(Vector2.zero(), Vector2(0, -1));
-    game.releaseBullet(bullet1);
-    final bullet2 = game.acquireBullet(Vector2.zero(), Vector2(0, -1));
+    final bullet1 = game.pools.acquireBullet(Vector2.zero(), Vector2(0, -1));
+    game.pools.releaseBullet(bullet1);
+    final bullet2 = game.pools.acquireBullet(Vector2.zero(), Vector2(0, -1));
     expect(identical(bullet1, bullet2), isTrue);
   });
 }

--- a/test/mineral_magnet_test.dart
+++ b/test/mineral_magnet_test.dart
@@ -47,7 +47,7 @@ void main() {
     await game.ready();
 
     final start = Vector2(Constants.playerMagnetRange - 10, 0);
-    final mineral = game.acquireMineral(start.clone());
+    final mineral = game.pools.acquireMineral(start.clone());
     await game.add(mineral);
     await game.ready();
 
@@ -66,7 +66,7 @@ void main() {
     await game.ready();
 
     final start = Vector2(Constants.playerMagnetRange + 10, 0);
-    final mineral = game.acquireMineral(start.clone());
+    final mineral = game.pools.acquireMineral(start.clone());
     await game.add(mineral);
     await game.ready();
 

--- a/test/mineral_pickup_test.dart
+++ b/test/mineral_pickup_test.dart
@@ -57,7 +57,7 @@ void main() {
     final game = _TestGame(storage: storage, audio: audio);
     await game.onLoad();
 
-    final asteroid = game.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    final asteroid = game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
     await game.add(asteroid);
     game.update(0);
     final origin = asteroid.position.clone();
@@ -66,11 +66,12 @@ void main() {
     while (asteroid.parent != null && hits < 10) {
       asteroid.takeDamage(1);
       game.update(0);
+      game.update(0);
       hits++;
     }
     await game.ready();
-    expect(game.mineralPickups.length, hits);
-    for (final mineral in game.mineralPickups) {
+    expect(game.pools.mineralPickups.length, hits);
+    for (final mineral in game.pools.mineralPickups) {
       final offset = mineral.position - origin;
       expect(offset.length, greaterThan(0));
       expect(offset.length, lessThanOrEqualTo(Constants.mineralDropRadius));
@@ -85,8 +86,7 @@ void main() {
     final game = _TestGame(storage: storage, audio: audio);
     await game.onLoad();
 
-    final mineral = game.acquireMineral(game.player.position.clone());
-    game.mineralPickups.add(mineral);
+    final mineral = game.pools.acquireMineral(game.player.position.clone());
     final initial = game.minerals.value;
     game.player.onCollisionStart({}, mineral);
 

--- a/test/player_bullet_direction_test.dart
+++ b/test/player_bullet_direction_test.dart
@@ -9,6 +9,7 @@ import 'package:space_game/components/player.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/pool_manager.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
 
@@ -25,9 +26,8 @@ class _TestPlayer extends PlayerComponent {
   Future<void> onLoad() async {}
 }
 
-class _TestGame extends SpaceGame {
-  _TestGame({required StorageService storage, required AudioService audio})
-      : super(storageService: storage, audioService: audio);
+class _TestPoolManager extends PoolManager {
+  _TestPoolManager({required super.game, required super.events});
 
   final List<_TestBullet> _pool = [];
 
@@ -42,6 +42,15 @@ class _TestGame extends SpaceGame {
   void releaseBullet(BulletComponent bullet) {
     _pool.add(bullet as _TestBullet);
   }
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  PoolManager createPoolManager() =>
+      _TestPoolManager(game: this, events: eventBus);
 
   @override
   Future<void> onLoad() async {

--- a/test/player_shoot_cooldown_test.dart
+++ b/test/player_shoot_cooldown_test.dart
@@ -7,6 +7,7 @@ import 'package:space_game/components/player.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/pool_manager.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
 
@@ -23,9 +24,8 @@ class _TestPlayer extends PlayerComponent {
   Future<void> onLoad() async {}
 }
 
-class _TestGame extends SpaceGame {
-  _TestGame({required StorageService storage, required AudioService audio})
-      : super(storageService: storage, audioService: audio);
+class _TestPoolManager extends PoolManager {
+  _TestPoolManager({required super.game, required super.events});
 
   final List<_TestBullet> _pool = [];
 
@@ -40,6 +40,15 @@ class _TestGame extends SpaceGame {
   void releaseBullet(BulletComponent bullet) {
     _pool.add(bullet as _TestBullet);
   }
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  PoolManager createPoolManager() =>
+      _TestPoolManager(game: this, events: eventBus);
 
   @override
   Future<void> onLoad() async {


### PR DESCRIPTION
## Summary
- Introduce generic `ObjectPool<T>` and synchronous `GameEventBus` for lifecycle events
- Rework `PoolManager` to compose typed pools, subscribe to spawn/remove events (including minerals) and provide a unified `clear`
- Expose `PoolManager` via `SpaceGame` with dependency injection and remove wrapper methods
- Optimize mineral magnetism with a distance-squared check and have minerals emit spawn events when mounted
- Move mining laser timer setup to the constructor and centralize lifecycle cleanup through `PoolManager.clear`

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b40b4d60888330a8b1b60dc93562d2