### PR TITLE
Default HUD and text scale to 0.75

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -35,6 +35,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it
+- [ ] Settings overlay sliders adjust HUD button, text and joystick sizes
+      (default 0.75 for buttons and text)
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -3,9 +3,13 @@ import 'package:flutter/foundation.dart';
 /// Holds tweakable UI scale values for live prototyping.
 class SettingsService {
   SettingsService()
-      : hudButtonScale = ValueNotifier<double>(1),
-        textScale = ValueNotifier<double>(1),
-        joystickScale = ValueNotifier<double>(1);
+      : hudButtonScale = ValueNotifier<double>(defaultHudButtonScale),
+        textScale = ValueNotifier<double>(defaultTextScale),
+        joystickScale = ValueNotifier<double>(defaultJoystickScale);
+
+  static const double defaultHudButtonScale = 0.75;
+  static const double defaultTextScale = 0.75;
+  static const double defaultJoystickScale = 1;
 
   /// Multiplier applied to HUD buttons and icons.
   final ValueNotifier<double> hudButtonScale;


### PR DESCRIPTION
## Summary
- Set default HUD button and in-game text scaling to 0.75 with named constants
- Document settings overlay slider defaults in playtest checklist

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b808ace8a88330978acea2012674f7