### PR TITLE
Fix service worker load timeout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -44,6 +44,13 @@
       }
     </script>
     <script src="segmenter_polyfill.js"></script>
+    <script>
+      // Disable Flutter's default service worker bootstrap since we register our
+      // own `sw.js` above. This prevents Flutter's loader from waiting four
+      // seconds for `flutter_service_worker.js`, which would otherwise log a
+      // noisy console error when it times out.
+      var serviceWorkerVersion = null;
+    </script>
     <script src="flutter_bootstrap.js" async></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent Flutter bootstrap from waiting on its generated service worker

## Testing
- `scripts/dartw format web/index.html` *(fails: The '===' operator is not supported.)*
- `scripts/dartw format lib test`
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b805240a2c83309c7bb472d9a43126