### PR TITLE
Snap camera to player on start

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -27,7 +27,6 @@ class LifecycleManager {
       )..reset();
       game.player = player;
       game.add(player);
-      game.camera.follow(player);
       // Recreate the mining laser for the new player.
       game.miningLaser.removeFromParent();
       game.miningLaser = MiningLaserComponent(player: player);
@@ -39,8 +38,8 @@ class LifecycleManager {
     } else {
       game.player.setSprite(game.selectedPlayerSprite);
       game.player.reset();
-      game.camera.follow(game.player);
     }
+    game.camera.follow(game.player, snap: true);
     game.enemySpawner
       ..stop()
       ..start();

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -135,7 +135,7 @@ class SpaceGame extends FlameGame
         ),
         considerViewport: true,
       )
-      ..follow(player);
+      ..follow(player, snap: true);
     miningLaser = MiningLaserComponent(player: player);
     add(miningLaser);
 

--- a/test/camera_start_center_test.dart
+++ b/test/camera_start_center_test.dart
@@ -1,0 +1,36 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('camera centers on player on startup', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.explosions]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+
+    expect(game.player.position, Constants.worldSize / 2);
+    expect(game.camera.viewfinder.position, game.player.position);
+  });
+}


### PR DESCRIPTION
## Summary
- snap game camera to player on load and restart
- verify camera centers on player at startup

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b561dd93ac83308c9d5929cbb3930a