### PR TITLE
feat: add centralized theming with color scheme

### DIFF
--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -23,9 +23,27 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
 
   final PlayerComponent player;
   AsteroidComponent? _target;
-  final Paint _paint = Paint()..color = const Color(0x66ffffff);
+  late Paint _paint;
   final Timer _pulseTimer = Timer(Constants.miningPulseInterval, repeat: true);
   bool _playingSound = false;
+  late final VoidCallback _themeListener;
+
+  @override
+  void onMount() {
+    super.onMount();
+    _paint = Paint()..color = _laserColor();
+    _themeListener = () => _paint.color = _laserColor();
+    game.themeService.addListener(_themeListener);
+  }
+
+  Color _laserColor() =>
+      game.themeService.gameColors.miningLaser.withValues(alpha: 0.4);
+
+  @override
+  void onRemove() {
+    game.themeService.removeListener(_themeListener);
+    super.onRemove();
+  }
 
   @override
   void update(double dt) {

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -58,12 +58,9 @@ class PlayerComponent extends SpriteComponent
   bool isMoving = false;
 
   /// Paint used when drawing the auto-aim radius.
-  final Paint _autoAimPaint = Paint()
-    ..color = const Color(0x66ffffff)
-    ..style = PaintingStyle.stroke;
+  final Paint _autoAimPaint = Paint()..style = PaintingStyle.stroke;
 
-  static final _damageFilter =
-      ColorFilter.mode(const Color(0xffff0000), BlendMode.srcATop);
+  late VoidCallback _themeListener;
 
   /// Remaining time for the damage flash effect.
   double _damageFlashTime = 0;
@@ -106,7 +103,10 @@ class PlayerComponent extends SpriteComponent
   /// Triggers a short red flash to indicate damage taken.
   void flashDamage() {
     _damageFlashTime = Constants.playerDamageFlashDuration;
-    paint.colorFilter = _damageFilter;
+    paint.colorFilter = ColorFilter.mode(
+      game.themeService.colorScheme.error,
+      BlendMode.srcATop,
+    );
   }
 
   /// Allows external callers to fire a bullet.
@@ -128,6 +128,7 @@ class PlayerComponent extends SpriteComponent
     await add(_input);
     await add(_autoAim);
     await add(TractorAuraRenderer());
+    _applyTheme();
   }
 
   @override
@@ -139,6 +140,8 @@ class PlayerComponent extends SpriteComponent
     if (!contains(_autoAim)) {
       add(_autoAim);
     }
+    _themeListener = _applyTheme;
+    game.themeService.addListener(_themeListener);
     keyDispatcher.register(
       LogicalKeyboardKey.space,
       onDown: startShooting,
@@ -149,6 +152,7 @@ class PlayerComponent extends SpriteComponent
   @override
   void onRemove() {
     keyDispatcher.unregister(LogicalKeyboardKey.space);
+    game.themeService.removeListener(_themeListener);
     super.onRemove();
   }
 
@@ -176,6 +180,11 @@ class PlayerComponent extends SpriteComponent
         paint.colorFilter = null;
       }
     }
+  }
+
+  void _applyTheme() {
+    final color = game.themeService.colorScheme.primary;
+    _autoAimPaint.color = color.withValues(alpha: 0.4);
   }
 
   @override

--- a/lib/components/tractor_aura_renderer.dart
+++ b/lib/components/tractor_aura_renderer.dart
@@ -3,10 +3,12 @@ import 'dart:ui';
 import 'package:flame/components.dart';
 
 import '../constants.dart';
+import '../game/space_game.dart';
 import 'player.dart';
 
 /// Renders the player's tractor aura as a radial gradient.
