### PR TITLE
Refactor PoolManager with generic object pools

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -98,7 +98,9 @@ class AsteroidComponent extends SpriteComponent
       final angle = _rand.nextDouble() * math.pi * 2;
       final distance = _rand.nextDouble() * Constants.mineralDropRadius;
       final offset = Vector2(math.cos(angle), math.sin(angle))..scale(distance);
-      final mineral = game.pools.acquireMineral(position + offset);
+      final mineral = game.pools.acquire<MineralComponent>(
+        (m) => m.reset(position + offset),
+      );
       game.add(mineral);
       game.eventBus.emit(ComponentSpawnEvent<MineralComponent>(mineral));
       game.addScore(Constants.asteroidScore);

--- a/lib/components/asteroid_spawner.dart
+++ b/lib/components/asteroid_spawner.dart
@@ -4,6 +4,7 @@ import 'package:flame/components.dart';
 
 import '../constants.dart';
 import '../game/space_game.dart';
+import 'asteroid.dart';
 
 /// Spawns asteroids at timed intervals when started.
 class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
@@ -78,7 +79,9 @@ class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
     }
     position.clamp(Vector2.zero(), Constants.worldSize);
     game.add(
-      game.pools.acquireAsteroid(position, velocity),
+      game.pools.acquire<AsteroidComponent>(
+        (a) => a.reset(position, velocity),
+      ),
     );
   }
 }

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 
 import '../constants.dart';
 import '../game/space_game.dart';
+import 'enemy.dart';
 
 /// Spawns enemies at timed intervals when started.
 class EnemySpawner extends Component with HasGameReference<SpaceGame> {
@@ -69,7 +70,9 @@ class EnemySpawner extends Component with HasGameReference<SpaceGame> {
           (Constants.enemyGroupSpread * 2);
       final position = base + offset;
       position.clamp(Vector2.zero(), Constants.worldSize);
-      game.add(game.pools.acquireEnemy(position));
+      game.add(
+        game.pools.acquire<EnemyComponent>((e) => e.reset(position)),
+      );
     }
   }
 

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -12,6 +12,7 @@ import '../game/key_dispatcher.dart';
 import 'enemy.dart';
 import 'asteroid.dart';
 import 'mineral.dart';
+import 'bullet.dart';
 import '../util/nearest_component.dart';
 
 /// Controllable player ship.
@@ -92,7 +93,9 @@ class PlayerComponent extends SpriteComponent
     }
     final direction =
         Vector2(math.cos(angle - math.pi / 2), math.sin(angle - math.pi / 2));
-    final bullet = game.pools.acquireBullet(position.clone(), direction);
+    final bullet = game.pools.acquire<BulletComponent>(
+      (b) => b.reset(position.clone(), direction),
+    );
     game.add(bullet);
     game.audioService.playShoot();
     _shootCooldown = Constants.bulletCooldown;
@@ -190,7 +193,7 @@ class PlayerComponent extends SpriteComponent
   }
 
   void _autoAim() {
-    final enemies = game.pools.enemies;
+    final enemies = game.pools.components<EnemyComponent>();
     final target = enemies.findClosest(
       position,
       Constants.playerAutoAimRange,

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -172,7 +172,7 @@ class SpaceGame extends FlameGame
   }
 
   @protected
-  PoolManager createPoolManager() => PoolManager(game: this, events: eventBus);
+  PoolManager createPoolManager() => PoolManager(events: eventBus);
 
   /// Toggles the upgrades overlay and pauses/resumes the game.
   void toggleUpgrades() {

--- a/test/asteroid_damage_limit_test.dart
+++ b/test/asteroid_damage_limit_test.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:space_game/assets.dart';
 import 'package:space_game/components/asteroid.dart';
 import 'package:space_game/components/player.dart';
+import 'package:space_game/components/mineral.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/space_game.dart';
@@ -54,7 +55,9 @@ void main() {
     final game = _TestGame(storageService: storage, audioService: audio);
     await game.onLoad();
 
-    final asteroid = game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    final asteroid = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2.zero(), Vector2.zero()),
+    );
     await game.add(asteroid);
     game.update(0);
     final initialHealth = asteroid.health;
@@ -65,7 +68,7 @@ void main() {
 
     expect(asteroid.health, 0);
     expect(
-      game.pools.mineralPickups.length,
+      game.pools.components<MineralComponent>().length,
       math.min(initialHealth, Constants.asteroidMineralDropMax),
     );
   });

