### PR TITLE
Fix PowerShell script analyzer path handling

### DIFF
--- a/.github/workflows/script-analysis.yml
+++ b/.github/workflows/script-analysis.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
-          $ps1 = Get-ChildItem -Path . -Filter *.ps1 -Recurse | Select-Object -ExpandProperty FullName
+          [string[]]$ps1 = Get-ChildItem -Path . -Filter *.ps1 -Recurse | Select-Object -ExpandProperty FullName
           if ($ps1) {
             Invoke-ScriptAnalyzer -Path $ps1
           } else {


### PR DESCRIPTION
## Summary
- ensure PSScriptAnalyzer receives string paths in CI workflow to avoid type conversion error

## Testing
- `./scripts/flutterw analyze`
- `./scripts/dartw format --output=none --set-exit-if-changed .`
- `./scripts/flutterw test` *(fails: player re-registers space key after remount)*
- `pwsh` *(missing: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6d4aef8b8833085d8cadc18943481