### PR TITLE
Reduce mining laser SFX volume

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -33,7 +33,7 @@ class Constants {
   static const double miningPulseInterval = 0.5;
 
   /// Volume for the mining laser sound effect (0-1).
-  static const double miningLaserVolume = 0.5;
+  static const double miningLaserVolume = 0.25;
 
   /// Starting health for the player.
   static const int playerMaxHealth = 3;


### PR DESCRIPTION
## Summary
- Lower mining laser loop volume to make the sound effect quieter

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b42f64e1748330ae195680219735ef