--- a/test/asteroid_pool_test.dart
+++ b/test/asteroid_pool_test.dart
@@ -7,6 +7,7 @@ import 'package:space_game/game/space_game.dart';
 import 'package:space_game/assets.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/components/asteroid.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -18,11 +19,13 @@ void main() {
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);
 
-    final asteroid1 =
-        game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
-    game.pools.releaseAsteroid(asteroid1);
-    final asteroid2 =
-        game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    final asteroid1 = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2.zero(), Vector2.zero()),
+    );
+    game.pools.release(asteroid1);
+    final asteroid2 = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2.zero(), Vector2.zero()),
+    );
     expect(identical(asteroid1, asteroid2), isTrue);
   });
 }

--- a/test/asteroid_spatial_lookup_test.dart
+++ b/test/asteroid_spatial_lookup_test.dart
@@ -28,9 +28,15 @@ void main() {
     final game = _TestGame(storage: storage, audio: audio);
     await game.onLoad();
 
-    final a1 = game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
-    final a2 = game.pools.acquireAsteroid(Vector2(100, 0), Vector2.zero());
-    final a3 = game.pools.acquireAsteroid(Vector2(500, 500), Vector2.zero());
+    final a1 = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2.zero(), Vector2.zero()),
+    );
+    final a2 = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2(100, 0), Vector2.zero()),
+    );
+    final a3 = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2(500, 500), Vector2.zero()),
+    );
     await game.add(a1);
     await game.add(a2);
     await game.add(a3);

--- a/test/bullet_pool_test.dart
+++ b/test/bullet_pool_test.dart
@@ -5,6 +5,7 @@ import 'package:flame/components.dart';
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/components/bullet.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -15,9 +16,13 @@ void main() {
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);
 
-    final bullet1 = game.pools.acquireBullet(Vector2.zero(), Vector2(0, -1));
-    game.pools.releaseBullet(bullet1);
-    final bullet2 = game.pools.acquireBullet(Vector2.zero(), Vector2(0, -1));
+    final bullet1 = game.pools.acquire<BulletComponent>(
+      (b) => b.reset(Vector2.zero(), Vector2(0, -1)),
+    );
+    game.pools.release(bullet1);
+    final bullet2 = game.pools.acquire<BulletComponent>(
+      (b) => b.reset(Vector2.zero(), Vector2(0, -1)),
+    );
     expect(identical(bullet1, bullet2), isTrue);
   });
 }

--- a/test/enemy_pool_test.dart
+++ b/test/enemy_pool_test.dart
@@ -7,6 +7,7 @@ import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/storage_service.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:flame/components.dart';
+import 'package:space_game/components/enemy.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -18,9 +19,13 @@ void main() {
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);
 
-    final enemy1 = game.pools.acquireEnemy(Vector2.zero());
-    game.pools.releaseEnemy(enemy1);
-    final enemy2 = game.pools.acquireEnemy(Vector2.zero());
+    final enemy1 = game.pools.acquire<EnemyComponent>(
+      (e) => e.reset(Vector2.zero()),
+    );
+    game.pools.release(enemy1);
+    final enemy2 = game.pools.acquire<EnemyComponent>(
+      (e) => e.reset(Vector2.zero()),
+    );
     expect(identical(enemy1, enemy2), isTrue);
   });
 }

