### PR TITLE
Use ColorScheme across UI and game components

### DIFF
--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -58,9 +58,8 @@ class PlayerComponent extends SpriteComponent
   bool isMoving = false;
 
   /// Paint used when drawing the auto-aim radius.
-  final Paint _autoAimPaint = Paint()
-    ..color = const Color(0x66ffffff)
-    ..style = PaintingStyle.stroke;
+  final Paint _autoAimPaint = Paint()..style = PaintingStyle.stroke;
+  late void Function() _autoAimColorListener;
 
   static final _damageFilter =
       ColorFilter.mode(const Color(0xffff0000), BlendMode.srcATop);
@@ -139,6 +138,14 @@ class PlayerComponent extends SpriteComponent
     if (!contains(_autoAim)) {
       add(_autoAim);
     }
+    void updateAutoAimColor() {
+      _autoAimPaint.color =
+          game.colorScheme.value.primary.withValues(alpha: 0.4);
+    }
+
+    updateAutoAimColor();
+    _autoAimColorListener = updateAutoAimColor;
+    game.colorScheme.addListener(_autoAimColorListener);
     keyDispatcher.register(
       LogicalKeyboardKey.space,
       onDown: startShooting,
@@ -149,6 +156,7 @@ class PlayerComponent extends SpriteComponent
   @override
   void onRemove() {
     keyDispatcher.unregister(LogicalKeyboardKey.space);
+    game.colorScheme.removeListener(_autoAimColorListener);
     super.onRemove();
   }
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -107,6 +107,7 @@ class SpaceGame extends FlameGame
   bool _playerInitialized = false;
 
   late void Function() _updateFireButtonColors;
+  late void Function() _updateJoystickColors;
 
   ValueNotifier<int> get score => scoreService.score;
   ValueNotifier<int> get highScore => scoreService.highScore;
@@ -137,6 +138,16 @@ class SpaceGame extends FlameGame
 
     joystick = _buildJoystick();
     await add(joystick);
+    void updateJoystickColors() {
+      (joystick.knob as CircleComponent).paint.color =
+          colorScheme.value.primary;
+      (joystick.background as CircleComponent).paint.color =
+          colorScheme.value.primary.withValues(alpha: 0.4);
+    }
+
+    updateJoystickColors();
+    _updateJoystickColors = updateJoystickColors;
+    colorScheme.addListener(_updateJoystickColors);
 
     _starfield = await StarfieldComponent();
     await add(_starfield!);
@@ -211,7 +222,9 @@ class SpaceGame extends FlameGame
 
   @override
   void onRemove() {
-    colorScheme.removeListener(_updateFireButtonColors);
+    colorScheme
+      ..removeListener(_updateFireButtonColors)
+      ..removeListener(_updateJoystickColors);
     super.onRemove();
   }
 
@@ -335,14 +348,15 @@ class SpaceGame extends FlameGame
 
   JoystickComponent _buildJoystick() {
     final scale = settingsService.joystickScale.value;
+    final scheme = colorScheme.value;
     return JoystickComponent(
       knob: CircleComponent(
         radius: 20 * scale,
-        paint: Paint()..color = const Color(0xffffffff),
+        paint: Paint()..color = scheme.primary,
       ),
       background: CircleComponent(
         radius: 50 * scale,
-        paint: Paint()..color = const Color(0x66ffffff),
+        paint: Paint()..color = scheme.primary.withValues(alpha: 0.4),
       ),
       margin: const EdgeInsets.only(left: 40, bottom: 40),
     );

--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -31,13 +31,7 @@ class GameText extends StatelessWidget {
   /// Explicit colour override for the text.
   final Color? color;
 
-  /// Base colour used for in-game text.
-  static const Color defaultColor = Colors.yellow;
-
-  static const _baseStyle = TextStyle(
-    color: defaultColor,
-    fontSize: 18,
-  );
+  static const _baseStyle = TextStyle(fontSize: 18);
 
   /// Globally applied text scale factor. When attached, all [GameText]
   /// instances rebuild in response to changes.
@@ -51,8 +45,9 @@ class GameText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Widget buildText(double scale) {
+      final scheme = Theme.of(context).colorScheme;
       final mergedStyle =
-          _baseStyle.merge(style).copyWith(color: color ?? defaultColor);
+          _baseStyle.merge(style).copyWith(color: color ?? scheme.primary);
       final baseSize = mergedStyle.fontSize ?? _baseStyle.fontSize!;
       return AutoSizeText(
         data,

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
 import '../game/game_state.dart';
-import 'game_text.dart';
 import 'responsive.dart';
 import 'overlay_widgets.dart';
 import 'mineral_display.dart';
@@ -66,7 +65,7 @@ class HudOverlay extends StatelessWidget {
                             // Mirrors the Escape and P keyboard shortcuts.
                             icon: Icon(
                               paused ? Icons.play_arrow : Icons.pause,
-                              color: GameText.defaultColor,
+                              color: Theme.of(context).colorScheme.primary,
                             ),
                             onPressed:
                                 paused ? game.resumeGame : game.pauseGame,

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -59,34 +59,36 @@ class MenuOverlay extends StatelessWidget {
             SizedBox(height: spacing),
             ValueListenableBuilder<int>(
               valueListenable: game.selectedPlayerIndex,
-              builder: (context, selected, _) => Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  for (var i = 0; i < Assets.players.length; i++)
-                    GestureDetector(
-                      onTap: () => game.selectPlayer(i),
-                      child: Container(
-                        margin: EdgeInsets.all(spacing),
-                        width: playerSize,
-                        height: playerSize,
-                        decoration: BoxDecoration(
-                          border: Border.all(
-                            color: selected == i
-                                ? GameText.defaultColor
-                                : Colors.transparent,
-                            width: 2,
+              builder: (context, selected, _) {
+                final primary = Theme.of(context).colorScheme.primary;
+                return Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (var i = 0; i < Assets.players.length; i++)
+                      GestureDetector(
+                        onTap: () => game.selectPlayer(i),
+                        child: Container(
+                          margin: EdgeInsets.all(spacing),
+                          width: playerSize,
+                          height: playerSize,
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color:
+                                  selected == i ? primary : Colors.transparent,
+                              width: 2,
+                            ),
+                          ),
+                          child: Image.asset(
+                            'assets/images/${Assets.players[i]}',
+                            fit: BoxFit.contain,
+                            // Use nearest-neighbor sampling to avoid blurred sprites.
+                            filterQuality: FilterQuality.none,
                           ),
                         ),
-                        child: Image.asset(
-                          'assets/images/${Assets.players[i]}',
-                          fit: BoxFit.contain,
-                          // Use nearest-neighbor sampling to avoid blurred sprites.
-                          filterQuality: FilterQuality.none,
-                        ),
                       ),
-                    ),
-                ],
-              ),
+                  ],
+                );
+              },
             ),
             SizedBox(height: spacing),
             Row(

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -58,14 +58,17 @@ class MuteButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ValueListenableBuilder<bool>(
       valueListenable: game.audioService.muted,
-      builder: (context, muted, _) => IconButton(
-        iconSize: iconSize,
-        icon: Icon(
-          muted ? Icons.volume_off : Icons.volume_up,
-          color: GameText.defaultColor,
-        ),
-        onPressed: game.audioService.toggleMute,
-      ),
+      builder: (context, muted, _) {
+        final primary = Theme.of(context).colorScheme.primary;
+        return IconButton(
+          iconSize: iconSize,
+          icon: Icon(
+            muted ? Icons.volume_off : Icons.volume_up,
+            color: primary,
+          ),
+          onPressed: game.audioService.toggleMute,
+        );
+      },
     );
   }
 }
@@ -83,9 +86,10 @@ class HelpButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (iconSize != null) {
+      final primary = Theme.of(context).colorScheme.primary;
       return IconButton(
         iconSize: iconSize,
-        icon: const Icon(Icons.help_outline, color: GameText.defaultColor),
+        icon: Icon(Icons.help_outline, color: primary),
         onPressed: game.toggleHelp,
       );
     }
@@ -109,9 +113,10 @@ class UpgradeButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
     return IconButton(
       iconSize: iconSize,
-      icon: const Icon(Icons.upgrade, color: GameText.defaultColor),
+      icon: Icon(Icons.upgrade, color: primary),
       onPressed: game.toggleUpgrades,
     );
   }
@@ -126,9 +131,10 @@ class SettingsButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
     return IconButton(
       iconSize: iconSize,
-      icon: const Icon(Icons.tune, color: GameText.defaultColor),
+      icon: Icon(Icons.tune, color: primary),
       onPressed: game.toggleSettings,
     );
   }


### PR DESCRIPTION
## Summary
- derive default GameText color from active ColorScheme
- theme overlay buttons and menu selection using ColorScheme
- apply dynamic ColorScheme colors to joystick and player auto-aim radius

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b812fd19e48330889f28ee89afa6ca