### PR TITLE
fix: capture F1 key in web

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -30,6 +30,13 @@
   </head>
   <body>
     <script>
+      // Prevent F1 from opening browser help so the game can use it for debugging.
+      window.addEventListener('keydown', (event) => {
+        if (event.key === 'F1') {
+          event.preventDefault();
+        }
+      });
+
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function () {
           navigator.serviceWorker.register('sw.js');


### PR DESCRIPTION
## Summary
- prevent browser help from intercepting F1 so the game can use it for debugging

## Testing
- `scripts/dartw format web/index.html` *(fails: The '===' operator is not supported)*
- `scripts/flutterw test --no-pub --reporter expanded | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b7f92ad0648330a367f8603f7e7d2f