### PR TITLE
Enable auto-aim test

### DIFF
--- a/test/player_auto_aim_test.dart
+++ b/test/player_auto_aim_test.dart
@@ -37,6 +37,7 @@ class _TestGame extends SpaceGame {
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);
+    await player.onLoad();
     onGameResize(
       Vector2.all(
         Constants.playerSize *
@@ -75,5 +76,5 @@ void main() {
     enemy.reset(game.player.position - Vector2(100, 0));
     game.update(0.5);
     expect(game.player.angle, closeTo(-math.pi / 2, 0.001));
-  }, skip: true);
+  });
 }


### PR DESCRIPTION
## Summary
- ensure player component loads in auto-aim test
- run previously skipped auto-aim test

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b6dfe0fd3483309f4a0a92843b812d