### PR TITLE
refactor: modularize player and centralize lifecycle

### DIFF
--- a/lib/components/auto_aim_behavior.dart
+++ b/lib/components/auto_aim_behavior.dart
@@ -1,0 +1,34 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart';
+
+import '../constants.dart';
+import '../game/space_game.dart';
+import '../util/nearest_component.dart';
+import 'enemy.dart';
+import 'player.dart';
+
+/// Automatically rotates the player toward nearby enemies when idle.
+class AutoAimBehavior extends Component
+    with HasGameReference<SpaceGame>, ParentIsA<PlayerComponent> {
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (parent.isMoving) {
+      return;
+    }
+    final enemies = game.pools.components<EnemyComponent>();
+    final target = enemies.findClosest(
+      parent.position,
+      Constants.playerAutoAimRange,
+    );
+    if (target != null) {
+      parent.targetAngle = math.atan2(
+            target.position.y - parent.position.y,
+            target.position.x - parent.position.x,
+          ) +
+          math.pi / 2;
+      parent.updateRotation(dt);
+    }
+  }
+}

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -5,16 +5,21 @@ import 'package:flame/components.dart';
 
 import '../assets.dart';
 import '../constants.dart';
-import '../game/event_bus.dart';
 import '../game/space_game.dart';
 import 'damageable.dart';
+import 'offscreen_despawn.dart';
+import 'spawn_remove_emitter.dart';
 
 /// Short-lived projectile fired by the player.
 ///
 /// Instances are pooled by [SpaceGame] to reduce garbage collection. Call
 /// [reset] before adding to the game to initialise position and direction.
 class BulletComponent extends SpriteComponent
