### PR TITLE
Loop explosion animation for timed bursts

### DIFF
--- a/lib/components/explosion.dart
+++ b/lib/components/explosion.dart
@@ -39,7 +39,7 @@ class ExplosionComponent extends SpriteAnimationComponent {
           .map((path) => Sprite(Flame.images.fromCache(path)))
           .toList(),
       stepTime: Constants.explosionFrameDuration,
-      loop: false,
+      loop: true,
     );
   }
 }

--- a/lib/components/explosion.md
+++ b/lib/components/explosion.md
@@ -2,5 +2,5 @@
 
 Short-lived animation played when a ship is destroyed.
 
-- Displays a three-frame explosion sprite animation.
-- Removes itself from the game once the animation completes.
+- Displays a looping explosion sprite animation cycling through three frames.
+- Removes itself from the game after `Constants.explosionLifetime` seconds.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -66,7 +66,7 @@ class Constants {
   static const double explosionScale = 0;
 
   /// Duration of each explosion animation frame in seconds.
-  static const double explosionFrameDuration = 0.1;
+  static const double explosionFrameDuration = 0.05;
 
   /// Seconds an explosion stays on screen before being removed.
   static const double explosionLifetime = 3;

--- a/test/explosion_component_test.dart
+++ b/test/explosion_component_test.dart
@@ -9,7 +9,7 @@ import 'package:space_game/constants.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('removes itself after animation completes', () async {
+  test('removes itself after lifetime expires', () async {
     await Flame.images.loadAll(Assets.explosions);
     final game = FlameGame();
     final explosion = ExplosionComponent(position: Vector2.zero());


### PR DESCRIPTION
## Summary
- Loop explosion sprite animation for the entire lifetime
- Speed up explosion frame rate for faster cycling
- Update docs and tests to reflect looping behavior

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b42f0554f883309e53c6a3885a8c3b