### PR TITLE
Keep HUD visible when game is paused

### DIFF
--- a/lib/game/game_state_machine.dart
+++ b/lib/game/game_state_machine.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../services/overlay_service.dart';
 import 'game_state.dart';
 
@@ -19,7 +21,10 @@ class GameStateMachine {
   final void Function() onGameOver;
   final void Function() onMenu;
 
-  GameState state = GameState.menu;
+  final ValueNotifier<GameState> stateNotifier =
+      ValueNotifier<GameState>(GameState.menu);
+  GameState get state => stateNotifier.value;
+  set state(GameState value) => stateNotifier.value = value;
 
   void startGame() {
     state = GameState.playing;

--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -31,9 +31,7 @@ class OverlayService {
   }
 
   void showPause() {
-    game.overlays
-      ..remove(HudOverlay.id)
-      ..add(PauseOverlay.id);
+    game.overlays.add(PauseOverlay.id);
   }
 
   void showGameOver() {

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import '../game/game_state.dart';
 import 'game_text.dart';
 import 'responsive.dart';
 import 'overlay_widgets.dart';
@@ -72,12 +73,21 @@ class HudOverlay extends StatelessWidget {
                       HelpButton(game: game, iconSize: iconSize),
                       SettingsButton(game: game, iconSize: iconSize),
                       MuteButton(game: game, iconSize: iconSize),
-                      IconButton(
-                        iconSize: iconSize,
-                        // Mirrors the Escape and P keyboard shortcuts.
-                        icon: const Icon(Icons.pause,
-                            color: GameText.defaultColor),
-                        onPressed: game.pauseGame,
+                      ValueListenableBuilder<GameState>(
+                        valueListenable: game.stateMachine.stateNotifier,
+                        builder: (context, state, _) {
+                          final paused = state == GameState.paused;
+                          return IconButton(
+                            iconSize: iconSize,
+                            // Mirrors the Escape and P keyboard shortcuts.
+                            icon: Icon(
+                              paused ? Icons.play_arrow : Icons.pause,
+                              color: GameText.defaultColor,
+                            ),
+                            onPressed:
+                                paused ? game.resumeGame : game.pauseGame,
+                          );
+                        },
                       ),
                     ],
                   ),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -7,14 +7,14 @@ Heads-up display shown during play.
 - Shows current score, high score and health using `ValueNotifier`s from
   `SpaceGame`.
 - Displays minerals in a centred pill with an icon and count.
-- Provides auto-aim radius toggle, upgrades, help, mute and pause buttons bound
-  to `SpaceGame` and `AudioService`.
+- Provides auto-aim radius toggle, upgrades, help, mute and pause/resume button
+  bound to `SpaceGame` and `AudioService`.
 - Icon sizes scale with screen size for better usability on different devices.
 - `U` opens the upgrades overlay; `Esc` closes it.
 - `H` opens the help overlay showing controls; `Esc` closes it.
 - `M` key also toggles audio mute.
 - `Escape` or `P` keys also pause or resume.
 - Press `R` to restart the current run without using on-screen buttons.
-- Visible only in the `playing` state.
+- Visible in the `playing` and `paused` states.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/pause_overlay.md
+++ b/lib/ui/pause_overlay.md
@@ -5,7 +5,8 @@ Overlay displayed when the game is paused.
 ## Features
 
 - Shows a centered "PAUSED" label.
-- Gameplay is halted but the interface remains visible for inspection.
+- Gameplay is halted but the interface, including the HUD, remains visible for
+  inspection.
 - Triggered from the HUD pause button or the Escape or `P` key.
 - Visible only while the game state is `paused`.
 - Keyboard shortcuts still work: `R` restarts, `Q` returns to the menu,

--- a/test/pause_overlay_hud_visible_test.dart
+++ b/test/pause_overlay_hud_visible_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('pause overlay does not hide HUD', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.overlays
+      ..addEntry(HudOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+
+    game.stateMachine.state = GameState.playing;
+    game.overlayService.showHud();
+    game.resumeEngine();
+
+    game.pauseGame();
+
+    expect(game.stateMachine.state, GameState.paused);
+    expect(game.overlays.isActive(PauseOverlay.id), isTrue);
+    expect(game.overlays.isActive(HudOverlay.id), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Keep HUD overlay active while Pause overlay is shown
- Make game state listenable and toggle HUD button between pause and resume
- Document HUD visibility and add regression test

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b804813db08330a1327fa41e8ccda4