### PR TITLE
chore: remove unused experimental import

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
-import 'package:flame/experimental.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart' show EdgeInsets;
 import 'package:flutter/widgets.dart' show FocusNode;


### PR DESCRIPTION
## Summary
- remove unused flame experimental import in SpaceGame

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test` *(fails: player re-registers space key after remount)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d179cb9883308905403ef28c999e