### PR TITLE
Add ScoreService tests and improve input/auto-aim coverage

### DIFF
--- a/test/key_dispatcher_propagation_test.dart
+++ b/test/key_dispatcher_propagation_test.dart
@@ -6,14 +6,29 @@ import 'package:space_game/game/key_dispatcher.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('KeyDispatcher consumes events', () {
+  test('KeyDispatcher tracks pressed and released keys', () {
     final dispatcher = KeyDispatcher();
-    final event = KeyDownEvent(
-      logicalKey: LogicalKeyboardKey.space,
-      physicalKey: PhysicalKeyboardKey.space,
-      timeStamp: Duration.zero,
+
+    final handledDown = dispatcher.onKeyEvent(
+      const KeyDownEvent(
+        logicalKey: LogicalKeyboardKey.space,
+        physicalKey: PhysicalKeyboardKey.space,
+        timeStamp: Duration.zero,
+      ),
+      {LogicalKeyboardKey.space},
     );
-    final handled = dispatcher.onKeyEvent(event, {LogicalKeyboardKey.space});
-    expect(handled, isTrue);
+    expect(handledDown, isTrue);
+    expect(dispatcher.isPressed(LogicalKeyboardKey.space), isTrue);
+
+    final handledUp = dispatcher.onKeyEvent(
+      const KeyUpEvent(
+        logicalKey: LogicalKeyboardKey.space,
+        physicalKey: PhysicalKeyboardKey.space,
+        timeStamp: Duration.zero,
+      ),
+      <LogicalKeyboardKey>{},
+    );
+    expect(handledUp, isTrue);
+    expect(dispatcher.isPressed(LogicalKeyboardKey.space), isFalse);
   });
 }

--- a/test/player_auto_aim_radius_toggle_test.dart
+++ b/test/player_auto_aim_radius_toggle_test.dart
@@ -57,5 +57,7 @@ void main() {
     expect(game.player.showAutoAimRadius, isFalse);
     game.toggleAutoAimRadius();
     expect(game.player.showAutoAimRadius, isTrue);
+    game.toggleAutoAimRadius();
+    expect(game.player.showAutoAimRadius, isFalse);
   });
 }

--- a/test/score_service_test.dart
+++ b/test/score_service_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/constants.dart';
+import 'package:space_game/services/score_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('reset restores default values', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+
+    score.addScore(5);
+    score.addMinerals(3);
+    score.hitPlayer();
+    expect(score.score.value, 5);
+    expect(score.minerals.value, 3);
+    expect(score.health.value, Constants.playerMaxHealth - 1);
+
+    score.reset();
+    expect(score.score.value, 0);
+    expect(score.minerals.value, 0);
+    expect(score.health.value, Constants.playerMaxHealth);
+  });
+
+  test('updates and resets high score', () async {
+    SharedPreferences.setMockInitialValues({'highScore': 10});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+
+    expect(score.highScore.value, 10);
+
+    score.addScore(15);
+    await score.updateHighScoreIfNeeded();
+    expect(score.highScore.value, 15);
+    expect(storage.getHighScore(), 15);
+
+    await score.resetHighScore();
+    expect(score.highScore.value, 0);
+    expect(storage.getHighScore(), 0);
+  });
+}


### PR DESCRIPTION
## Summary
- strengthen KeyDispatcher test to verify pressed/released state
- exercise both enable and disable paths for auto-aim radius toggle
- add ScoreService unit tests for resets and high score persistence

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b80192a9a083309af69e939e321ddc