### PR TITLE
Add resume hint to pause overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -125,7 +125,8 @@ tree spanning weapons and ship systems.
 - The game starts in a menu overlay that also exposes a mute toggle.
 - `SpaceGame` transitions to `playing` when the user taps start.
 - Players can pause the game from the HUD or with the Escape or `P` key,
-  showing a centered `PAUSED` label while gameplay halts.
+  showing a centered `PAUSED` label with a hint to press `Esc` or `P` to
+  resume while gameplay halts.
 - During play the HUD provides score, minerals, high score, health, pause and
   mute controls.
 - On player death, a game over overlay appears with restart, menu and mute buttons.

--- a/PLAN.md
+++ b/PLAN.md
@@ -171,8 +171,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   `H` shows a help overlay that `Esc` also closes)
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
-- Pause or resume with a `PAUSED` label overlay; `Q` returns to the menu from
-  pause or game over
+- Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
+  `P` to resume; `Q` returns to the menu from pause or game over
 
 ## 🗓️ Milestones
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ dedicated server or NAT traversal.
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
   screens, plus an `M` key shortcut
-- Pause or resume via keyboard or HUD button with a centered `PAUSED`
-  indicator that leaves the interface visible
+- Pause or resume via keyboard or HUD button with a `PAUSED` indicator and a
+  hint to press `Esc` or `P` to resume, leaving the interface visible
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `F1` toggles debug
   overlays, `Enter` starts or restarts from the menu or game over, `R` restarts at

--- a/lib/game/game_state.md
+++ b/lib/game/game_state.md
@@ -7,8 +7,8 @@ Enum describing high-level game phases.
 - `menu` – initial overlay before play.
 - `playing` – active gameplay loop.
 - `upgrades` – upgrade selection overlay while gameplay is paused.
-- `paused` – gameplay halted with a centered `PAUSED` indicator; keyboard
-  shortcuts still work.
+- `paused` – gameplay halted with a `PAUSED` indicator and resume hint;
+  keyboard shortcuts still work.
 - `gameOver` – player died; show overlay with restart, menu and mute options.
 
 Used by `SpaceGame` to swap overlays and reset state.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -15,8 +15,8 @@ Flutter overlays and HUD widgets.
   reset, help (`H`) and mute toggle.
 - [HudOverlay](hud_overlay.md) – shows score, high score, minerals (with icon)
     and health with auto-aim radius toggle, help, upgrades, mute and pause buttons.
-- [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label while
-  the game is paused.
+- [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label with
+  instructions to press `Esc` or `P` to resume while the game is paused.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with
   restart (button or `Enter`/`R`), menu, help and mute options.
 - [HelpOverlay](help_overlay.md) – lists all controls; toggled with `H` and

--- a/lib/ui/pause_overlay.dart
+++ b/lib/ui/pause_overlay.dart
@@ -14,11 +14,21 @@ class PauseOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return IgnorePointer(
       child: OverlayLayout(
-        builder: (context, _, __) {
-          return GameText(
-            'PAUSED',
-            style: Theme.of(context).textTheme.headlineMedium,
-            maxLines: 1,
+        builder: (context, spacing, __) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              GameText(
+                'PAUSED',
+                style: Theme.of(context).textTheme.headlineMedium,
+                maxLines: 1,
+              ),
+              SizedBox(height: spacing),
+              const GameText(
+                'Press Esc or P to resume',
+                maxLines: 1,
+              ),
+            ],
           );
         },
       ),

--- a/lib/ui/pause_overlay.md
+++ b/lib/ui/pause_overlay.md
@@ -4,7 +4,7 @@ Overlay displayed when the game is paused.
 
 ## Features
 
-- Shows a centered "PAUSED" label.
+- Shows a centered "PAUSED" label with a hint to press `Esc` or `P` to resume.
 - Gameplay is halted but the interface remains visible for inspection.
 - Triggered from the HUD pause button or the Escape or `P` key.
 - Visible only while the game state is `paused`.


### PR DESCRIPTION
## Summary
- Show “Press Esc or P to resume” under the PAUSED label
- Document the new resume hint across docs

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b8053521bc8330a940678caf6d4f39