### PR TITLE
feat: rename magnet field to Tractor Aura

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -19,7 +19,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   groups
 - Auto-firing mining laser targets asteroids while the main cannon locks onto
   the closest enemy
-- A blue magnetic aura around the ship pulls in loose mineral pickups
+- A blue Tractor Aura around the ship pulls in nearby pickups
 - Minerals feed a broad upgrade tree for weapons and ship systems in later
   milestones
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dedicated server or NAT traversal.
   closest foe
 - Asteroids can be mined for mineral pickups using an auto-targeting laser;
   each hit drops a mineral nearby
-- A blue magnetic aura draws nearby mineral pickups toward the ship
+- A blue Tractor Aura draws nearby pickups toward the ship
 - Single endless level with quick restart
 - Player health, minerals and high score displayed in the HUD; health drops on
   collision and minerals increase when collecting pickups from mined asteroids

--- a/TASKS.md
+++ b/TASKS.md
@@ -79,7 +79,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [ ] Add a mining laser that automatically targets and fires at nearby
       asteroids.
 - [x] Drop mineral pickups from asteroids and track the player's total.
-- [x] Pull nearby minerals toward the player with a magnetic field.
+- [x] Pull nearby pickups toward the player with a Tractor Aura.
 - [x] Auto-aim the primary weapon at the closest enemy when stationary.
 - [x] Refine auto-aim targeting behaviour for smoother updates.
 - [ ] Design a broad upgrade system where minerals purchase new weapon and ship

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -2,7 +2,7 @@
 
 Gameplay entities and reusable pieces.
 
-- Includes player, enemy, asteroid, bullet, mineral pickup and magnet
+- Includes player, enemy, asteroid, bullet and mineral pickup
   components.
 - Each extends a Flame component and mixes in `HasGameReference<SpaceGame>`
   when it needs game context.
@@ -31,8 +31,8 @@ Gameplay entities and reusable pieces.
   asteroids with a widening pulse beam.
 - [MineralComponent](mineral.md) – collectible dropped whenever an asteroid is
   damaged that increases the player's mineral total when picked up.
-- Each mineral independently homes toward the player when within magnet range,
-  removing the need for a separate magnet component.
+- Each mineral independently homes toward the player when within the Tractor
+  Aura, removing the need for a separate component.
 - [Starfield](starfield.md) – parallax background built with Flame's
   `ParallaxComponent`.
 - [ExplosionComponent](explosion.md) – short animation and sound played when

--- a/lib/components/mineral.dart
+++ b/lib/components/mineral.dart
@@ -50,12 +50,12 @@ class MineralComponent extends SpriteComponent
     final toPlayer = game.player.position - position;
     final distanceSquared = toPlayer.length2;
     final rangeSquared =
-        Constants.playerMagnetRange * Constants.playerMagnetRange;
+        Constants.playerTractorAuraRadius * Constants.playerTractorAuraRadius;
     if (distanceSquared == 0 || distanceSquared > rangeSquared) {
       return;
     }
     final distance = math.sqrt(distanceSquared);
-    position += toPlayer / distance * Constants.mineralMagnetSpeed * dt;
+    position += toPlayer / distance * Constants.tractorAuraPullSpeed * dt;
   }
 
   @override

--- a/lib/components/mineral.md
+++ b/lib/components/mineral.md
@@ -9,7 +9,7 @@ Collectible pickup dropped by destroyed asteroids.
 - Uses the `mineral.png` sprite from `assets.dart` and values from
   `constants.dart`.
 - Instances are pooled by `SpaceGame` and tracked in `mineralPickups`.
-- When inside the player's magnetic field, drifts toward the ship for easier
+- When inside the player's Tractor Aura, drifts toward the ship for easier
   collection.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -57,11 +57,8 @@ class PlayerComponent extends SpriteComponent
     ..color = const Color(0x66ffffff)
     ..style = PaintingStyle.stroke;
 
-  /// Paint used when drawing the player's magnetic field.
-  final Paint _magnetPaint = Paint()
-    ..color = const Color(0x3300aaff)
-    ..style = PaintingStyle.stroke
-    ..strokeWidth = 2;
+  /// Paint used when drawing the player's Tractor Aura.
+  final Paint _tractorAuraPaint = Paint()..style = PaintingStyle.fill;
 
   static final _damageFilter =
       ColorFilter.mode(const Color(0xffff0000), BlendMode.srcATop);
