### PR TITLE
Handle pending explosions on restart

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -14,6 +14,10 @@ class LifecycleManager {
   void onStart() {
     game.scoreService.reset();
     game.pools.clear();
+    // Process any queued lifecycle events so components added just before the
+    // previous session ended (like the player's explosion on death) are
+    // mounted and can be removed before the new run begins.
+    game.processLifecycleEvents();
     // Remove any lingering explosions from a previous session.
     for (final explosion in List<ExplosionComponent>.from(
       game.children.whereType<ExplosionComponent>(),

--- a/test/restart_clears_explosions_test.dart
+++ b/test/restart_clears_explosions_test.dart
@@ -43,4 +43,28 @@ void main() {
     await game.ready();
     expect(game.children.whereType<ExplosionComponent>(), isEmpty);
   });
+
+  test('restarting immediately clears pending explosions', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.explosions]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    audio.muted.value = true;
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+
+    game.startGame();
+    for (var i = 0; i < Constants.playerMaxHealth; i++) {
+      game.hitPlayer();
+    }
+    // Immediately restart without waiting for lifecycle events to process.
+    game.startGame();
+    await game.ready();
+    expect(game.children.whereType<ExplosionComponent>(), isEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
- process lifecycle events before clearing explosions when a new game starts
- test that immediate restarts remove pending explosions

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b80d18eed88330bf8c39e1304a6145