### PR TITLE
Clear lingering explosions on restart

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -1,4 +1,5 @@
 import '../game/space_game.dart';
+import '../components/explosion.dart';
 
 /// Handles start, menu, and game over transitions.
 class LifecycleManager {
@@ -9,6 +10,12 @@ class LifecycleManager {
   void onStart() {
     game.scoreService.reset();
     game.pools.clear();
+    // Remove any lingering explosions from a previous session.
+    for (final explosion in List<ExplosionComponent>.from(
+      game.children.whereType<ExplosionComponent>(),
+    )) {
+      explosion.removeFromParent();
+    }
     if (!game.player.isMounted) {
       game.add(game.player);
       game.camera.follow(game.player);

--- a/test/restart_clears_explosions_test.dart
+++ b/test/restart_clears_explosions_test.dart
@@ -1,0 +1,46 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/explosion.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('restarting clears active explosions', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.explosions]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    audio.muted.value = true;
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+
+    game.startGame();
+    for (var i = 0; i < Constants.playerMaxHealth; i++) {
+      game.hitPlayer();
+    }
+    await game.ready();
+    expect(game.children.whereType<ExplosionComponent>(), isNotEmpty);
+
+    game.startGame();
+    await game.ready();
+    expect(game.children.whereType<ExplosionComponent>(), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- remove leftover ExplosionComponents when starting a new session
- add regression test ensuring explosions are cleared on restart

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b42f27f31883308d2e687824116e37