### PR TITLE
Update help menu controls

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -166,13 +166,11 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   available on menu, HUD and game over overlays
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `Enter` starts or
-  restarts from the menu or game over, `R` restarts at any time, `Q` returns to
-  the menu from pause or game over, `Esc` also returns to the menu from game over,
-  `H` shows a help overlay that `Esc` also closes)
+  restarts from the menu or game over, `R` restarts at any time, `H` shows a help
+  overlay that `Esc` also closes)
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
-- Pause or resume with a `PAUSED` label overlay; `Q` returns to the menu from
-  pause or game over
+- Pause or resume with a `PAUSED` label overlay
 
 ## 🗓️ Milestones
 

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -9,7 +9,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Player can shoot and destroy a basic enemy
 - [ ] Bullets travel in the direction the ship is facing
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
-- [ ] HUD button toggles auto-aim radius display
+- [ ] Target button toggles auto-aim radius display
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score
@@ -23,15 +23,14 @@ _Update this file whenever a player-facing feature is added or changed._
       → restart or menu
 - [ ] Player can choose a ship from the menu before starting
 - [ ] Enter starts or restarts from the menu or game over; `R` restarts at any time
-- [ ] Escape or `P` key pauses or resumes the game; `Q` returns to the menu from
-      pause or game over, `Esc` also returns to the menu from game over
+- [ ] Escape or `P` key pauses or resumes the game
 - [ ] Parallax starfield renders behind gameplay
 - [ ] Sound effects play and can be muted from menu, HUD or game over overlay,
       or via the `M` key
 - [ ] Laser shot sound plays when firing
 - [ ] Explosion animation and sound play when a ship is destroyed
 - [ ] Mining laser emits a looping sound while active
-- [ ] Game can be paused and resumed; `Q` returns to the menu (including from game over)
+- [ ] Game can be paused and resumed
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ dedicated server or NAT traversal.
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `F1` toggles debug
   overlays, `Enter` starts or restarts from the menu or game over, `R` restarts at
-  any time, `Q` returns to the menu from pause or game over, `Esc` also returns to
-  the menu from game over, `H` shows a help overlay that `Esc` also closes)
+  any time, `H` shows a help overlay that `Esc` also closes, `U`
+  opens an upgrades overlay that `Esc` also closes)
 - Game works offline after the first load
 - Parallax starfield background
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -64,8 +64,6 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Keyboard shortcut `P` pauses or resumes the game.
 - [x] Keyboard shortcuts: `Enter` starts or restarts from the menu or game over;
       `R` restarts during play, pause or game over.
-- [x] Keyboard shortcut `Q` returns to the menu from pause or game over.
-- [x] Keyboard shortcut `Esc` returns to the menu from game over.
 - [x] Help overlay lists controls and can be toggled with a button or the `H` key;
       `Esc` also closes it.
 - [x] HUD displays current and high scores alongside health.

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -20,8 +20,6 @@ class ShortcutManager {
         stateMachine.pauseGame();
       } else if (stateMachine.state == GameState.paused) {
         stateMachine.resumeGame();
-      } else if (stateMachine.state == GameState.gameOver) {
-        stateMachine.returnToMenu();
       }
     });
 
@@ -50,13 +48,6 @@ class ShortcutManager {
           stateMachine.state == GameState.playing ||
           stateMachine.state == GameState.paused) {
         stateMachine.startGame();
-      }
-    });
-
-    keyDispatcher.register(LogicalKeyboardKey.keyQ, onDown: () {
-      if (stateMachine.state == GameState.paused ||
-          stateMachine.state == GameState.gameOver) {
-        stateMachine.returnToMenu();
       }
     });
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -25,9 +25,7 @@ Flutter overlays and HUD widgets.
   upgrades; opened with `U` and pauses gameplay.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
-  time; `Escape` or `P` pauses or resumes; `Q` returns to the menu from pause
-  or game over and `Esc` also returns to the menu from game over; `H` shows or
-  hides the help overlay, `U` opens upgrades, and `Esc` also closes overlays
-  when visible.
+  time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,
+  `U` opens upgrades, and `Esc` also closes overlays when visible.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -33,11 +33,12 @@ class HelpOverlay extends StatelessWidget {
               'Shoot: Space\n'
               'Mute: M\n'
               'Toggle Debug: F1\n'
-              'Auto-aim Radius: HUD button\n'
+              'Auto-aim Radius: Target Button\n'
+              'Upgrades: U or HUD button\n'
+              'Settings: HUD button\n'
               'Pause/Resume: Esc or P\n'
               'Start/Restart: Enter\n'
               'Restart anytime: R\n'
-              'Menu: Q (pause/game over), Esc (game over)\n'
               'Toggle Help: H or Esc',
               textAlign: TextAlign.center,
             ),

--- a/lib/ui/pause_overlay.md
+++ b/lib/ui/pause_overlay.md
@@ -9,8 +9,7 @@ Overlay displayed when the game is paused.
   inspection.
 - Triggered from the HUD pause button or the Escape or `P` key.
 - Visible only while the game state is `paused`.
-- Keyboard shortcuts still work: `R` restarts, `Q` returns to the menu,
-  `M` toggles audio mute and `H` opens the help overlay which resumes when
-  closed; `Esc` also closes it.
+- Keyboard shortcuts still work: `R` restarts, `M` toggles audio mute and `H`
+  opens the help overlay which resumes when closed; `Esc` also closes it.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- rename auto-aim HUD entry to target button and drop menu shortcut
- remove Q/Esc menu hotkeys and refresh documentation

## Testing
- `npx --yes markdownlint-cli README.md PLAYTEST_CHECKLIST.md PLAN.md TASKS.md lib/ui/pause_overlay.md lib/ui/README.md`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b8097689c4833094dd26ca3290a17f