### PR TITLE
fix: update joystick scale when paused

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -318,10 +318,9 @@ class SpaceGame extends FlameGame
   }
 
   void _updateJoystickScale() {
-    final oldJoystick = joystick;
-    joystick = _buildJoystick();
-    oldJoystick.removeFromParent();
-    add(joystick);
+    final scale = settingsService.joystickScale.value;
+    (joystick.knob as CircleComponent).radius = 20 * scale;
+    (joystick.background as CircleComponent).radius = 50 * scale;
   }
 
   void _updateHudButtonScale() {


### PR DESCRIPTION
## Summary
- update joystick knob/background radius directly to apply scale while paused

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b8119c8b0483308307e2437acaa861