### PR TITLE
Remove lingering player on restart

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -18,27 +18,29 @@ class LifecycleManager {
     )) {
       explosion.removeFromParent();
     }
-    if (game.player.isRemoving || !game.player.isMounted) {
-      // Previous player is pending removal; create a fresh instance.
-      final player = PlayerComponent(
-        joystick: game.joystick,
-        keyDispatcher: game.keyDispatcher,
-        spritePath: game.selectedPlayerSprite,
-      )..reset();
-      game.player = player;
-      game.add(player);
-      // Recreate the mining laser for the new player.
-      game.miningLaser.removeFromParent();
-      game.miningLaser = MiningLaserComponent(player: player);
-      game.add(game.miningLaser);
-      // Update fire button callbacks.
-      game.fireButton
-        ..onPressed = player.startShooting
-        ..onReleased = player.stopShooting;
-    } else {
-      game.player.setSprite(game.selectedPlayerSprite);
-      game.player.reset();
+    // Ensure any previous player instances are fully removed before starting.
+    for (final player in List<PlayerComponent>.from(
+      game.children.whereType<PlayerComponent>(),
+    )) {
+      player.removeFromParent();
     }
+
+    // Create a fresh player for the new session.
+    final player = PlayerComponent(
+      joystick: game.joystick,
+      keyDispatcher: game.keyDispatcher,
+      spritePath: game.selectedPlayerSprite,
+    )..reset();
+    game.player = player;
+    game.add(player);
+    // Recreate the mining laser for the new player.
+    game.miningLaser.removeFromParent();
+    game.miningLaser = MiningLaserComponent(player: player);
+    game.add(game.miningLaser);
+    // Update fire button callbacks.
+    game.fireButton
+      ..onPressed = player.startShooting
+      ..onReleased = player.stopShooting;
     game.camera.follow(game.player, snap: true);
     game.enemySpawner
       ..stop()

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -116,7 +116,7 @@ class SpaceGame extends FlameGame
     add(joystick);
 
     _starfield = await createStarfieldParallax(Constants.worldSize);
-    add(_starfield!);
+    await add(_starfield!);
 
     player = PlayerComponent(
       joystick: joystick,

--- a/test/restart_removes_old_player_test.dart
+++ b/test/restart_removes_old_player_test.dart
@@ -1,0 +1,49 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('restarting removes the previous player instance', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.explosions]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+
+    game.startGame();
+    game.player.position.setValues(20, 20);
+    // Kill the player.
+    for (var i = 0; i < Constants.playerMaxHealth; i++) {
+      game.hitPlayer();
+    }
+    expect(game.stateMachine.state, GameState.gameOver);
+
+    // Restart the game and ensure only one player exists at the spawn point.
+    game.startGame();
+    final players = game.children.whereType<PlayerComponent>().toList();
+    expect(players.length, 1);
+    expect(players.first.position, Constants.worldSize / 2);
+  });
+}


### PR DESCRIPTION
## Summary
- Ensure previous player components are removed before starting a new session to prevent duplicates
- Await starfield loading to avoid late initialization during restart
- Add regression test verifying only one player exists after restart

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b5685bd9c48330b2859dae2374c866