### PR TITLE
Remove stale shoot.wav asset reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,10 @@ Create the remaining assets locally under `assets/` before running the game:
 - Enemy sprites in `assets/images/enemies/`
 - Asteroid sprites in `assets/images/asteroids/`
 - `assets/images/bullet.png`
-- `assets/audio/shoot.wav`
 
 Simple placeholders can be generated with common tools. For example:
 
 - ImageMagick: `convert -size 32x32 canvas:red assets/images/enemies/enemy1.png`
-- FFmpeg: `ffmpeg -f lavfi -i "sine=frequency=880:duration=0.1" assets/audio/shoot.wav`
 
 Remember to update `assets_manifest.json` and credit any third-party assets in
 `ASSET_CREDITS.md`.

--- a/web/assets_manifest.json
+++ b/web/assets_manifest.json
@@ -10,11 +10,17 @@
     "assets/images/enemies/enemy2.png",
     "assets/images/enemies/enemy3.png",
     "assets/images/enemies/enemy4.png",
+    "assets/images/explosions/explosion1.png",
+    "assets/images/explosions/explosion2.png",
+    "assets/images/explosions/explosion3.png",
+    "assets/images/icons/mineral.png",
     "assets/images/players/player1.png",
     "assets/images/players/player2.png"
   ],
   "audio": [
-    "assets/audio/shoot.wav"
+    "assets/audio/explosion.mp3",
+    "assets/audio/laser-bullet.mp3",
+    "assets/audio/mining-laser-continuous.mp3"
   ],
   "fonts": []
 }


### PR DESCRIPTION
## Summary
- sync web asset manifest with current game assets to remove nonexistent shoot.wav
- drop README instructions for generating obsolete shoot.wav placeholder

## Testing
- `scripts/flutterw test` *(fails: hangs while loading upgrades_overlay_test.dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b42e7540f88330bec0370495b94aaa