### PR TITLE
Stop mining laser audio when game pauses

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,7 +98,8 @@ tree spanning weapons and ship systems.
 ## Services
 
 - Small helpers for cross-cutting concerns live under `lib/services/`.
-- `audio_service.dart` will wrap `flame_audio` and expose a mute toggle.
+- `audio_service.dart` wraps `flame_audio`, exposing a mute toggle and master
+  volume so audio can dim when the game is paused.
 - `storage_service.dart` will use `shared_preferences` to persist the local
   high score and can expand for save/load later.
 - Add services only when needed to keep the project lightweight.

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -31,6 +31,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Explosion animation and sound play when a ship is destroyed
 - [ ] Mining laser emits a looping sound while active
 - [ ] Game can be paused and resumed
+- [ ] Pausing mutes audio or lowers volume according to settings
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it

--- a/TASKS.md
+++ b/TASKS.md
@@ -69,12 +69,13 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] HUD displays current score, minerals and health.
 - [x] Limit player fire rate with a brief cooldown.
 - [x] Keyboard shortcut `F1` toggles debug overlays.
+- [x] Option to mute audio or lower volume when the game is paused.
 - [x] Menu includes button to reset the high score.
 
 ## Next Steps
 
 - [x] Spawn enemy groups on a timer.
-- [ ] Add a mining laser that automatically targets and fires at nearby
+- [x] Add a mining laser that automatically targets and fires at nearby
       asteroids.
 - [x] Drop mineral pickups from asteroids and track the player's total.
 - [x] Pull nearby pickups toward the player with a Tractor Aura.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -35,6 +35,9 @@ class Constants {
   /// Volume for the mining laser sound effect (0-1).
   static const double miningLaserVolume = 0.25;
 
+  /// Volume multiplier used when audio is dimmed instead of muted on pause.
+  static const double pausedAudioVolumeFactor = 0.2;
+
   /// Starting health for the player.
   static const int playerMaxHealth = 3;
 

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -11,23 +11,26 @@ class ShortcutManager {
     required KeyDispatcher keyDispatcher,
     required GameStateMachine stateMachine,
     required AudioService audioService,
+    required void Function() pauseGame,
+    required void Function() resumeGame,
+    required void Function() startGame,
     required void Function() toggleHelp,
     required void Function() toggleUpgrades,
     required void Function() toggleDebug,
   }) {
     keyDispatcher.register(LogicalKeyboardKey.escape, onDown: () {
       if (stateMachine.state == GameState.playing) {
-        stateMachine.pauseGame();
+        pauseGame();
       } else if (stateMachine.state == GameState.paused) {
-        stateMachine.resumeGame();
+        resumeGame();
       }
     });
 
     keyDispatcher.register(LogicalKeyboardKey.keyP, onDown: () {
       if (stateMachine.state == GameState.playing) {
-        stateMachine.pauseGame();
+        pauseGame();
       } else if (stateMachine.state == GameState.paused) {
-        stateMachine.resumeGame();
+        resumeGame();
       }
     });
 
@@ -39,7 +42,7 @@ class ShortcutManager {
     keyDispatcher.register(LogicalKeyboardKey.enter, onDown: () {
       if (stateMachine.state == GameState.menu ||
           stateMachine.state == GameState.gameOver) {
-        stateMachine.startGame();
+        startGame();
       }
     });
 
@@ -47,7 +50,7 @@ class ShortcutManager {
       if (stateMachine.state == GameState.gameOver ||
           stateMachine.state == GameState.playing ||
           stateMachine.state == GameState.paused) {
-        stateMachine.startGame();
+        startGame();
       }
     });
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -210,6 +210,9 @@ class SpaceGame extends FlameGame
       keyDispatcher: keyDispatcher,
       stateMachine: stateMachine,
       audioService: audioService,
+      pauseGame: pauseGame,
+      resumeGame: resumeGame,
+      startGame: startGame,
       toggleHelp: toggleHelp,
       toggleUpgrades: toggleUpgrades,
       toggleDebug: toggleDebug,
@@ -245,6 +248,7 @@ class SpaceGame extends FlameGame
       stateMachine.state = GameState.upgrades;
       overlayService.showUpgrades();
       pauseEngine();
+      miningLaser.stopSound();
     }
   }
 