--- a/test/mineral_magnet_test.dart
+++ b/test/mineral_magnet_test.dart
@@ -47,7 +47,9 @@ void main() {
     await game.ready();
 
     final start = Vector2(Constants.playerMagnetRange - 10, 0);
-    final mineral = game.pools.acquireMineral(start.clone());
+    final mineral = game.pools.acquire<MineralComponent>(
+      (m) => m.reset(start.clone()),
+    );
     await game.add(mineral);
     await game.ready();
 
@@ -66,7 +68,9 @@ void main() {
     await game.ready();
 
     final start = Vector2(Constants.playerMagnetRange + 10, 0);
-    final mineral = game.pools.acquireMineral(start.clone());
+    final mineral = game.pools.acquire<MineralComponent>(
+      (m) => m.reset(start.clone()),
+    );
     await game.add(mineral);
     await game.ready();
 

--- a/test/mineral_pickup_test.dart
+++ b/test/mineral_pickup_test.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:space_game/assets.dart';
 import 'package:space_game/components/mineral.dart';
 import 'package:space_game/components/player.dart';
+import 'package:space_game/components/asteroid.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/space_game.dart';
@@ -57,7 +58,9 @@ void main() {
     final game = _TestGame(storage: storage, audio: audio);
     await game.onLoad();
 
-    final asteroid = game.pools.acquireAsteroid(Vector2.zero(), Vector2.zero());
+    final asteroid = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2.zero(), Vector2.zero()),
+    );
     await game.add(asteroid);
     game.update(0);
     final origin = asteroid.position.clone();
@@ -70,8 +73,8 @@ void main() {
       hits++;
     }
     await game.ready();
-    expect(game.pools.mineralPickups.length, hits);
-    for (final mineral in game.pools.mineralPickups) {
+    expect(game.pools.components<MineralComponent>().length, hits);
+    for (final mineral in game.pools.components<MineralComponent>()) {
       final offset = mineral.position - origin;
       expect(offset.length, greaterThan(0));
       expect(offset.length, lessThanOrEqualTo(Constants.mineralDropRadius));
@@ -86,7 +89,9 @@ void main() {
     final game = _TestGame(storage: storage, audio: audio);
     await game.onLoad();
 
-    final mineral = game.pools.acquireMineral(game.player.position.clone());
+    final mineral = game.pools.acquire<MineralComponent>(
+      (m) => m.reset(game.player.position.clone()),
+    );
     final initial = game.minerals.value;
     game.player.onCollisionStart({}, mineral);
 

--- a/test/player_damage_flash_test.dart
+++ b/test/player_damage_flash_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flame/components.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/test/player_shoot_cooldown_test.dart
+++ b/test/player_shoot_cooldown_test.dart
@@ -25,20 +25,27 @@ class _TestPlayer extends PlayerComponent {
 }
 
 class _TestPoolManager extends PoolManager {
-  _TestPoolManager({required super.game, required super.events});
+  _TestPoolManager({required super.events});
 
   final List<_TestBullet> _pool = [];
 
   @override
-  BulletComponent acquireBullet(Vector2 position, Vector2 direction) {
-    final bullet = _pool.isNotEmpty ? _pool.removeLast() : _TestBullet();
-    bullet.reset(position, direction);
-    return bullet;
+  T acquire<T extends Component>(void Function(T) reset) {
+    if (T == BulletComponent) {
+      final bullet = _pool.isNotEmpty ? _pool.removeLast() : _TestBullet();
+      reset(bullet as T);
+      return bullet as T;
+    }
+    return super.acquire<T>(reset);
   }
 
   @override
-  void releaseBullet(BulletComponent bullet) {
-    _pool.add(bullet as _TestBullet);
+  void release<T extends Component>(T component) {
+    if (component is BulletComponent) {
+      _pool.add(component as _TestBullet);
+      return;
+    }
+    super.release(component);
   }
 }
 
@@ -47,8 +54,7 @@ class _TestGame extends SpaceGame {
       : super(storageService: storage, audioService: audio);
 
   @override
-  PoolManager createPoolManager() =>
-      _TestPoolManager(game: this, events: eventBus);
+  PoolManager createPoolManager() => _TestPoolManager(events: eventBus);
 
   @override
   Future<void> onLoad() async {


### PR DESCRIPTION
## Summary
- Refactor PoolManager to register and manage pools generically
- Update components to use generic acquire/release API and central list access
- Keep mining magnet and laser initialisation optimised

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b4162143ec83308d0dd3328d577319