### PR TITLE
fix: avoid apt cache permission warning

### DIFF
--- a/.github/workflows/script-analysis.yml
+++ b/.github/workflows/script-analysis.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Cache APT packages
         uses: actions/cache@v3
         with:
-          path: /var/cache/apt/archives
+          path: /var/cache/apt/archives/*.deb
           key: ${{ runner.os }}-apt-shellcheck-${{ hashFiles('setup.sh') }}
           restore-keys: |
             ${{ runner.os }}-apt-shellcheck-


### PR DESCRIPTION
## Summary
- limit apt cache step to `.deb` files to stop permission warnings during ShellCheck workflow

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f8b7cb14833099f58a833a756f28