### PR TITLE
Add runtime UI scaling settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,8 +9,11 @@ import 'ui/menu_overlay.dart';
 import 'ui/pause_overlay.dart';
 import 'ui/help_overlay.dart';
 import 'ui/upgrades_overlay.dart';
+import 'ui/settings_overlay.dart';
+import 'ui/game_text.dart';
 import 'services/storage_service.dart';
 import 'services/audio_service.dart';
+import 'services/settings_service.dart';
 
 /// Application entry point.
 Future<void> main() async {
@@ -18,12 +21,15 @@ Future<void> main() async {
   await Assets.load();
   final storage = await StorageService.create();
   final audio = await AudioService.create(storage);
+  final settings = SettingsService();
   final focusNode = FocusNode();
   final game = SpaceGame(
     storageService: storage,
     audioService: audio,
+    settingsService: settings,
     focusNode: focusNode,
   );
+  GameText.attachTextScale(settings.textScale);
   runApp(
     MaterialApp(
       theme: ThemeData(
@@ -49,6 +55,8 @@ Future<void> main() async {
           HelpOverlay.id: (context, SpaceGame game) => HelpOverlay(game: game),
           UpgradesOverlay.id: (context, SpaceGame game) =>
               UpgradesOverlay(game: game),
+          SettingsOverlay.id: (context, SpaceGame game) =>
+              SettingsOverlay(game: game),
         },
       ),
     ),

--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -6,6 +6,7 @@ import '../ui/menu_overlay.dart';
 import '../ui/pause_overlay.dart';
 import '../ui/help_overlay.dart';
 import '../ui/upgrades_overlay.dart';
+import '../ui/settings_overlay.dart';
 
 /// Handles showing and hiding Flutter overlays.
 class OverlayService {
@@ -57,4 +58,8 @@ class OverlayService {
       ..remove(UpgradesOverlay.id)
       ..add(HudOverlay.id);
   }
+
+  void showSettings() => game.overlays.add(SettingsOverlay.id);
+
+  void hideSettings() => game.overlays.remove(SettingsOverlay.id);
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+
+/// Holds tweakable UI scale values for live prototyping.
+class SettingsService {
+  SettingsService()
+      : hudButtonScale = ValueNotifier<double>(1),
+        textScale = ValueNotifier<double>(1),
+        joystickScale = ValueNotifier<double>(1);
+
+  /// Multiplier applied to HUD buttons and icons.
+  final ValueNotifier<double> hudButtonScale;
+
+  /// Multiplier applied to in-game text sizes.
+  final ValueNotifier<double> textScale;
+
+  /// Multiplier applied to on-screen joystick elements.
+  final ValueNotifier<double> joystickScale;
+}

--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 /// Displays text using a consistent style across game overlays.
 ///
@@ -38,15 +39,36 @@ class GameText extends StatelessWidget {
     fontSize: 18,
   );
 
+  /// Globally applied text scale factor. When attached, all [GameText]
+  /// instances rebuild in response to changes.
+  static ValueListenable<double>? textScale;
+
+  /// Registers a [ValueListenable] that controls text scaling.
+  static void attachTextScale(ValueListenable<double> notifier) {
+    textScale = notifier;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final mergedStyle =
-        _baseStyle.merge(style).copyWith(color: color ?? defaultColor);
-    return AutoSizeText(
-      data,
-      maxLines: maxLines,
-      textAlign: textAlign,
-      style: mergedStyle,
-    );
+    Widget buildText(double scale) {
+      final mergedStyle =
+          _baseStyle.merge(style).copyWith(color: color ?? defaultColor);
+      final baseSize = mergedStyle.fontSize ?? _baseStyle.fontSize!;
+      return AutoSizeText(
+        data,
+        maxLines: maxLines,
+        textAlign: textAlign,
+        style: mergedStyle.copyWith(fontSize: baseSize * scale),
+      );
+    }
+
+    final notifier = textScale;
+    if (notifier != null) {
+      return ValueListenableBuilder<double>(
+        valueListenable: notifier,
+        builder: (context, scale, _) => buildText(scale),
+      );
+    }
+    return buildText(1);
   }
 }

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -18,68 +18,75 @@ class HudOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final iconSize = responsiveIconSizeFromContext(context);
-    return SafeArea(
-      child: Align(
-        alignment: Alignment.topCenter,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    ValueListenableBuilder<int>(
-                      valueListenable: game.score,
-                      builder: (context, value, _) => GameText(
-                        'Score: $value',
-                        maxLines: 1,
-                      ),
-                    ),
-                    ValueListenableBuilder<int>(
-                      valueListenable: game.highScore,
-                      builder: (context, value, _) => GameText(
-                        'High: $value',
-                        maxLines: 1,
-                      ),
-                    ),
-                    ValueListenableBuilder<int>(
-                      valueListenable: game.health,
-                      builder: (context, value, _) => GameText(
-                        'Health: $value',
-                        maxLines: 1,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              MineralDisplay(game: game),
-              Row(
+    return ValueListenableBuilder<double>(
+      valueListenable: game.settingsService.hudButtonScale,
+      builder: (context, scale, _) {
+        final iconSize = responsiveIconSizeFromContext(context) * scale;
+        return SafeArea(
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  IconButton(
-                    iconSize: iconSize,
-                    icon: const Icon(Icons.gps_fixed, color: Colors.white),
-                    onPressed: game.toggleAutoAimRadius,
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ValueListenableBuilder<int>(
+                          valueListenable: game.score,
+                          builder: (context, value, _) => GameText(
+                            'Score: $value',
+                            maxLines: 1,
+                          ),
+                        ),
+                        ValueListenableBuilder<int>(
+                          valueListenable: game.highScore,
+                          builder: (context, value, _) => GameText(
+                            'High: $value',
+                            maxLines: 1,
+                          ),
+                        ),
+                        ValueListenableBuilder<int>(
+                          valueListenable: game.health,
+                          builder: (context, value, _) => GameText(
+                            'Health: $value',
+                            maxLines: 1,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                  UpgradeButton(game: game, iconSize: iconSize),
-                  HelpButton(game: game, iconSize: iconSize),
-                  MuteButton(game: game, iconSize: iconSize),
-                  IconButton(
-                    iconSize: iconSize,
-                    // Mirrors the Escape and P keyboard shortcuts.
-                    icon: const Icon(Icons.pause, color: GameText.defaultColor),
-                    onPressed: game.pauseGame,
+                  MineralDisplay(game: game),
+                  Row(
+                    children: [
+                      IconButton(
+                        iconSize: iconSize,
+                        icon: const Icon(Icons.gps_fixed, color: Colors.white),
+                        onPressed: game.toggleAutoAimRadius,
+                      ),
+                      UpgradeButton(game: game, iconSize: iconSize),
+                      HelpButton(game: game, iconSize: iconSize),
+                      SettingsButton(game: game, iconSize: iconSize),
+                      MuteButton(game: game, iconSize: iconSize),
+                      IconButton(
+                        iconSize: iconSize,
+                        // Mirrors the Escape and P keyboard shortcuts.
+                        icon: const Icon(Icons.pause,
+                            color: GameText.defaultColor),
+                        onPressed: game.pauseGame,
+                      ),
+                    ],
                   ),
                 ],
               ),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -112,3 +112,20 @@ class UpgradeButton extends StatelessWidget {
     );
   }
 }
+
+/// Icon button that opens the runtime settings overlay.
+class SettingsButton extends StatelessWidget {
+  const SettingsButton({super.key, required this.game, required this.iconSize});
+
+  final SpaceGame game;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      iconSize: iconSize,
+      icon: const Icon(Icons.tune, color: GameText.defaultColor),
+      onPressed: game.toggleSettings,
+    );
+  }
+}

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../game/space_game.dart';
+import 'game_text.dart';
+import 'overlay_widgets.dart';
+
+/// Overlay providing runtime UI scaling sliders.
+class SettingsOverlay extends StatelessWidget {
+  const SettingsOverlay({super.key, required this.game});
+
+  final SpaceGame game;
+
+  static const String id = 'settingsOverlay';
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = game.settingsService;
+    return OverlayLayout(
+      dimmed: true,
+      builder: (context, spacing, iconSize) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GameText(
+              'UI Settings',
+              style: Theme.of(context).textTheme.headlineSmall,
+              maxLines: 1,
+            ),
+            SizedBox(height: spacing),
+            _buildSlider(
+              context,
+              'HUD Buttons',
+              settings.hudButtonScale,
+              spacing,
+            ),
+            _buildSlider(
+              context,
+              'Text',
+              settings.textScale,
+              spacing,
+            ),
+            _buildSlider(
+              context,
+              'Joypad',
+              settings.joystickScale,
+              spacing,
+            ),
+            SizedBox(height: spacing),
+            ElevatedButton(
+              onPressed: game.toggleSettings,
+              child: const GameText(
+                'Close',
+                maxLines: 1,
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildSlider(
+    BuildContext context,
+    String label,
+    ValueNotifier<double> notifier,
+    double spacing,
+  ) {
+    return ValueListenableBuilder<double>(
+      valueListenable: notifier,
+      builder: (context, value, _) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GameText('$label: ${value.toStringAsFixed(2)}'),
+          Slider(
+            value: value,
+            min: 0.5,
+            max: 2.0,
+            onChanged: (v) => notifier.value = v,
+          ),
+          SizedBox(height: spacing),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add settings overlay with sliders to resize HUD buttons, text, and joystick
- integrate SettingsService for live UI scaling and expose settings button in HUD

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fdb3fb108330b5693f0eacb330de