### PR TITLE
Fix blurry ship selection icons

### DIFF
--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -80,6 +80,8 @@ class MenuOverlay extends StatelessWidget {
                         child: Image.asset(
                           'assets/images/${Assets.players[i]}',
                           fit: BoxFit.contain,
+                          // Use nearest-neighbor sampling to avoid blurred sprites.
+                          filterQuality: FilterQuality.none,
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- render menu ship icons with nearest-neighbor sampling to keep pixel art crisp

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b7f8e0b7a4833080ebb728635a11de