@@ -252,10 +249,20 @@ class PlayerComponent extends SpriteComponent
   @override
   void render(Canvas canvas) {
     super.render(canvas);
+    final auraCenter = Offset(size.x / 2, size.y / 2);
+    final auraRadius = Constants.playerTractorAuraRadius;
+    _tractorAuraPaint.shader = Gradient.radial(
+      auraCenter,
+      auraRadius,
+      [
+        const Color(0x5500aaff),
+        const Color(0x0000aaff),
+      ],
+    );
     canvas.drawCircle(
-      Offset(size.x / 2, size.y / 2),
-      Constants.playerMagnetRange,
-      _magnetPaint,
+      auraCenter,
+      auraRadius,
+      _tractorAuraPaint,
     );
     if (showAutoAimRadius) {
       canvas.drawCircle(

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -11,7 +11,7 @@ Controllable ship for the player.
   and briefly tints the ship red to show damage.
 - When stationary, periodically rotates to face the nearest enemy within range.
 - Collects `MineralComponent`s on contact to increase the mineral counter.
-- A blue magnetic aura pulls nearby mineral pickups toward the ship.
+- A blue Tractor Aura pulls nearby pickups toward the ship.
 - Pulls sprites from `assets.dart` and tuning values from `constants.dart`.
 - Uses `CircleHitbox` and `HasGameReference<SpaceGame>`.
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -41,11 +41,11 @@ class Constants {
   /// Seconds that the player sprite flashes red after taking damage.
   static const double playerDamageFlashDuration = 0.2;
 
-  /// Radius of the player's mineral attractor field in pixels.
-  static const double playerMagnetRange = 150;
+  /// Radius of the player's Tractor Aura in pixels.
+  static const double playerTractorAuraRadius = 150;
 
-  /// Speed minerals move toward the player within the attractor field.
-  static const double mineralMagnetSpeed = 200;
+  /// Speed pickups move toward the player within the Tractor Aura.
+  static const double tractorAuraPullSpeed = 200;
 
   /// Bullet travel speed in pixels per second.
   static const double bulletSpeed = 400;

--- a/test/tractor_aura_test.dart
+++ b/test/tractor_aura_test.dart
@@ -37,7 +37,7 @@ class _TestGame extends SpaceGame {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('mineral moves toward player within magnet range', () async {
+  test('pickup moves toward player within Tractor Aura radius', () async {
     SharedPreferences.setMockInitialValues({});
     await Flame.images.loadAll([Assets.mineralIcon, ...Assets.players]);
     final storage = await StorageService.create();
@@ -46,19 +46,19 @@ void main() {
     await game.onLoad();
     await game.ready();
 
-    final start = Vector2(Constants.playerMagnetRange - 10, 0);
-    final mineral = game.pools.acquire<MineralComponent>(
+    final start = Vector2(Constants.playerTractorAuraRadius - 10, 0);
+    final pickup = game.pools.acquire<MineralComponent>(
       (m) => m.reset(start.clone()),
     );
-    await game.add(mineral);
+    await game.add(pickup);
     await game.ready();
 
-    final before = mineral.position.clone();
+    final before = pickup.position.clone();
     game.update(0.1);
-    expect(mineral.position.x, lessThan(before.x));
+    expect(pickup.position.x, lessThan(before.x));
   });
 
-  test('mineral outside magnet range stays put', () async {
+  test('pickup outside Tractor Aura radius stays put', () async {
     SharedPreferences.setMockInitialValues({});
     await Flame.images.loadAll([Assets.mineralIcon, ...Assets.players]);
     final storage = await StorageService.create();
@@ -67,15 +67,15 @@ void main() {
     await game.onLoad();
     await game.ready();
 
-    final start = Vector2(Constants.playerMagnetRange + 10, 0);
-    final mineral = game.pools.acquire<MineralComponent>(
+    final start = Vector2(Constants.playerTractorAuraRadius + 10, 0);
+    final pickup = game.pools.acquire<MineralComponent>(
       (m) => m.reset(start.clone()),
     );
-    await game.add(mineral);
+    await game.add(pickup);
     await game.ready();
 
-    final before = mineral.position.clone();
+    final before = pickup.position.clone();
     game.update(0.1);
-    expect(mineral.position, equals(before));
+    expect(pickup.position, equals(before));
   });
 }


### PR DESCRIPTION
## Summary
- rename magnetic field features to "Tractor Aura"
- render Tractor Aura with blue radial gradient
- update docs and tests for new, more general terminology

## Testing
- `npx --yes markdownlint-cli README.md PLAN.md TASKS.md lib/components/README.md lib/components/mineral.md lib/components/player.md`
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b4334916a48330980d5989e841f0d8