### PR TITLE
Streamline pool event handling for minerals

### DIFF
--- a/lib/components/mineral.dart
+++ b/lib/components/mineral.dart
@@ -42,7 +42,6 @@ class MineralComponent extends SpriteComponent
   @override
   void onMount() {
     super.onMount();
-    game.eventBus.emit(ComponentSpawnEvent<MineralComponent>(this));
   }
 
   @override


### PR DESCRIPTION
## Summary
- rely on asteroid damage to emit mineral spawn events
- remove redundant spawn event from `MineralComponent` on mount

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b4187ed894833090ecc13fff09cdf0