### PR TITLE
Fix missing brace in Flutter bootstrap script

### DIFF
--- a/scripts/bootstrap_flutter.ps1
+++ b/scripts/bootstrap_flutter.ps1
@@ -253,6 +253,8 @@ Remove-Item $destZip -Force
   Pop-Location
 }
 
+}
+
 if ($needsDownload) {
   Say "Flutter SDK installed at $FLUTTER_DIR"
 } else {


### PR DESCRIPTION
## Summary
- close open conditional in `bootstrap_flutter.ps1`

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `./scripts/dartw test` *(fails: Could not find package `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d006c47483308ff4b5fafd6607dd