-class TractorAuraRenderer extends Component with ParentIsA<PlayerComponent> {
+class TractorAuraRenderer extends Component
+    with ParentIsA<PlayerComponent>, HasGameReference<SpaceGame> {
   final Paint _paint = Paint()..style = PaintingStyle.fill;
 
   @override
@@ -14,12 +16,13 @@ class TractorAuraRenderer extends Component with ParentIsA<PlayerComponent> {
     super.render(canvas);
     final auraCenter = Offset(parent.size.x / 2, parent.size.y / 2);
     final auraRadius = Constants.playerTractorAuraRadius;
+    final color = game.themeService.colorScheme.secondary;
     _paint.shader = Gradient.radial(
       auraCenter,
       auraRadius,
       [
-        const Color(0x5500aaff),
-        const Color(0x0000aaff),
+        color.withValues(alpha: 0.33),
+        color.withValues(alpha: 0),
       ],
     );
     canvas.drawCircle(auraCenter, auraRadius, _paint);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'ui/game_text.dart';
 import 'services/storage_service.dart';
 import 'services/audio_service.dart';
 import 'services/settings_service.dart';
+import 'services/theme_service.dart';
 
 /// Application entry point.
 Future<void> main() async {
@@ -22,42 +23,44 @@ Future<void> main() async {
   final storage = await StorageService.create();
   final audio = await AudioService.create(storage);
   final settings = SettingsService();
+  final theme = ThemeService();
   final focusNode = FocusNode();
   final game = SpaceGame(
     storageService: storage,
     audioService: audio,
+    themeService: theme,
     settingsService: settings,
     focusNode: focusNode,
   );
   GameText.attachTextScale(settings.textScale);
   runApp(
-    MaterialApp(
-      theme: ThemeData(
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.grey.shade700,
-            side: BorderSide(color: Colors.grey.shade500, width: 2),
-          ),
+    AnimatedBuilder(
+      animation: theme,
+      builder: (context, _) => MaterialApp(
+        theme: theme.lightTheme,
+        darkTheme: theme.darkTheme,
+        themeMode: theme.themeMode,
+        home: GameWidget<SpaceGame>(
+          game: game,
+          focusNode: focusNode,
+          // Automatically request keyboard focus so web players can use WASD
+          // without tapping the canvas first.
+          autofocus: true,
+          overlayBuilderMap: {
+            MenuOverlay.id: (context, SpaceGame game) =>
+                MenuOverlay(game: game),
+            HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
+            PauseOverlay.id: (context, SpaceGame game) => const PauseOverlay(),
+            GameOverOverlay.id: (context, SpaceGame game) =>
+                GameOverOverlay(game: game),
+            HelpOverlay.id: (context, SpaceGame game) =>
+                HelpOverlay(game: game),
+            UpgradesOverlay.id: (context, SpaceGame game) =>
+                UpgradesOverlay(game: game),
+            SettingsOverlay.id: (context, SpaceGame game) =>
+                SettingsOverlay(game: game),
+          },
         ),
-      ),
-      home: GameWidget<SpaceGame>(
-        game: game,
-        focusNode: focusNode,
-        // Automatically request keyboard focus so web players can use WASD
-        // without tapping the canvas first.
-        autofocus: true,
-        overlayBuilderMap: {
-          MenuOverlay.id: (context, SpaceGame game) => MenuOverlay(game: game),
-          HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
-          PauseOverlay.id: (context, SpaceGame game) => const PauseOverlay(),
-          GameOverOverlay.id: (context, SpaceGame game) =>
-              GameOverOverlay(game: game),
-          HelpOverlay.id: (context, SpaceGame game) => HelpOverlay(game: game),
-          UpgradesOverlay.id: (context, SpaceGame game) =>
-              UpgradesOverlay(game: game),
-          SettingsOverlay.id: (context, SpaceGame game) =>
-              SettingsOverlay(game: game),
-        },
       ),
     ),
   );

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../theme/game_colors.dart';
+
+/// Manages the current [ThemeMode] and provides the app-wide [ThemeData].
+class ThemeService extends ChangeNotifier {
+  ThemeService() : _themeMode = ThemeMode.system;
+
+  ThemeMode _themeMode;
+  ThemeMode get themeMode => _themeMode;
+
+  /// Toggles between light and dark themes.
+  void toggleTheme() {
+    _themeMode =
+        _themeMode == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+  }
+
+  /// Light theme built from a seed colour and custom [GameColors].
+  ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.grey.shade700,
+            side: BorderSide(color: Colors.grey.shade500, width: 2),
+          ),
+        ),
+        extensions: const <ThemeExtension<dynamic>>[
+          GameColors(
+            miningLaser: Colors.lightGreenAccent,
+            enemyLaser: Colors.redAccent,
+          ),
+        ],
+      );
+
+  /// Dark theme variant with its own [ColorScheme] and [GameColors].
+  ThemeData get darkTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.dark,
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.grey.shade600,
+            side: const BorderSide(color: Colors.grey, width: 2),
+          ),
+        ),
+        extensions: const <ThemeExtension<dynamic>>[
+          GameColors(
+            miningLaser: Colors.greenAccent,
+            enemyLaser: Colors.red,
+          ),
+        ],
+      );
+
+  /// Convenience getter for the active [ColorScheme].
+  ColorScheme get colorScheme =>
+      (themeMode == ThemeMode.dark ? darkTheme : lightTheme).colorScheme;
+
+  /// Convenience getter for the active [GameColors] extension.
+  GameColors get gameColors => (themeMode == ThemeMode.dark
+      ? darkTheme.extension<GameColors>()
+      : lightTheme.extension<GameColors>())!;
+}

