### PR TITLE
feat: add centralized color theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dedicated server or NAT traversal.
 - Code and asset base kept tiny and easy to maintain
 - Ship quickly and iterate in small increments
 - Responsive scaling for phones, tablets and desktop
+- Centralised colour theming with light and dark palettes
 - Solo-friendly workflow with minimal tooling
 - Fun, casual tone with cartoony visuals
 - Modular game logic built with Flame (pinned for stability)

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -20,9 +20,22 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
 
   final PlayerComponent player;
   AsteroidComponent? _target;
-  final Paint _paint = Paint()..color = const Color(0x66ffffff);
+  final Paint _paint = Paint();
+  late void Function() _colorListener;
   final Timer _pulseTimer = Timer(Constants.miningPulseInterval, repeat: true);
   bool _playingSound = false;
+
+  @override
+  void onMount() {
+    super.onMount();
+    void updateColor() {
+      _paint.color = game.gameColors.value.playerLaser.withValues(alpha: 0.4);
+    }
+
+    updateColor();
+    _colorListener = updateColor;
+    game.gameColors.addListener(_colorListener);
+  }
 
   @override
   void update(double dt) {
@@ -86,5 +99,11 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
       _target!.position.toOffset(),
       _paint,
     );
+  }
+
+  @override
+  void onRemove() {
+    game.gameColors.removeListener(_colorListener);
+    super.onRemove();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'assets.dart';
 import 'game/space_game.dart';
+import 'theme/game_theme.dart';
 import 'ui/game_over_overlay.dart';
 import 'ui/hud_overlay.dart';
 import 'ui/menu_overlay.dart';
@@ -23,41 +24,70 @@ Future<void> main() async {
   final audio = await AudioService.create(storage);
   final settings = SettingsService();
   final focusNode = FocusNode();
+
+  final lightScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
+  final darkScheme = ColorScheme.fromSeed(
+      seedColor: Colors.deepPurple, brightness: Brightness.dark);
+  final colorScheme = ValueNotifier<ColorScheme>(lightScheme);
+  final gameColors = ValueNotifier<GameColors>(GameColors.light);
+
+  settings.themeMode.addListener(() {
+    if (settings.themeMode.value == ThemeMode.dark) {
+      colorScheme.value = darkScheme;
+      gameColors.value = GameColors.dark;
+    } else {
+      colorScheme.value = lightScheme;
+      gameColors.value = GameColors.light;
+    }
+  });
+
   final game = SpaceGame(
     storageService: storage,
     audioService: audio,
     settingsService: settings,
     focusNode: focusNode,
+    colorScheme: colorScheme,
+    gameColors: gameColors,
   );
+
   GameText.attachTextScale(settings.textScale);
+
   runApp(
-    MaterialApp(
-      theme: ThemeData(
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.grey.shade700,
-            side: BorderSide(color: Colors.grey.shade500, width: 2),
-          ),
+    ValueListenableBuilder<ThemeMode>(
+      valueListenable: settings.themeMode,
+      builder: (context, mode, _) => MaterialApp(
+        theme: ThemeData(
+          colorScheme: lightScheme,
+          useMaterial3: true,
+          extensions: const [GameColors.light],
         ),
-      ),
-      home: GameWidget<SpaceGame>(
-        game: game,
-        focusNode: focusNode,
-        // Automatically request keyboard focus so web players can use WASD
-        // without tapping the canvas first.
-        autofocus: true,
-        overlayBuilderMap: {
-          MenuOverlay.id: (context, SpaceGame game) => MenuOverlay(game: game),
-          HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
-          PauseOverlay.id: (context, SpaceGame game) => const PauseOverlay(),
-          GameOverOverlay.id: (context, SpaceGame game) =>
-              GameOverOverlay(game: game),
-          HelpOverlay.id: (context, SpaceGame game) => HelpOverlay(game: game),
-          UpgradesOverlay.id: (context, SpaceGame game) =>
-              UpgradesOverlay(game: game),
-          SettingsOverlay.id: (context, SpaceGame game) =>
-              SettingsOverlay(game: game),
-        },
+        darkTheme: ThemeData(
+          colorScheme: darkScheme,
+          useMaterial3: true,
+          extensions: const [GameColors.dark],
+        ),
+        themeMode: mode,
+        home: GameWidget<SpaceGame>(
+          game: game,
+          focusNode: focusNode,
+          // Automatically request keyboard focus so web players can use WASD
+          // without tapping the canvas first.
+          autofocus: true,
+          overlayBuilderMap: {
+            MenuOverlay.id: (context, SpaceGame game) =>
+                MenuOverlay(game: game),
+            HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
+            PauseOverlay.id: (context, SpaceGame game) => const PauseOverlay(),
+            GameOverOverlay.id: (context, SpaceGame game) =>
+                GameOverOverlay(game: game),
+            HelpOverlay.id: (context, SpaceGame game) =>
+                HelpOverlay(game: game),
+            UpgradesOverlay.id: (context, SpaceGame game) =>
+                UpgradesOverlay(game: game),
+            SettingsOverlay.id: (context, SpaceGame game) =>
+                SettingsOverlay(game: game),
+          },
+        ),
       ),
     ),
   );

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,11 +1,12 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 /// Holds tweakable UI scale values for live prototyping.
 class SettingsService {
   SettingsService()
       : hudButtonScale = ValueNotifier<double>(defaultHudButtonScale),
         textScale = ValueNotifier<double>(defaultTextScale),
-        joystickScale = ValueNotifier<double>(defaultJoystickScale);
+        joystickScale = ValueNotifier<double>(defaultJoystickScale),
+        themeMode = ValueNotifier<ThemeMode>(ThemeMode.light);
 
   static const double defaultHudButtonScale = 0.75;
   static const double defaultTextScale = 1.5;
@@ -19,4 +20,7 @@ class SettingsService {
 
   /// Multiplier applied to on-screen joystick elements.
   final ValueNotifier<double> joystickScale;
+
+  /// Currently selected theme mode.
+  final ValueNotifier<ThemeMode> themeMode;
 }

--- a/lib/theme/game_theme.dart
+++ b/lib/theme/game_theme.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Theme extension holding game-specific colour roles.
+@immutable
+class GameColors extends ThemeExtension<GameColors> {
+  const GameColors({required this.playerLaser, required this.enemyLaser});
+
+  /// Colour for the player's mining laser and related effects.
+  final Color playerLaser;
+
+  /// Colour for enemy projectiles.
+  final Color enemyLaser;
+
+  @override
+  GameColors copyWith({Color? playerLaser, Color? enemyLaser}) {
+    return GameColors(
+      playerLaser: playerLaser ?? this.playerLaser,
+      enemyLaser: enemyLaser ?? this.enemyLaser,
+    );
+  }
+
+  @override
+  GameColors lerp(ThemeExtension<GameColors>? other, double t) {
+    if (other is! GameColors) return this;
+    return GameColors(
+      playerLaser: Color.lerp(playerLaser, other.playerLaser, t)!,
+      enemyLaser: Color.lerp(enemyLaser, other.enemyLaser, t)!,
+    );
+  }
+
+  /// Light theme values.
+  static const GameColors light = GameColors(
+    playerLaser: Color(0xffffffff),
+    enemyLaser: Color(0xffff6666),
+  );
+
+  /// Dark theme values.
+  static const GameColors dark = GameColors(
+    playerLaser: Color(0xffffffff),
+    enemyLaser: Color(0xffff8888),
+  );
+}

--- a/lib/ui/health_display.dart
+++ b/lib/ui/health_display.dart
@@ -12,9 +12,10 @@ class HealthDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return HudValueDisplay(
       valueListenable: game.health,
-      icon: const Icon(Icons.favorite, color: Colors.white, size: 24),
+      icon: Icon(Icons.favorite, color: scheme.error, size: 24),
     );
   }
 }

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -49,7 +49,8 @@ class HudOverlay extends StatelessWidget {
                     children: [
                       IconButton(
                         iconSize: iconSize,
-                        icon: const Icon(Icons.gps_fixed, color: Colors.white),
+                        icon: Icon(Icons.gps_fixed,
+                            color: Theme.of(context).colorScheme.onSurface),
                         onPressed: game.toggleAutoAimRadius,
                       ),
                       UpgradeButton(game: game, iconSize: iconSize),

--- a/lib/ui/hud_value_display.dart
+++ b/lib/ui/hud_value_display.dart
@@ -19,14 +19,15 @@ class HudValueDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return ValueListenableBuilder<int>(
       valueListenable: valueListenable,
       builder: (context, value, _) => Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
         decoration: BoxDecoration(
-          color: Colors.black54,
+          color: scheme.surface.withValues(alpha: 0.7),
           borderRadius: BorderRadius.circular(24),
-          border: Border.all(color: Colors.white),
+          border: Border.all(color: scheme.onSurface),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -35,7 +35,11 @@ class OverlayLayout extends StatelessWidget {
 
         Widget child = Center(child: builder(context, spacing, iconSize));
         if (dimmed) {
-          child = Container(color: Colors.black54, child: child);
+          final scheme = Theme.of(context).colorScheme;
+          child = Container(
+            color: scheme.scrim.withValues(alpha: 0.54),
+            child: child,
+          );
         }
         return child;
       },

--- a/lib/ui/score_display.dart
+++ b/lib/ui/score_display.dart
@@ -12,9 +12,10 @@ class ScoreDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return HudValueDisplay(
       valueListenable: game.score,
-      icon: const Icon(Icons.star, color: Colors.white, size: 24),
+      icon: Icon(Icons.star, color: scheme.primary, size: 24),
     );
   }
 }

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -45,6 +45,15 @@ class SettingsOverlay extends StatelessWidget {
               settings.joystickScale,
               spacing,
             ),
+            ValueListenableBuilder<ThemeMode>(
+              valueListenable: settings.themeMode,
+              builder: (context, mode, _) => SwitchListTile(
+                title: const GameText('Dark Theme', maxLines: 1),
+                value: mode == ThemeMode.dark,
+                onChanged: (v) => settings.themeMode.value =
+                    v ? ThemeMode.dark : ThemeMode.light,
+              ),
+            ),
             SizedBox(height: spacing),
             ElevatedButton(
               onPressed: game.toggleSettings,


### PR DESCRIPTION
## Summary
- introduce `GameColors` theme extension and centralized light/dark `ColorScheme`
- allow runtime theme switching via `SettingsService` and overlay toggle
- apply theme colours across HUD widgets and Flame components

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`
- `npx --yes markdownlint-cli README.md`


------
https://chatgpt.com/codex/tasks/task_e_68b80ff744348330b5414cd96c0efaa3