### PR TITLE
Run Flutter doctor only after new Flutter install

### DIFF
--- a/scripts/bootstrap_flutter.sh
+++ b/scripts/bootstrap_flutter.sh
@@ -208,12 +208,16 @@ PATH="$(pwd)/$FLUTTER_DIR/bin:$PATH"
 export PATH
 git config --global --add safe.directory "$(pwd)/$FLUTTER_DIR" 2>/dev/null || true
 
-log "Running flutter --version"
-.tooling/flutter/bin/flutter --version || true
-log "Enabling web support"
-.tooling/flutter/bin/flutter config --enable-web || true
-if [ "${SKIP_DOCTOR:-}" != "1" ]; then
-  log "Running flutter doctor"
-  .tooling/flutter/bin/flutter doctor -v || true
+if [ "$needs_download" = true ]; then
+  log "Running flutter --version"
+  .tooling/flutter/bin/flutter --version || true
+  log "Enabling web support"
+  .tooling/flutter/bin/flutter config --enable-web || true
+  if [ "${SKIP_DOCTOR:-}" != "1" ]; then
+    log "Running flutter doctor"
+    .tooling/flutter/bin/flutter doctor -v || true
+  fi
+else
+  log "Flutter SDK already installed; skipping flutter doctor"
 fi
 log "Flutter bootstrap complete"


### PR DESCRIPTION
## Summary
- skip `flutter doctor` and related setup when Flutter SDK is already present

## Testing
- `./scripts/flutterw test`
- `./scripts/flutterw test --reporter json`

------
https://chatgpt.com/codex/tasks/task_e_68b6e088b82c8330bad14734c30e560d