### PR TITLE
Reduce explosion lifetime to 2s

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -69,7 +69,7 @@ class Constants {
   static const double explosionFrameDuration = 0.05;
 
   /// Seconds an explosion stays on screen before being removed.
-  static const double explosionLifetime = 3;
+  static const double explosionLifetime = 2;
 
   /// Enemy movement speed in pixels per second.
   static const double enemySpeed = 100;


### PR DESCRIPTION
## Summary
- shorten explosionLifetime constant to 2 seconds

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b4337cc64c8330a49ad06903542eb1