### PR TITLE
Fix missing ship after restarting game

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -62,8 +62,8 @@ class SpaceGame extends FlameGame
   late final GameStateMachine stateMachine;
 
   late final KeyDispatcher keyDispatcher;
-  late final PlayerComponent player;
-  late final MiningLaserComponent miningLaser;
+  late PlayerComponent player;
+  late MiningLaserComponent miningLaser;
   late final JoystickComponent joystick;
   late final HudButtonComponent fireButton;
   late final EnemySpawner enemySpawner;


### PR DESCRIPTION
## Summary
- Recreate player component when starting a new game if the previous one was removed
- Rebuild mining laser and update fire button callbacks for the new player
- Allow `SpaceGame` to reassign player and mining laser instances

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b52a9e25d88330abb6d98249b82f05