### PR TITLE
Use targeting service for mineral tractor pull

### DIFF
--- a/lib/components/mineral.dart
+++ b/lib/components/mineral.dart
@@ -46,8 +46,10 @@ class MineralComponent extends SpriteComponent
   @override
   void update(double dt) {
     super.update(dt);
-    final playerPos =
-        game.targetingService.playerPosition ?? game.player.position;
+    final playerPos = game.targetingService.playerPosition;
+    if (playerPos == null) {
+      return;
+    }
     final toPlayer = playerPos - position;
     final distanceSquared = toPlayer.length2;
     final rangeSquared =


### PR DESCRIPTION
## Summary
- Remove direct `game.player` dependency from mineral tractor aura
- Early-out when no player position is available

## Testing
- `scripts/flutterw test` *(fails: tractor_aura_test, player_rotation_test, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a0a17cec833082d3c17d13496795