### PR TITLE
test: stub images for restart test

### DIFF
--- a/test/restart_removes_old_player_test.dart
+++ b/test/restart_removes_old_player_test.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/flame.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -15,13 +14,14 @@ import 'package:space_game/ui/game_over_overlay.dart';
 import 'package:space_game/ui/hud_overlay.dart';
 import 'package:space_game/ui/menu_overlay.dart';
 import 'package:space_game/ui/pause_overlay.dart';
+import 'test_images.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('restarting removes the previous player instance', () async {
     SharedPreferences.setMockInitialValues({});
-    await Flame.images.loadAll([...Assets.players, ...Assets.explosions]);
+    await loadTestImages([...Assets.players, ...Assets.explosions]);
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);

--- a/test/test_images.dart
+++ b/test/test_images.dart
@@ -1,0 +1,19 @@
+import 'dart:ui';
+
+import 'package:flame/flame.dart';
+
+/// Registers 1×1 placeholder images for the given asset [paths].
+///
+/// Loading real sprites is unnecessary in most unit tests and can make them
+/// brittle when asset files or the Flutter asset bundle are unavailable. This
+/// helper inserts a tiny blank image into [Flame.images] for each path so tests
+/// can instantiate components without touching the filesystem.
+Future<void> loadTestImages(Iterable<String> paths) async {
+  final recorder = PictureRecorder();
+  final canvas = Canvas(recorder);
+  canvas.drawRect(const Rect.fromLTWH(0, 0, 1, 1), Paint());
+  final image = await recorder.endRecording().toImage(1, 1);
+  for (final path in paths) {
+    Flame.images.add(path, image);
+  }
+}


### PR DESCRIPTION
## Summary
- avoid loading real sprite assets in restart test by stubbing images
- add helper to register 1x1 placeholder images for tests

## Testing
- `scripts/flutterw test --reporter expanded test/restart_removes_old_player_test.dart`
- `scripts/flutterw test --reporter expanded`
- `scripts/flutterw analyze`


------
https://chatgpt.com/codex/tasks/task_e_68b7f836b8608330b1cbb5bb8554c565