### PR TITLE
Initialize Flutter binding in key dispatcher tests

### DIFF
--- a/test/key_dispatcher_any_pressed_test.dart
+++ b/test/key_dispatcher_any_pressed_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('isAnyPressed reports true when any key is pressed', () {
     final dispatcher = KeyDispatcher();
     dispatcher.onKeyEvent(

--- a/test/key_dispatcher_propagation_test.dart
+++ b/test/key_dispatcher_propagation_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('KeyDispatcher consumes events', () {
     final dispatcher = KeyDispatcher();
     final event = KeyDownEvent(

--- a/test/key_dispatcher_test.dart
+++ b/test/key_dispatcher_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('onKeyEvent consumes handled keys', () {
     final dispatcher = KeyDispatcher();
     var pressed = false;

--- a/test/key_dispatcher_unregister_test.dart
+++ b/test/key_dispatcher_unregister_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('unregister removes callbacks and pressed state', () {
     final dispatcher = KeyDispatcher();
     var count = 0;

--- a/test/nearest_component_test.dart
+++ b/test/nearest_component_test.dart
@@ -10,6 +10,8 @@ class _TestComponent extends PositionComponent {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('findClosestComponent returns nearest within range', () {
     final components = [
       _TestComponent(Vector2(10, 0)),


### PR DESCRIPTION
## Summary
- Ensure Flutter framework is ready in key dispatcher tests and nearest component test by calling `TestWidgetsFlutterBinding.ensureInitialized`

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fda712a08330a0f8dc6232c05172