-    with HasGameReference<SpaceGame>, CollisionCallbacks {
+    with
+        HasGameReference<SpaceGame>,
+        CollisionCallbacks,
+        SpawnRemoveEmitter<BulletComponent>,
+        OffscreenDespawn {
   BulletComponent()
       : super(size: Vector2.all(Constants.bulletSize), anchor: Anchor.center);
 
@@ -36,27 +41,10 @@ class BulletComponent extends SpriteComponent
   }
 
   @override
-  void onMount() {
-    super.onMount();
-    game.eventBus.emit(ComponentSpawnEvent<BulletComponent>(this));
-  }
-
-  @override
   void update(double dt) {
     super.update(dt);
     position += _direction * Constants.bulletSpeed * dt;
-    if (position.y < -size.y ||
-        position.y > Constants.worldSize.y + size.y ||
-        position.x < -size.x ||
-        position.x > Constants.worldSize.x + size.x) {
-      removeFromParent();
-    }
-  }
-
-  @override
-  void onRemove() {
-    super.onRemove();
-    game.eventBus.emit(ComponentRemoveEvent<BulletComponent>(this));
+    removeIfOffscreen();
   }
 
   @override

--- a/lib/components/mineral.dart
+++ b/lib/components/mineral.dart
@@ -5,16 +5,20 @@ import 'package:flame/components.dart';
 
 import '../assets.dart';
 import '../constants.dart';
-import '../game/event_bus.dart';
 import '../game/space_game.dart';
 import '../util/collision_utils.dart';
+import 'spawn_remove_emitter.dart';
 
 /// Collectible mineral dropped by destroyed asteroids.
 ///
 /// Instances are pooled by [SpaceGame] to avoid repeated allocations. Call
 /// [reset] before adding to the game to set its position and value.
 class MineralComponent extends SpriteComponent
-    with HasGameReference<SpaceGame>, CollisionCallbacks, SolidBody {
+    with
+        HasGameReference<SpaceGame>,
+        CollisionCallbacks,
+        SolidBody,
+        SpawnRemoveEmitter<MineralComponent> {
   MineralComponent()
       : super(
           size: Vector2.all(
@@ -40,14 +44,11 @@ class MineralComponent extends SpriteComponent
   }
 
   @override
-  void onMount() {
-    super.onMount();
-  }
-
-  @override
   void update(double dt) {
     super.update(dt);
-    final toPlayer = game.player.position - position;
+    final playerPos =
+        game.targetingService.playerPosition ?? game.player.position;
+    final toPlayer = playerPos - position;
     final distanceSquared = toPlayer.length2;
     final rangeSquared =
         Constants.playerTractorAuraRadius * Constants.playerTractorAuraRadius;
@@ -56,11 +57,5 @@ class MineralComponent extends SpriteComponent
     }
     final distance = math.sqrt(distanceSquared);
     position += toPlayer / distance * Constants.tractorAuraPullSpeed * dt;
-  }
-
-  @override
-  void onRemove() {
-    super.onRemove();
-    game.eventBus.emit(ComponentRemoveEvent<MineralComponent>(this));
   }
 }

--- a/lib/components/offscreen_despawn.dart
+++ b/lib/components/offscreen_despawn.dart
@@ -1,0 +1,19 @@
+import 'package:flame/components.dart';
+
+import '../constants.dart';
+
+/// Mixin that removes a component once it leaves the world bounds.
+///
+/// Call [removeIfOffscreen] during [update] to automatically clean up
+/// entities that drift outside the playable area.
+mixin OffscreenDespawn on PositionComponent {
+  /// Removes the component if it moves outside the world extents.
+  void removeIfOffscreen() {
+    if (y < -height ||
+        y > Constants.worldSize.y + height ||
+        x < -width ||
+        x > Constants.worldSize.x + width) {
+      removeFromParent();
+    }
+  }
+}

--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -1,0 +1,142 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart';
+import 'package:flutter/services.dart';
+
+import '../constants.dart';
+import '../game/key_dispatcher.dart';
+import '../game/space_game.dart';
+import 'bullet.dart';
+import 'player.dart';
+
+/// Handles keyboard/joystick input, movement and shooting for the player.
+class PlayerInputBehavior extends Component
+    with HasGameReference<SpaceGame>, ParentIsA<PlayerComponent> {
+  PlayerInputBehavior({
+    required this.joystick,
+    required this.keyDispatcher,
+  });
+
+  final JoystickComponent joystick;
+  final KeyDispatcher keyDispatcher;
+
+  final Vector2 _keyboardDirection = Vector2.zero();
+  double _shootCooldown = 0;
+  bool _isShooting = false;
+
+  @override
+  void onMount() {
+    super.onMount();
+    keyDispatcher.register(
+      LogicalKeyboardKey.space,
+      onDown: startShooting,
+      onUp: stopShooting,
+    );
+  }
+
+  @override
+  void onRemove() {
+    keyDispatcher.unregister(LogicalKeyboardKey.space);
+    super.onRemove();
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    _applyCooldown(dt);
+    if (_isShooting) {
+      shoot();
+    }
+    final moved = _processInput(dt);
+    if (moved) {
+      parent.updateRotation(dt);
+    }
+  }
+
+  /// Clears movement and shooting state for a fresh start.
+  void reset() {
+    _shootCooldown = 0;
+    _keyboardDirection.setZero();
+    _isShooting = false;
+  }
+
+  void _applyCooldown(double dt) {
+    if (_shootCooldown > 0) {
+      _shootCooldown -= dt;
+    }
+  }
+
+  bool _processInput(double dt) {
+    parent.isMoving = false;
+    _keyboardDirection
+      ..setZero()
+      ..x += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyA,
+        LogicalKeyboardKey.arrowLeft,
+      ])
+          ? -1
+          : 0
+      ..x += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyD,
+        LogicalKeyboardKey.arrowRight,
+      ])
+          ? 1
+          : 0
+      ..y += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyW,
+        LogicalKeyboardKey.arrowUp,
+      ])
+          ? -1
+          : 0
+      ..y += keyDispatcher.isAnyPressed([
+        LogicalKeyboardKey.keyS,
+        LogicalKeyboardKey.arrowDown,
+      ])
+          ? 1
+          : 0;
+
+    var input =
+        joystick.delta.isZero() ? _keyboardDirection : joystick.relativeDelta;
+    if (!input.isZero()) {
+      input = input.normalized();
+      parent.position += input * Constants.playerSpeed * dt;
+      final halfSize = Vector2.all(parent.size.x / 2);
+      parent.position.clamp(
+        halfSize,
+        Constants.worldSize - halfSize,
+      );
+      parent.targetAngle = math.atan2(input.y, input.x) + math.pi / 2;
+      parent.isMoving = true;
+      return true;
+    }
+    return false;
+  }
+
+  /// Fires a bullet from the player's current position.
+  void shoot() {
+    if (_shootCooldown > 0) {
+      return;
+    }
+    final direction = Vector2(
+      math.cos(parent.angle - math.pi / 2),
+      math.sin(parent.angle - math.pi / 2),
+    );
+    final bullet = game.pools.acquire<BulletComponent>(
+      (b) => b.reset(parent.position.clone(), direction),
+    );
+    game.add(bullet);
+    game.audioService.playShoot();
+    _shootCooldown = Constants.bulletCooldown;
+  }
+
+  /// Begins continuous shooting and fires immediately.
+  void startShooting() {
+    _isShooting = true;
+    shoot();
+  }
+
+  /// Stops continuous shooting.
+  void stopShooting() {
+    _isShooting = false;
+  }
+}

