### PR TITLE
docs: document settings overlay and update tasks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,9 +98,13 @@ tree spanning weapons and ship systems.
 ## Services
 
 - Small helpers for cross-cutting concerns live under `lib/services/`.
-- `audio_service.dart` will wrap `flame_audio` and expose a mute toggle.
-- `storage_service.dart` will use `shared_preferences` to persist the local
-  high score and can expand for save/load later.
+- `audio_service.dart` wraps `flame_audio` and exposes a mute toggle.
+- `storage_service.dart` uses `shared_preferences` to persist the local
+  high score and settings.
+- `score_service.dart` tracks score, minerals and health values.
+- `overlay_service.dart` shows and hides the Flutter overlays.
+- `settings_service.dart` holds tweakable UI scale values and theme mode.
+- `targeting_service.dart` assists auto-aim queries.
 - Add services only when needed to keep the project lightweight.
 
 ## State and Data
@@ -132,6 +136,10 @@ tree spanning weapons and ship systems.
 - On player death, a game over overlay appears with restart, menu and mute buttons.
 - A help overlay lists controls and can be toggled with the `H` key, pausing the
   game when opened mid-run. `Esc` also closes it without triggering pause.
+- An upgrades overlay (placeholder) opens with the `U` key or HUD button and
+  pauses gameplay until dismissed.
+- A settings overlay provides sliders for HUD, text and joystick scale along
+  with a dark theme toggle.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -168,6 +168,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `Enter` starts or
   restarts from the menu or game over, `R` restarts at any time, `H` shows a help
   overlay that `Esc` also closes)
+- Upgrades overlay placeholder opened with a HUD button or the `U` key and
+  pausing gameplay for future ship upgrades
+- Settings overlay with sliders for HUD, text and joystick scale plus a dark
+  theme toggle
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or

--- a/TASKS.md
+++ b/TASKS.md
@@ -70,11 +70,14 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Limit player fire rate with a brief cooldown.
 - [x] Keyboard shortcut `F1` toggles debug overlays.
 - [x] Menu includes button to reset the high score.
+- [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
+- [x] Settings overlay with sliders for HUD, text and joystick scale plus a
+      dark theme toggle.
 
 ## Next Steps
 
 - [x] Spawn enemy groups on a timer.
-- [ ] Add a mining laser that automatically targets and fires at nearby
+- [x] Add a mining laser that automatically targets and fires at nearby
       asteroids.
 - [x] Drop mineral pickups from asteroids and track the player's total.
 - [x] Pull nearby pickups toward the player with a Tractor Aura.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -5,14 +5,11 @@ Optional helpers for cross-cutting concerns.
 - `audio_service.dart` wraps `flame_audio` to play sound effects and
   handles a mute toggle persisted via `StorageService`.
 - `storage_service.dart` stores the local high score and mute setting using
-  `shared_preferences` and can clear the high score.
+  `shared_preferences`.
+- `score_service.dart` tracks score, minerals and health values.
+- `overlay_service.dart` shows and hides overlays on the `GameWidget`.
+- `settings_service.dart` holds UI scale values and theme mode.
+- `targeting_service.dart` assists auto-aim queries.
 - Keep services lightweight; add them only when a milestone needs them.
-
-## Planned Services
-
-- [AudioService](audio_service.md) – preloads clips, plays one-shot effects and
-  remembers a mute flag.
-- [StorageService](storage_service.md) – loads and saves the high score; may
-  persist settings or future save data.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -23,6 +23,8 @@ Flutter overlays and HUD widgets.
   pauses gameplay when opened mid-run; `Esc` also closes it.
 - [UpgradesOverlay](upgrades_overlay.md) – placeholder screen for future ship
   upgrades; opened with `U` and pauses gameplay.
+- [SettingsOverlay](settings_overlay.md) – adjust HUD, text and joystick scale
+  and toggle the dark theme; opened via HUD button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -137,7 +137,7 @@ class SettingsButton extends StatelessWidget {
       iconSize: iconSize,
       icon: ImageIcon(
         AssetImage('assets/images/${Assets.settingsIcon}'),
-        color: GameText.defaultColor,
+        color: primary,
       ),
       onPressed: game.toggleSettings,
     );

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -1,0 +1,11 @@
+# SettingsOverlay
+
+Overlay providing runtime UI scaling controls and a dark theme toggle.
+
+## Features
+
+- Sliders adjust HUD button, text and joystick scales.
+- Switch toggles between light and dark themes.
+- Opens from the HUD; closing returns to the game.
+
+See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -23,8 +23,5 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 ## Next Steps
 
-- Spawn enemy groups in timed waves.
-- Equip the player with an auto-firing mining laser for nearby asteroids.
-- Drop minerals from mined asteroids and track the currency.
-- Auto-aim the main weapon at the closest enemy.
-- Outline a mineral-based upgrade system for weapons and ship systems.
+- Design a broad upgrade system where minerals purchase new weapon and ship
+  upgrades.


### PR DESCRIPTION
## Summary
- document settings overlay and upgrades overlay across plan, design and tasks
- add docs for settings overlay and services
- fix settings button color to satisfy analyzer

## Testing
- `./scripts/dartw format lib/ui/overlay_widgets.dart`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68b82843bc4483309118b71527eca940