### PR TITLE
Limit explosion lifetime to 3 seconds

### DIFF
--- a/lib/components/explosion.dart
+++ b/lib/components/explosion.dart
@@ -14,8 +14,22 @@ class ExplosionComponent extends SpriteAnimationComponent {
                 (Constants.spriteScale + Constants.explosionScale),
           ),
           anchor: Anchor.center,
-        ) {
-    removeOnFinish = true;
+        );
+
+  final Timer _timer = Timer(Constants.explosionLifetime);
+
+  @override
+  Future<void> onMount() async {
+    _timer
+      ..onTick = removeFromParent
+      ..start();
+    return super.onMount();
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    _timer.update(dt);
   }
 
   @override
@@ -25,6 +39,7 @@ class ExplosionComponent extends SpriteAnimationComponent {
           .map((path) => Sprite(Flame.images.fromCache(path)))
           .toList(),
       stepTime: Constants.explosionFrameDuration,
+      loop: false,
     );
   }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -65,6 +65,9 @@ class Constants {
   /// Duration of each explosion animation frame in seconds.
   static const double explosionFrameDuration = 0.1;
 
+  /// Seconds an explosion stays on screen before being removed.
+  static const double explosionLifetime = 3;
+
   /// Enemy movement speed in pixels per second.
   static const double enemySpeed = 100;
 

--- a/test/explosion_component_test.dart
+++ b/test/explosion_component_test.dart
@@ -15,7 +15,7 @@ void main() {
     final explosion = ExplosionComponent(position: Vector2.zero());
     await game.add(explosion);
     await game.ready();
-    final total = Constants.explosionFrameDuration * Assets.explosions.length;
+    final total = Constants.explosionLifetime;
     game.update(total + 0.1);
     await game.ready();
     expect(explosion.isMounted, isFalse);


### PR DESCRIPTION
## Summary
- remove explosions automatically after 3 seconds using a timer
- add constant for explosion lifetime and update tests

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b42874811483308d1fe56ce8b2b4bb