### PR TITLE
Use theme primary color for settings icon

### DIFF
--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -137,7 +137,7 @@ class SettingsButton extends StatelessWidget {
       iconSize: iconSize,
       icon: ImageIcon(
         AssetImage('assets/images/${Assets.settingsIcon}'),
-        color: GameText.defaultColor,
+        color: primary,
       ),
       onPressed: game.toggleSettings,
     );


### PR DESCRIPTION
## Summary
- replace `GameText.defaultColor` reference with theme primary color
- remove unused variable warning in `SettingsButton`

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b81b9204588330bb07d7cde7ab3165