### PR TITLE
Simplify pause overlay for interface inspection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -125,7 +125,7 @@ tree spanning weapons and ship systems.
 - The game starts in a menu overlay that also exposes a mute toggle.
 - `SpaceGame` transitions to `playing` when the user taps start.
 - Players can pause the game from the HUD or with the Escape or `P` key,
-  showing a pause overlay with resume, menu and mute buttons.
+  showing a centered `PAUSED` label while gameplay halts.
 - During play the HUD provides score, minerals, high score, health, pause and
   mute controls.
 - On player death, a game over overlay appears with restart, menu and mute buttons.

--- a/PLAN.md
+++ b/PLAN.md
@@ -163,7 +163,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Local high score stored on device (e.g., shared preferences)
 - Menu offers a reset button to clear the high score
 - Basic sound effects using `flame_audio` with mute toggle (button or `M` key)
-  available on menu, HUD, pause and game over overlays
+  available on menu, HUD and game over overlays
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `Enter` starts or
   restarts from the menu or game over, `R` restarts at any time, `Q` returns to
@@ -171,7 +171,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   `H` shows a help overlay that `Esc` also closes)
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
-- Pause, resume or return to the menu via overlay
+- Pause or resume with a `PAUSED` label overlay; `Q` returns to the menu from
+  pause or game over
 
 ## 🗓️ Milestones
 

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -26,12 +26,12 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Escape or `P` key pauses or resumes the game; `Q` returns to the menu from
       pause or game over, `Esc` also returns to the menu from game over
 - [ ] Parallax starfield renders behind gameplay
-- [ ] Sound effects play and can be muted from menu, HUD, pause or game over overlay,
+- [ ] Sound effects play and can be muted from menu, HUD or game over overlay,
       or via the `M` key
 - [ ] Laser shot sound plays when firing
 - [ ] Explosion animation and sound play when a ship is destroyed
 - [ ] Mining laser emits a looping sound while active
-- [ ] Game can be paused, resumed and return to menu (including from game over)
+- [ ] Game can be paused and resumed; `Q` returns to the menu (including from game over)
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ dedicated server or NAT traversal.
 - Player health, minerals and high score displayed in the HUD; health drops on
   collision and minerals increase when collecting pickups from mined asteroids
 - Local high score stored on device using `shared_preferences`
-- Basic sound effects with a mute toggle on menu, HUD, pause and game over
+- Basic sound effects with a mute toggle on menu, HUD and game over
   screens, plus an `M` key shortcut
-- Pause, resume or return to the menu via overlays (including game over screen)
+- Pause or resume via keyboard or HUD button with a centered `PAUSED`
+  indicator that leaves the interface visible
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `F1` toggles debug
   overlays, `Enter` starts or restarts from the menu or game over, `R` restarts at

--- a/lib/game/game_state.md
+++ b/lib/game/game_state.md
@@ -7,7 +7,8 @@ Enum describing high-level game phases.
 - `menu` – initial overlay before play.
 - `playing` – active gameplay loop.
 - `upgrades` – upgrade selection overlay while gameplay is paused.
-- `paused` – gameplay halted with a pause overlay to resume or return to menu.
+- `paused` – gameplay halted with a centered `PAUSED` indicator; keyboard
+  shortcuts still work.
 - `gameOver` – player died; show overlay with restart, menu and mute options.
 
 Used by `SpaceGame` to swap overlays and reset state.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -241,7 +241,7 @@ class SpaceGame extends FlameGame
   /// Adds [value] to the current mineral count.
   void addMinerals(int value) => scoreService.addMinerals(value);
 
