### PR TITLE
Fix PSScriptAnalyzer workflow

### DIFF
--- a/.github/workflows/script-analysis.yml
+++ b/.github/workflows/script-analysis.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
-          $ps1 = Get-ChildItem -Path . -Filter *.ps1 -Recurse
+          $ps1 = Get-ChildItem -Path . -Filter *.ps1 -Recurse | Select-Object -ExpandProperty FullName
           if ($ps1) {
             Invoke-ScriptAnalyzer -Path $ps1
           } else {


### PR DESCRIPTION
## Summary
- ensure PSScriptAnalyzer receives string paths by expanding FullName

## Testing
- `python3 - <<'PY'
import yaml, sys
yaml.safe_load(open('.github/workflows/script-analysis.yml'))
print('YAML OK')
PY`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d27e6248833082c76eb1b6b449a1