### PR TITLE
Restore magnet aura around player

### DIFF
--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -57,6 +57,12 @@ class PlayerComponent extends SpriteComponent
     ..color = const Color(0x66ffffff)
     ..style = PaintingStyle.stroke;
 
+  /// Paint used when drawing the player's magnetic field.
+  final Paint _magnetPaint = Paint()
+    ..color = const Color(0x3300aaff)
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 2;
+
   static final _damageFilter =
       ColorFilter.mode(const Color(0xffff0000), BlendMode.srcATop);
 
@@ -241,6 +247,11 @@ class PlayerComponent extends SpriteComponent
   @override
   void render(Canvas canvas) {
     super.render(canvas);
+    canvas.drawCircle(
+      Offset(size.x / 2, size.y / 2),
+      Constants.playerMagnetRange,
+      _magnetPaint,
+    );
     if (showAutoAimRadius) {
       canvas.drawCircle(
         Offset(size.x / 2, size.y / 2),


### PR DESCRIPTION
## Summary
- render a blue magnetic field around the player ship

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b420f039ac8330b0c1f36103b21781