### PR TITLE
Fix mining laser cleanup duplication

### DIFF
--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -100,15 +100,6 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
   }
 
   @override
-  void onRemove() {
-    if (_playingSound) {
-      game.audioService.stopMiningLaser();
-      _playingSound = false;
-    }
-    super.onRemove();
-  }
-
-  @override
   void render(Canvas canvas) {
     super.render(canvas);
     if (_target == null || !_target!.isMounted) return;
@@ -121,6 +112,10 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
 
   @override
   void onRemove() {
+    if (_playingSound) {
+      game.audioService.stopMiningLaser();
+      _playingSound = false;
+    }
     game.gameColors.removeListener(_colorListener);
     super.onRemove();
   }


### PR DESCRIPTION
## Summary
- merge duplicate `onRemove` implementations in `MiningLaserComponent`

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`
- `./scripts/flutterw build web --release --base-href "/space-game/"`


------
https://chatgpt.com/codex/tasks/task_e_68b8141be5b88330831c4b650c3ff370