### PR TITLE
test: stub images in player remount test

### DIFF
--- a/test/player_space_key_reregister_test.dart
+++ b/test/player_space_key_reregister_test.dart
@@ -1,5 +1,4 @@
 import 'package:flame/components.dart';
-import 'package:flame/flame.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -15,6 +14,7 @@ import 'package:space_game/ui/game_over_overlay.dart';
 import 'package:space_game/ui/hud_overlay.dart';
 import 'package:space_game/ui/menu_overlay.dart';
 import 'package:space_game/ui/pause_overlay.dart';
+import 'test_images.dart';
 import 'test_joystick.dart';
 
 class _TestPlayer extends PlayerComponent {
@@ -47,7 +47,7 @@ void main() {
 
   test('player re-registers space key after remount', () async {
     SharedPreferences.setMockInitialValues({});
-    await Flame.images.loadAll([...Assets.players]);
+    await loadTestImages(Assets.players);
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     final game = _TestGame(storage: storage, audio: audio);


### PR DESCRIPTION
## Summary
- stub player sprite images in `player_space_key_reregister_test`

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b7fda712a08330a0f8dc6232c05172