### PR TITLE
Fix spacebar shooting by re-registering key on player remount

### DIFF
--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -127,6 +127,11 @@ class PlayerComponent extends SpriteComponent
     paint.color = const Color(0xffffffff);
     paint.colorFilter = null;
     add(CircleHitbox());
+  }
+
+  @override
+  void onMount() {
+    super.onMount();
     keyDispatcher.register(
       LogicalKeyboardKey.space,
       onDown: startShooting,

--- a/test/player_space_key_reregister_test.dart
+++ b/test/player_space_key_reregister_test.dart
@@ -1,0 +1,60 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/components/player.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: 'players/player1.png');
+
+  bool started = false;
+
+  @override
+  void startShooting() {
+    started = true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('player re-registers space key after remount', () async {
+    final keyDispatcher = KeyDispatcher();
+    final joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    final player = _TestPlayer(
+      joystick: joystick,
+      keyDispatcher: keyDispatcher,
+    );
+
+    final recorder = PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawRect(
+        Rect.fromLTWH(0, 0, 1, 1), Paint()..color = const Color(0xffffffff));
+    final image = await recorder.endRecording().toImage(1, 1);
+    Flame.images.add('players/player1.png', image);
+    await player.onLoad();
+
+    player.onMount();
+    player.onRemove();
+    player.onMount();
+
+    keyDispatcher.onKeyEvent(
+      KeyDownEvent(
+        logicalKey: LogicalKeyboardKey.space,
+        physicalKey: PhysicalKeyboardKey.space,
+        timeStamp: Duration.zero,
+      ),
+      {LogicalKeyboardKey.space},
+    );
+
+    expect(player.started, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- register the spacebar each time the player mounts so keyboard shooting works after respawn
- add regression test verifying space key is registered again when the player returns

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b428611638833081ff6415cf6d4d04