### PR TITLE
Fix PSScriptAnalyzer step in CI

### DIFF
--- a/.github/workflows/script-analysis.yml
+++ b/.github/workflows/script-analysis.yml
@@ -49,9 +49,11 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
-          [string[]]$ps1 = Get-ChildItem -Path . -Filter *.ps1 -Recurse | Select-Object -ExpandProperty FullName
+          $ps1 = Get-ChildItem -Path . -Filter *.ps1 -Recurse | Select-Object -ExpandProperty FullName
           if ($ps1) {
-            Invoke-ScriptAnalyzer -Path $ps1
+            foreach ($script in $ps1) {
+              Invoke-ScriptAnalyzer -Path $script
+            }
           } else {
             Write-Host 'No PowerShell scripts found'
           }


### PR DESCRIPTION
## Summary
- Run PSScriptAnalyzer on each PowerShell script individually

## Testing
- `./scripts/dartw --version`
- `./scripts/dartw format .github/workflows/script-analysis.yml` *(fails: Could not format because the source could not be parsed)*
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7f8aca14883309371eb687f911114