-  /// Pauses the game and shows the pause overlay.
+  /// Pauses the game and shows the `PAUSED` overlay.
   void pauseGame() => stateMachine.pauseGame();
 
   /// Resumes the game from a paused state.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,8 +43,7 @@ Future<void> main() async {
         overlayBuilderMap: {
           MenuOverlay.id: (context, SpaceGame game) => MenuOverlay(game: game),
           HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
-          PauseOverlay.id: (context, SpaceGame game) =>
-              PauseOverlay(game: game),
+          PauseOverlay.id: (context, SpaceGame game) => const PauseOverlay(),
           GameOverOverlay.id: (context, SpaceGame game) =>
               GameOverOverlay(game: game),
           HelpOverlay.id: (context, SpaceGame game) => HelpOverlay(game: game),

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -15,8 +15,8 @@ Flutter overlays and HUD widgets.
   reset, help (`H`) and mute toggle.
 - [HudOverlay](hud_overlay.md) – shows score, high score, minerals (with icon)
     and health with auto-aim radius toggle, help, upgrades, mute and pause buttons.
-- [PauseOverlay](pause_overlay.md) – displayed when the game is paused with
-  resume, restart, menu, help and mute buttons.
+- [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label while
+  the game is paused.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with
   restart (button or `Enter`/`R`), menu, help and mute options.
 - [HelpOverlay](help_overlay.md) – lists all controls; toggled with `H` and

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -1,73 +1,27 @@
 import 'package:flutter/material.dart';
 
-import '../game/space_game.dart';
 import 'game_text.dart';
 import 'overlay_widgets.dart';
 
 /// Overlay shown when the game is paused.
 class PauseOverlay extends StatelessWidget {
-  const PauseOverlay({super.key, required this.game});
-
-  /// Reference to the running game.
-  final SpaceGame game;
+  const PauseOverlay({super.key});
 
   /// Overlay identifier used by [GameWidget].
   static const String id = 'pauseOverlay';
 
   @override
   Widget build(BuildContext context) {
-    return OverlayLayout(
-      builder: (context, spacing, iconSize) {
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            GameText(
-              'Paused',
-              style: Theme.of(context).textTheme.headlineMedium,
-              maxLines: 1,
-            ),
-            SizedBox(height: spacing),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ElevatedButton(
-                  // Mirrors the Escape and P keyboard shortcuts.
-                  onPressed: game.resumeGame,
-                  child: const GameText(
-                    'Resume',
-                    maxLines: 1,
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-                SizedBox(width: spacing),
-                ElevatedButton(
-                  // Mirrors the R keyboard shortcut.
-                  onPressed: game.startGame,
-                  child: const GameText(
-                    'Restart',
-                    maxLines: 1,
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-                SizedBox(width: spacing),
-                ElevatedButton(
-                  // Mirrors the Q keyboard shortcut.
-                  onPressed: game.returnToMenu,
-                  child: const GameText(
-                    'Menu',
-                    maxLines: 1,
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-                SizedBox(width: spacing),
-                HelpButton(game: game),
-                SizedBox(width: spacing),
-                MuteButton(game: game, iconSize: iconSize),
-              ],
-            ),
-          ],
-        );
-      },
+    return IgnorePointer(
+      child: OverlayLayout(
+        builder: (context, _, __) {
+          return GameText(
+            'PAUSED',
+            style: Theme.of(context).textTheme.headlineMedium,
+            maxLines: 1,
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/ui/pause_overlay.md
+++ b/lib/ui/pause_overlay.md
@@ -4,14 +4,12 @@ Overlay displayed when the game is paused.
 
 ## Features
 
-- Shows a "Paused" label with resume, restart, menu and mute buttons.
-- Icon sizes scale with screen size for consistency across devices.
+- Shows a centered "PAUSED" label.
+- Gameplay is halted but the interface remains visible for inspection.
 - Triggered from the HUD pause button or the Escape or `P` key.
 - Visible only while the game state is `paused`.
-- Press `R` to restart without using the button.
-- Pressing `M` also toggles audio mute.
-- Press `Q` to return to the menu without clicking the button.
-- Help button (or `H` key) opens a control reference and resumes when closed;
-  `Esc` also closes it.
+- Keyboard shortcuts still work: `R` restarts, `Q` returns to the menu,
+  `M` toggles audio mute and `H` opens the help overlay which resumes when
+  closed; `Esc` also closes it.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- Replace pause menu with minimal `PAUSED` overlay that doesn't block the HUD
- Update game state and documentation to reflect new pause behaviour

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fa2083108330a3540fba02bc05f3