--- a/lib/theme/game_colors.dart
+++ b/lib/theme/game_colors.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// Custom colours used throughout the game that are not covered by the core
+/// [ColorScheme].
+@immutable
+class GameColors extends ThemeExtension<GameColors> {
+  const GameColors({
+    required this.miningLaser,
+    required this.enemyLaser,
+  });
+
+  /// Colour of the player's mining laser beam.
+  final Color miningLaser;
+
+  /// Colour of enemy laser projectiles.
+  final Color enemyLaser;
+
+  @override
+  GameColors copyWith({Color? miningLaser, Color? enemyLaser}) {
+    return GameColors(
+      miningLaser: miningLaser ?? this.miningLaser,
+      enemyLaser: enemyLaser ?? this.enemyLaser,
+    );
+  }
+
+  @override
+  GameColors lerp(ThemeExtension<GameColors>? other, double t) {
+    if (other is! GameColors) {
+      return this;
+    }
+    return GameColors(
+      miningLaser: Color.lerp(miningLaser, other.miningLaser, t)!,
+      enemyLaser: Color.lerp(enemyLaser, other.enemyLaser, t)!,
+    );
+  }
+}

--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -1,11 +1,12 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 /// Displays text using a consistent style across game overlays.
 ///
-/// Defaults to yellow text with a modest font size but can be customised
-/// via [style], [maxLines] and [textAlign].
+/// The default colour is pulled from the active [Theme]'s
+/// [ColorScheme.primary] to keep text in sync with the app theme, but it can
+/// be overridden via [color], [style], [maxLines] and [textAlign].
 class GameText extends StatelessWidget {
   const GameText(
     this.data, {
@@ -31,13 +32,7 @@ class GameText extends StatelessWidget {
   /// Explicit colour override for the text.
   final Color? color;
 
-  /// Base colour used for in-game text.
-  static const Color defaultColor = Colors.yellow;
-
-  static const _baseStyle = TextStyle(
-    color: defaultColor,
-    fontSize: 18,
-  );
+  static const _baseStyle = TextStyle(fontSize: 18);
 
   /// Globally applied text scale factor. When attached, all [GameText]
   /// instances rebuild in response to changes.
@@ -50,6 +45,7 @@ class GameText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final defaultColor = Theme.of(context).colorScheme.primary;
     Widget buildText(double scale) {
       final mergedStyle =
           _baseStyle.merge(style).copyWith(color: color ?? defaultColor);

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -65,7 +65,10 @@ class HudOverlay extends StatelessWidget {
                     children: [
                       IconButton(
                         iconSize: iconSize,
-                        icon: const Icon(Icons.gps_fixed, color: Colors.white),
+                        icon: Icon(
+                          Icons.gps_fixed,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
                         onPressed: game.toggleAutoAimRadius,
                       ),
                       UpgradeButton(game: game, iconSize: iconSize),
@@ -75,8 +78,10 @@ class HudOverlay extends StatelessWidget {
                       IconButton(
                         iconSize: iconSize,
                         // Mirrors the Escape and P keyboard shortcuts.
-                        icon: const Icon(Icons.pause,
-                            color: GameText.defaultColor),
+                        icon: Icon(
+                          Icons.pause,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
                         onPressed: game.pauseGame,
                       ),
                     ],

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -72,7 +72,7 @@ class MenuOverlay extends StatelessWidget {
                         decoration: BoxDecoration(
                           border: Border.all(
                             color: selected == i
-                                ? GameText.defaultColor
+                                ? Theme.of(context).colorScheme.primary
                                 : Colors.transparent,
                             width: 2,
                           ),

--- a/lib/ui/mineral_display.dart
+++ b/lib/ui/mineral_display.dart
@@ -18,9 +18,9 @@ class MineralDisplay extends StatelessWidget {
       builder: (context, value, _) => Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
         decoration: BoxDecoration(
-          color: Colors.black54,
+          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.6),
           borderRadius: BorderRadius.circular(24),
-          border: Border.all(color: Colors.white),
+          border: Border.all(color: Theme.of(context).colorScheme.onSurface),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -35,7 +35,10 @@ class OverlayLayout extends StatelessWidget {
 
         Widget child = Center(child: builder(context, spacing, iconSize));
         if (dimmed) {
-          child = Container(color: Colors.black54, child: child);
+          child = Container(
+            color: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.5),
+            child: child,
+          );
         }
         return child;
       },
@@ -58,7 +61,7 @@ class MuteButton extends StatelessWidget {
         iconSize: iconSize,
         icon: Icon(
           muted ? Icons.volume_off : Icons.volume_up,
-          color: GameText.defaultColor,
+          color: Theme.of(context).colorScheme.primary,
         ),
         onPressed: game.audioService.toggleMute,
       ),
@@ -81,7 +84,10 @@ class HelpButton extends StatelessWidget {
     if (iconSize != null) {
       return IconButton(
         iconSize: iconSize,
-        icon: const Icon(Icons.help_outline, color: GameText.defaultColor),
+        icon: Icon(
+          Icons.help_outline,
+          color: Theme.of(context).colorScheme.primary,
+        ),
         onPressed: game.toggleHelp,
       );
     }
@@ -107,7 +113,10 @@ class UpgradeButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       iconSize: iconSize,
-      icon: const Icon(Icons.upgrade, color: GameText.defaultColor),
+      icon: Icon(
+        Icons.upgrade,
+        color: Theme.of(context).colorScheme.primary,
+      ),
       onPressed: game.toggleUpgrades,
     );
   }
@@ -124,7 +133,10 @@ class SettingsButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       iconSize: iconSize,
-      icon: const Icon(Icons.tune, color: GameText.defaultColor),
+      icon: Icon(
+        Icons.tune,
+        color: Theme.of(context).colorScheme.primary,
+      ),
       onPressed: game.toggleSettings,
     );
   }

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -45,6 +45,19 @@ class SettingsOverlay extends StatelessWidget {
               settings.joystickScale,
               spacing,
             ),
+            AnimatedBuilder(
+              animation: game.themeService,
+              builder: (context, _) => Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const GameText('Dark Theme'),
+                  Switch(
+                    value: game.themeService.themeMode == ThemeMode.dark,
+                    onChanged: (_) => game.themeService.toggleTheme(),
+                  ),
+                ],
+              ),
+            ),
             SizedBox(height: spacing),
             ElevatedButton(
               onPressed: game.toggleSettings,


### PR DESCRIPTION
## Summary
- introduce ThemeService with light/dark ColorSchemes and GameColors extension
- wire up ThemeService to MaterialApp, SpaceGame, and settings overlay
- use theme colors in MiningLaserComponent and overlay widgets
- theme joystick controls, player auto-aim radius, and tractor aura via shared ColorScheme

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test --reporter=compact`


------
https://chatgpt.com/codex/tasks/task_e_68b803db8a80833094d941b0446d4a9b