### PR TITLE
feat(ui): enlarge mineral HUD icon

### DIFF
--- a/lib/ui/mineral_display.dart
+++ b/lib/ui/mineral_display.dart
@@ -17,8 +17,8 @@ class MineralDisplay extends StatelessWidget {
       valueListenable: game.minerals,
       icon: Image.asset(
         'assets/images/${Assets.mineralIcon}',
-        width: 24,
-        height: 24,
+        width: 48,
+        height: 48,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Double the mineral icon dimensions in the HUD for greater visibility.

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b816b39290833080bffdc2923841bb