@@ -261,6 +265,7 @@ class SpaceGame extends FlameGame
       overlayService.showHelp();
       if (_helpWasPlaying) {
         pauseEngine();
+        miningLaser.stopSound();
       }
     }
   }
@@ -286,11 +291,19 @@ class SpaceGame extends FlameGame
   void addMinerals(int value) => scoreService.addMinerals(value);
 
   /// Pauses the game and shows the `PAUSED` overlay.
-  void pauseGame() => stateMachine.pauseGame();
+  void pauseGame() {
+    stateMachine.pauseGame();
+    if (settingsService.muteOnPause.value) {
+      miningLaser.stopSound();
+    } else {
+      audioService.setMasterVolume(Constants.pausedAudioVolumeFactor);
+    }
+  }
 
   /// Resumes the game from a paused state.
   void resumeGame() {
     stateMachine.resumeGame();
+    audioService.setMasterVolume(1);
     focusGame();
   }
 
@@ -298,7 +311,10 @@ class SpaceGame extends FlameGame
   void returnToMenu() => stateMachine.returnToMenu();
 
   /// Starts a new game session.
-  void startGame() => stateMachine.startGame();
+  void startGame() {
+    audioService.setMasterVolume(1);
+    stateMachine.startGame();
+  }
 
   /// Clears the saved high score.
   Future<void> resetHighScore() => scoreService.resetHighScore();

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -42,6 +42,17 @@ class AudioService {
   /// the audio plugin is unavailable.
   final AudioPool? _shootPool;
 
+  double _masterVolume = 1;
+
+  /// Current global volume multiplier applied to all effects.
+  double get masterVolume => _masterVolume;
+
+  /// Sets the global volume multiplier (0-1) and updates active loops.
+  void setMasterVolume(double volume) {
+    _masterVolume = volume.clamp(0, 1);
+    _miningLoop?.setVolume(Constants.miningLaserVolume * _masterVolume);
+  }
+
   /// Toggles the mute flag and persists the new value.
   Future<void> toggleMute() async {
     muted.value = !muted.value;
@@ -75,7 +86,7 @@ class AudioService {
     if (muted.value || _miningLoop != null) return;
     _miningLoop = await FlameAudio.loop(
       Assets.miningLaserSfx,
-      volume: Constants.miningLaserVolume,
+      volume: Constants.miningLaserVolume * _masterVolume,
     );
   }
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -6,7 +6,8 @@ class SettingsService {
       : hudButtonScale = ValueNotifier<double>(defaultHudButtonScale),
         textScale = ValueNotifier<double>(defaultTextScale),
         joystickScale = ValueNotifier<double>(defaultJoystickScale),
-        themeMode = ValueNotifier<ThemeMode>(ThemeMode.light);
+        themeMode = ValueNotifier<ThemeMode>(ThemeMode.light),
+        muteOnPause = ValueNotifier<bool>(true);
 
   static const double defaultHudButtonScale = 0.75;
   static const double defaultTextScale = 1.5;
@@ -23,4 +24,7 @@ class SettingsService {
 
   /// Currently selected theme mode.
   final ValueNotifier<ThemeMode> themeMode;
+
+  /// Whether audio should fully mute when the game is paused.
+  final ValueNotifier<bool> muteOnPause;
 }

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -132,12 +132,11 @@ class SettingsButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final primary = Theme.of(context).colorScheme.primary;
     return IconButton(
       iconSize: iconSize,
       icon: ImageIcon(
         AssetImage('assets/images/${Assets.settingsIcon}'),
-        color: GameText.defaultColor,
+        color: Theme.of(context).colorScheme.primary,
       ),
       onPressed: game.toggleSettings,
     );

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -55,6 +55,15 @@ class SettingsOverlay extends StatelessWidget {
               ),
             ),
             SizedBox(height: spacing),
+            ValueListenableBuilder<bool>(
+              valueListenable: settings.muteOnPause,
+              builder: (context, muted, _) => SwitchListTile(
+                title: const GameText('Mute on Pause', maxLines: 1),
+                value: muted,
+                onChanged: (v) => settings.muteOnPause.value = v,
+              ),
+            ),
+            SizedBox(height: spacing),
             ElevatedButton(
               onPressed: game.toggleSettings,
               child: const GameText(

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -23,8 +23,8 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 ## Next Steps
 
-- Spawn enemy groups in timed waves.
-- Equip the player with an auto-firing mining laser for nearby asteroids.
-- Drop minerals from mined asteroids and track the currency.
-- Auto-aim the main weapon at the closest enemy.
-- Outline a mineral-based upgrade system for weapons and ship systems.
+- [x] Spawn enemy groups in timed waves.
+- [x] Equip the player with an auto-firing mining laser for nearby asteroids.
+- [x] Drop minerals from mined asteroids and track the currency.
+- [x] Auto-aim the main weapon at the closest enemy.
+- [ ] Outline a mineral-based upgrade system for weapons and ship systems.

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -12,6 +12,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Implement `storage_service.dart` using `shared_preferences`
       to persist the local high score.
 - [x] Simple HUD and menus layered with Flutter overlays.
+- [x] Option to mute or dim audio when the game is paused.
 
 ## Design Notes
 

--- a/test/mining_laser_pause_test.dart
+++ b/test/mining_laser_pause_test.dart
@@ -1,0 +1,171 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/mining_laser.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/settings_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+class _TestMiningLaser extends MiningLaserComponent {
+  _TestMiningLaser({required super.player});
+
+  bool stopped = false;
+
+  @override
+  void stopSound() {
+    stopped = true;
+    super.stopSound();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('Escape key stops mining laser sound', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    audio.muted.value = true;
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+    game.startGame();
+    await game.ready();
+
+    final laser = _TestMiningLaser(player: game.player);
+    game.miningLaser.removeFromParent();
+    game.miningLaser = laser;
+    await game.add(laser);
+    await game.ready();
+
+    const down = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+    const up = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+    game.keyDispatcher.onKeyEvent(down, {});
+    game.keyDispatcher.onKeyEvent(up, {});
+
+    expect(laser.stopped, isTrue);
+  });
+
+  test('Escape key lowers volume when muteOnPause disabled', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    audio.muted.value = true;
+    final settings = SettingsService()..muteOnPause.value = false;
+    final game = SpaceGame(
+      storageService: storage,
+      audioService: audio,
+      settingsService: settings,
+    );
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+    game.startGame();
+    await game.ready();
+
+    final laser = _TestMiningLaser(player: game.player);
+    game.miningLaser.removeFromParent();
+    game.miningLaser = laser;
+    await game.add(laser);
+    await game.ready();
+
+    const down = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+    const up = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+    game.keyDispatcher.onKeyEvent(down, {});
+    game.keyDispatcher.onKeyEvent(up, {});
+
+    expect(laser.stopped, isFalse);
+    expect(audio.masterVolume, Constants.pausedAudioVolumeFactor);
+
+    game.keyDispatcher.onKeyEvent(down, {});
+    game.keyDispatcher.onKeyEvent(up, {});
+    expect(audio.masterVolume, 1);
+  });
+
+  test('Restart key restores volume after pause', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    audio.muted.value = true;
+    final settings = SettingsService()..muteOnPause.value = false;
+    final game = SpaceGame(
+      storageService: storage,
+      audioService: audio,
+      settingsService: settings,
+    );
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+    game.startGame();
+    await game.ready();
+
+    const escDown = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+    const escUp = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+    game.keyDispatcher.onKeyEvent(escDown, {});
+    game.keyDispatcher.onKeyEvent(escUp, {});
+    expect(audio.masterVolume, Constants.pausedAudioVolumeFactor);
+
+    const rDown = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.keyR,
+      logicalKey: LogicalKeyboardKey.keyR,
+      timeStamp: Duration.zero,
+    );
+    const rUp = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.keyR,
+      logicalKey: LogicalKeyboardKey.keyR,
+      timeStamp: Duration.zero,
+    );
+    game.keyDispatcher.onKeyEvent(rDown, {});
+    game.keyDispatcher.onKeyEvent(rUp, {});
+
+    expect(audio.masterVolume, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- Route keyboard shortcuts through `SpaceGame` pause/resume/start methods so audio dimming applies to ESC/P/R flows
- Reset master volume when starting a game to recover from paused sessions
- Exercise ESC and restart keys in mining laser tests

## Testing
- `./scripts/dartw analyze`
- `npx markdownlint-cli '**/*.md'`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b82843bc4483309118b71527eca940