### PR TITLE
Fix joystick scaling when paused

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -320,8 +320,12 @@ class SpaceGame extends FlameGame
   void _updateJoystickScale() {
     final oldJoystick = joystick;
     joystick = _buildJoystick();
-    oldJoystick.removeFromParent();
     add(joystick);
+    oldJoystick.removeFromParent();
+    // When the game is paused, lifecycle events like component additions are
+    // only processed during updates. Processing them here ensures the new
+    // joystick appears immediately so its scale updates even while paused.
+    processLifecycleEvents();
   }
 
   void _updateHudButtonScale() {


### PR DESCRIPTION
## Summary
- process lifecycle events after rebuilding the joystick so scale changes apply even while the game is paused

## Testing
- `./scripts/dartw analyze lib/game/space_game.dart`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b8119c8b0483308307e2437acaa861