### PR TITLE
Pause game audio when tab hidden

### DIFF
--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -99,6 +99,15 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
     }
   }
 
+  /// Stops the mining laser sound and resets the internal flag so it can
+  /// resume later if needed.
+  void stopSound() {
+    if (_playingSound) {
+      game.audioService.stopMiningLaser();
+      _playingSound = false;
+    }
+  }
+
   @override
   void render(Canvas canvas) {
     super.render(canvas);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,6 +50,10 @@ Future<void> main() async {
     gameColors: gameColors,
   );
 
+  // Pause the game and silence audio when the app is not visible.
+  final lifecycleObserver = _AppLifecycleObserver(game);
+  WidgetsBinding.instance.addObserver(lifecycleObserver);
+
   GameText.attachTextScale(settings.textScale);
 
   runApp(
@@ -91,4 +95,24 @@ Future<void> main() async {
       ),
     ),
   );
+}
+
+class _AppLifecycleObserver extends WidgetsBindingObserver {
+  _AppLifecycleObserver(this.game);
+
+  final SpaceGame game;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.detached) {
+      game.pauseEngine();
+      game.miningLaser.stopSound();
+      game.audioService.stopAll();
+    } else if (state == AppLifecycleState.resumed) {
+      game.resumeEngine();
+      game.focusGame();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- stop mining laser audio and pause engine when app is not visible
- allow mining laser component to reset its sound state

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b8170b1cd083309b530ab37796299b