### PR TITLE
Ensure service worker activates promptly

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -20,6 +20,10 @@ async function cacheAssets(cache, assets) {
 }
 
 self.addEventListener("install", (event) => {
+  // Activate the new service worker as soon as it's finished installing so
+  // `navigator.serviceWorker.ready` resolves without waiting for a page reload.
+  self.skipWaiting();
+
   event.waitUntil(
     caches.open(CACHE_NAME).then(async (cache) => {
       await cacheAssets(cache, CORE_ASSETS);
@@ -44,14 +48,16 @@ self.addEventListener("install", (event) => {
 });
 
 self.addEventListener("activate", (event) => {
+  // Take control of open pages right away so cached resources are served
+  // during the first load after this service worker activates.
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
-        ),
-      ),
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+      );
+      await self.clients.claim();
+    })(),
   );
 });
 


### PR DESCRIPTION
## Summary
- activate service worker immediately after install and claim clients
- update activation handler to clean old caches and take control quickly

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b429242f688330ac2593489ad0af1f