--- a/lib/components/spawn_remove_emitter.dart
+++ b/lib/components/spawn_remove_emitter.dart
@@ -1,0 +1,24 @@
+import 'package:flame/components.dart';
+
+import '../game/event_bus.dart';
+import '../game/space_game.dart';
+
+/// Mixin that emits spawn and remove events to the game's [GameEventBus].
+///
+/// When a component is mounted or removed, corresponding [ComponentSpawnEvent]
+/// and [ComponentRemoveEvent] events are fired. This centralises event bus
+/// wiring for pooled components.
+mixin SpawnRemoveEmitter<T extends Component>
+    on Component, HasGameReference<SpaceGame> {
+  @override
+  void onMount() {
+    super.onMount();
+    game.eventBus.emit(ComponentSpawnEvent<T>(this as T));
+  }
+
+  @override
+  void onRemove() {
+    super.onRemove();
+    game.eventBus.emit(ComponentRemoveEvent<T>(this as T));
+  }
+}

--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -7,51 +7,58 @@ import 'package:flutter/painting.dart' show ImageRepeat;
 
 import '../constants.dart';
 
-/// Creates a parallax starfield using Flame's [ParallaxComponent].
-///
-/// The starfield consists of three layers that scroll at different
-/// speeds to give a depth effect. Stars are drawn once into off-screen
-/// images and the parallax system handles the scrolling and wrapping.
-Future<ParallaxComponent> createStarfieldParallax(Vector2 size) async {
-  final random = Random();
-  final paint = Paint();
+/// Persistent parallax starfield that caches its layers after the first build.
+class StarfieldComponent extends ParallaxComponent {
+  StarfieldComponent() : super(priority: -1);
 
-  Future<ParallaxImage> buildLayer() async {
-    final recorder = PictureRecorder();
-    final canvas = Canvas(recorder);
-    for (var i = 0; i < Constants.starsPerLayer; i++) {
-      final brightness = 128 + random.nextInt(128);
-      paint.color = Color.fromARGB(255, brightness, brightness, brightness);
-      final position = Offset(
-        random.nextDouble() * size.x,
-        random.nextDouble() * size.y,
-      );
-      final radius = random.nextDouble() * Constants.starMaxSize + 1;
-      canvas.drawCircle(position, radius, paint);
-    }
-    final picture = recorder.endRecording();
-    final image = await picture.toImage(size.x.toInt(), size.y.toInt());
-    return ParallaxImage(image, repeat: ImageRepeat.repeat);
+  static Parallax? _cachedParallax;
+
+  @override
+  Future<void> onLoad() async {
+    size = Constants.worldSize;
+    parallax = _cachedParallax ??= await _buildParallax(size);
   }
 
-  final slowLayer = ParallaxLayer(
-    await buildLayer(),
-    velocityMultiplier: Vector2.all(1),
-  );
-  final mediumLayer = ParallaxLayer(
-    await buildLayer(),
-    velocityMultiplier:
-        Vector2.all(Constants.starSpeedMedium / Constants.starSpeedSlow),
-  );
-  final fastLayer = ParallaxLayer(
-    await buildLayer(),
-    velocityMultiplier:
-        Vector2.all(Constants.starSpeedFast / Constants.starSpeedSlow),
-  );
+  static Future<Parallax> _buildParallax(Vector2 size) async {
+    final random = Random();
+    final paint = Paint();
 
-  final parallax = Parallax(
-    [slowLayer, mediumLayer, fastLayer],
-    baseVelocity: Vector2(0, Constants.starSpeedSlow),
-  );
-  return ParallaxComponent(parallax: parallax, priority: -1);
+    Future<ParallaxImage> buildLayer() async {
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      for (var i = 0; i < Constants.starsPerLayer; i++) {
+        final brightness = 128 + random.nextInt(128);
+        paint.color = Color.fromARGB(255, brightness, brightness, brightness);
+        final position = Offset(
+          random.nextDouble() * size.x,
+          random.nextDouble() * size.y,
+        );
+        final radius = random.nextDouble() * Constants.starMaxSize + 1;
+        canvas.drawCircle(position, radius, paint);
+      }
+      final picture = recorder.endRecording();
+      final image = await picture.toImage(size.x.toInt(), size.y.toInt());
+      return ParallaxImage(image, repeat: ImageRepeat.repeat);
+    }
+
+    final slowLayer = ParallaxLayer(
+      await buildLayer(),
+      velocityMultiplier: Vector2.all(1),
+    );
+    final mediumLayer = ParallaxLayer(
+      await buildLayer(),
+      velocityMultiplier:
+          Vector2.all(Constants.starSpeedMedium / Constants.starSpeedSlow),
+    );
+    final fastLayer = ParallaxLayer(
+      await buildLayer(),
+      velocityMultiplier:
+          Vector2.all(Constants.starSpeedFast / Constants.starSpeedSlow),
+    );
+
+    return Parallax(
+      [slowLayer, mediumLayer, fastLayer],
+      baseVelocity: Vector2(0, Constants.starSpeedSlow),
+    );
+  }
 }

--- a/lib/components/tractor_aura_renderer.dart
+++ b/lib/components/tractor_aura_renderer.dart
@@ -1,0 +1,27 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+
+import '../constants.dart';
+import 'player.dart';
+
+/// Renders the player's tractor aura as a radial gradient.
+class TractorAuraRenderer extends Component with ParentIsA<PlayerComponent> {
+  final Paint _paint = Paint()..style = PaintingStyle.fill;
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    final auraCenter = Offset(parent.size.x / 2, parent.size.y / 2);
+    final auraRadius = Constants.playerTractorAuraRadius;
+    _paint.shader = Gradient.radial(
+      auraCenter,
+      auraRadius,
+      [
+        const Color(0x5500aaff),
+        const Color(0x0000aaff),
+      ],
+    );
+    canvas.drawCircle(auraCenter, auraRadius, _paint);
+  }
+}

--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import '../game/space_game.dart';
 import '../components/explosion.dart';
 import '../components/player.dart';
@@ -26,7 +28,12 @@ class LifecycleManager {
         spritePath: game.selectedPlayerSprite,
       )..reset();
       game.player = player;
-      game.add(player);
+      final addResult = game.add(player);
+      if (addResult is Future<void>) {
+        unawaited(addResult.then((_) => player.resetInput()));
+      } else {
+        player.resetInput();
+      }
       game.camera.follow(player);
       // Recreate the mining laser for the new player.
       game.miningLaser.removeFromParent();

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -22,6 +22,7 @@ import '../services/score_service.dart';
 import '../services/overlay_service.dart';
 import '../services/storage_service.dart';
 import '../services/audio_service.dart';
+import '../services/targeting_service.dart';
 import '../ui/help_overlay.dart';
 import '../ui/upgrades_overlay.dart';
 import 'event_bus.dart';
@@ -46,6 +47,7 @@ class SpaceGame extends FlameGame
         scoreService = ScoreService(storageService: storageService) {
     debugMode = kDebugMode;
     pools = createPoolManager();
+    targetingService = TargetingService(eventBus);
   }
 
   /// Handles persistence for the high score.
@@ -72,7 +74,8 @@ class SpaceGame extends FlameGame
   late final LifecycleManager lifecycle;
   late final game_shortcuts.ShortcutManager shortcuts;
   final GameEventBus eventBus = GameEventBus();
-  ParallaxComponent? _starfield;
+  late final TargetingService targetingService;
+  StarfieldComponent? _starfield;
   FpsTextComponent? _fpsText;
 
   ValueNotifier<int> get score => scoreService.score;
@@ -115,8 +118,8 @@ class SpaceGame extends FlameGame
     );
     add(joystick);
 
