### PR TITLE
Ensure mining audio stops on death and resets

### DIFF
--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -27,7 +27,16 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
   @override
   void update(double dt) {
     super.update(dt);
-    if (!player.isMounted) return;
+    if (!player.isMounted) {
+      _target = null;
+      _pulseTimer.stop();
+      _paint.strokeWidth = 2;
+      if (_playingSound) {
+        game.audioService.stopMiningLaser();
+        _playingSound = false;
+      }
+      return;
+    }
 
     final rangeSquared =
         Constants.playerMiningRange * Constants.playerMiningRange;
@@ -75,6 +84,15 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
         _playingSound = false;
       }
     }
+  }
+
+  @override
+  void onRemove() {
+    if (_playingSound) {
+      game.audioService.stopMiningLaser();
+      _playingSound = false;
+    }
+    super.onRemove();
   }
 
   @override

--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -12,6 +12,7 @@ class LifecycleManager {
   final SpaceGame game;
 
   void onStart() {
+    game.audioService.stopAll();
     game.scoreService.reset();
     game.pools.clear();
     // Process any queued lifecycle events so components added just before the
@@ -71,12 +72,14 @@ class LifecycleManager {
     game.enemySpawner.stop();
     game.asteroidSpawner.stop();
     game.scoreService.updateHighScoreIfNeeded();
+    game.audioService.stopAll();
     game.pauseEngine();
   }
 
   void onMenu() {
     game.enemySpawner.stop();
     game.asteroidSpawner.stop();
+    game.audioService.stopAll();
     game.pauseEngine();
   }
 }

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -84,4 +84,9 @@ class AudioService {
     _miningLoop?.stop();
     _miningLoop = null;
   }
+
+  /// Stops all ongoing audio loops.
+  void stopAll() {
+    stopMiningLaser();
+  }
 }


### PR DESCRIPTION
## Summary
- stop mining laser audio when player removed and during lifecycle transitions
- centralize audio cleanup with `AudioService.stopAll`

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b8111e253483309aeec1a45a4d6123