### PR TITLE
Set default text scaling to 1.5x

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 class SettingsService {
   SettingsService()
       : hudButtonScale = ValueNotifier<double>(1),
-        textScale = ValueNotifier<double>(1),
+        textScale = ValueNotifier<double>(1.5),
         joystickScale = ValueNotifier<double>(1);
 
   /// Multiplier applied to HUD buttons and icons.


### PR DESCRIPTION
## Summary
- increase default text scale factor to 1.5x for clearer in-game text

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b80878da648330911bec22d1239c99