-    _starfield = await createStarfieldParallax(Constants.worldSize);
-    add(_starfield!);
+    _starfield = StarfieldComponent();
+    await add(_starfield!);
 
     player = PlayerComponent(
       joystick: joystick,

--- a/lib/services/targeting_service.dart
+++ b/lib/services/targeting_service.dart
@@ -1,0 +1,23 @@
+import 'package:flame/components.dart';
+
+import '../components/player.dart';
+import '../game/event_bus.dart';
+
+/// Tracks key targets like the player for AI systems to query.
+class TargetingService {
+  TargetingService(GameEventBus events) {
+    events.on<ComponentSpawnEvent<PlayerComponent>>().listen((event) {
+      _player = event.component;
+    });
+    events.on<ComponentRemoveEvent<PlayerComponent>>().listen((event) {
+      if (_player == event.component) {
+        _player = null;
+      }
+    });
+  }
+
+  PlayerComponent? _player;
+
+  /// Current position of the tracked player, if any.
+  Vector2? get playerPosition => _player?.position;
+}

--- a/test/asteroid_damage_limit_test.dart
+++ b/test/asteroid_damage_limit_test.dart
@@ -22,6 +22,7 @@ class _TestPlayer extends PlayerComponent {
 
   @override
   Future<void> onLoad() async {
+    await super.onLoad();
     add(CircleHitbox());
   }
 }

--- a/test/enemy_direction_test.dart
+++ b/test/enemy_direction_test.dart
@@ -11,6 +11,7 @@ import 'package:space_game/components/player.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/event_bus.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
 
@@ -19,7 +20,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestGame extends SpaceGame {
@@ -35,7 +38,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *
@@ -54,6 +57,7 @@ void main() {
     final audio = await AudioService.create(storage);
     final game = _TestGame(storage: storage, audio: audio);
     await game.onLoad();
+    game.eventBus.emit(ComponentSpawnEvent<PlayerComponent>(game.player));
 
     final enemy = EnemyComponent()
       ..game = game

--- a/test/enemy_group_spawn_test.dart
+++ b/test/enemy_group_spawn_test.dart
@@ -18,7 +18,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestGame extends SpaceGame {
@@ -34,7 +36,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *

--- a/test/mineral_pickup_test.dart
+++ b/test/mineral_pickup_test.dart
@@ -20,6 +20,7 @@ class _TestPlayer extends PlayerComponent {
 
   @override
   Future<void> onLoad() async {
+    await super.onLoad();
     add(CircleHitbox());
   }
 }
@@ -37,7 +38,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *

--- a/test/player_auto_aim_radius_toggle_test.dart
+++ b/test/player_auto_aim_radius_toggle_test.dart
@@ -16,7 +16,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestGame extends SpaceGame {
@@ -32,7 +34,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *

--- a/test/player_auto_aim_test.dart
+++ b/test/player_auto_aim_test.dart
@@ -24,7 +24,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestGame extends SpaceGame {
@@ -40,7 +42,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *

--- a/test/player_bullet_direction_test.dart
+++ b/test/player_bullet_direction_test.dart
@@ -23,7 +23,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestPoolManager extends PoolManager {
@@ -67,7 +69,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *

--- a/test/player_damage_flash_test.dart
+++ b/test/player_damage_flash_test.dart
@@ -19,7 +19,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestGame extends SpaceGame {
@@ -44,7 +46,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(Vector2.all(Constants.playerSize *
         (Constants.spriteScale + Constants.playerScale) *
         2));
@@ -67,7 +69,7 @@ void main() {
     game.hitPlayer();
     expect(game.player.paint.colorFilter, isNotNull);
 
-    game.player.update(Constants.playerDamageFlashDuration);
+    game.update(Constants.playerDamageFlashDuration);
     expect(game.player.paint.colorFilter, isNull);
   });
 }

--- a/test/player_reset_orientation_test.dart
+++ b/test/player_reset_orientation_test.dart
@@ -32,21 +32,24 @@ void main() {
 
     // Set a non-zero orientation.
     game.joystick.delta.setValues(1, 0);
-    game.player.update(0.1);
+    game.joystick.relativeDelta.setValues(1, 0);
+    game.update(0.1);
     expect(game.player.angle, greaterThan(0));
     // Move the player away from center.
     game.player.position.setValues(20, 20);
 
     // Clear input before restarting.
     game.joystick.delta.setZero();
+    game.joystick.relativeDelta.setZero();
 
     // Starting a new game should reset orientation and position.
     game.startGame();
+    game.onGameResize(Vector2.all(100));
     expect(game.player.angle, 0);
     expect(game.player.position, Constants.worldSize / 2);
 
     // After update with no input, angle and position should remain unchanged.
-    game.player.update(0.1);
+    game.update(0.1);
     expect(game.player.angle, 0);
     expect(game.player.position, Constants.worldSize / 2);
   });

--- a/test/player_rotation_test.dart
+++ b/test/player_rotation_test.dart
@@ -16,7 +16,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestGame extends SpaceGame {
@@ -32,7 +34,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *
@@ -53,7 +55,9 @@ void main() {
 
     // Move down; target angle is pi.
     game.joystick.delta.setValues(0, 1);
-    game.player.update(0.05);
+    game.joystick.relativeDelta.setValues(0, 1);
+    final input = game.player.inputBehavior;
+    input.update(0.05);
     final angleAfterFirstUpdate = game.player.angle;
 
     // Should have started rotating but not reached the target.
@@ -62,11 +66,12 @@ void main() {
 
     // Change direction upward before rotation completes.
     game.joystick.delta.setValues(0, -1);
-    game.player.update(0.05);
+    game.joystick.relativeDelta.setValues(0, -1);
+    input.update(0.05);
     expect(game.player.angle, lessThan(angleAfterFirstUpdate));
 
     // Let it finish rotating to the new target.
-    game.player.update(1);
+    input.update(1);
     expect(game.player.angle, closeTo(0, 0.001));
   });
 }

--- a/test/player_shoot_cooldown_test.dart
+++ b/test/player_shoot_cooldown_test.dart
@@ -21,7 +21,9 @@ class _TestPlayer extends PlayerComponent {
       : super(spritePath: 'players/player1.png');
 
   @override
-  Future<void> onLoad() async {}
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
 }
 
 class _TestPoolManager extends PoolManager {
@@ -65,7 +67,7 @@ class _TestGame extends SpaceGame {
       background: CircleComponent(radius: 2),
     );
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
-    add(player);
+    await add(player);
     onGameResize(
       Vector2.all(Constants.playerSize *
           (Constants.spriteScale + Constants.playerScale) *
@@ -92,7 +94,7 @@ void main() {
     game.update(0);
     expect(game.children.whereType<BulletComponent>().length, 1);
 
-    game.player.update(Constants.bulletCooldown);
+    game.update(Constants.bulletCooldown);
     game.player.shoot();
     game.update(0);
     expect(game.children.whereType<BulletComponent>().length, 2);


### PR DESCRIPTION
## Summary
- mix minerals into SpawnRemoveEmitter to auto-fire spawn/remove events
- drop manual mineral spawn events from asteroids
- defer player input reset until after mounting and expose input behavior for tests
- ensure minerals still home toward player even if targeting service hasn't tracked them yet

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test` *(fails: asteroid_damage_limit_test, player_space_key_reregister_test, mineral_pickup_test, player_reset_orientation_test)*

------
https://chatgpt.com/codex/tasks/task_e_68b558efeefc833080d4112a1a2e4539