### PR TITLE
Fix keyboard focus after overlays

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -22,6 +22,7 @@ class LifecycleManager {
       ..stop()
       ..start();
     game.resumeEngine();
+    game.focusGame();
   }
 
   void onGameOver() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,12 @@ Future<void> main() async {
   await Assets.load();
   final storage = await StorageService.create();
   final audio = await AudioService.create(storage);
-  final game = SpaceGame(storageService: storage, audioService: audio);
+  final focusNode = FocusNode();
+  final game = SpaceGame(
+    storageService: storage,
+    audioService: audio,
+    focusNode: focusNode,
+  );
   runApp(
     MaterialApp(
       theme: ThemeData(
@@ -31,6 +36,7 @@ Future<void> main() async {
       ),
       home: GameWidget<SpaceGame>(
         game: game,
+        focusNode: focusNode,
         // Automatically request keyboard focus so web players can use WASD
         // without tapping the canvas first.
         autofocus: true,


### PR DESCRIPTION
## Summary
- ensure the game regains keyboard focus via a shared FocusNode
- refocus game when resuming from help or upgrades overlays and on start
- allow keyboard input without clicking canvas after overlays

## Testing
- `./scripts/flutterw test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68b420c6a8fc8330ab9a129e8e16c6a8