### PR TITLE
Reuse shoot sound via audio pool

### DIFF
--- a/lib/services/audio_service.md
+++ b/lib/services/audio_service.md
@@ -8,5 +8,7 @@ Lightweight wrapper around `flame_audio`.
 - Play one-shot effects for actions like shooting or explosions.
 - Expose a mute toggle persisted via `StorageService`.
 - Provide simple methods like `playShoot()` or `playExplosion()`.
+- Reuse the shoot sound via a web-only `AudioPool` to avoid network
+  fetches on rapid fire.
 
 See [../../PLAN.md](../../PLAN.md) for polish goals.


### PR DESCRIPTION
## Summary
- cache the shoot sound with an AudioPool so rapid fire reuses loaded audio on web
- document the AudioService's web-only sound pooling

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b42eb9a0588330a754673d2e2eac8a