### PR TITLE
Handle fire button touch cancellation

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -179,6 +179,7 @@ class SpaceGame extends FlameGame
       margin: const EdgeInsets.only(right: 40, bottom: 40),
       onPressed: player.startShooting,
       onReleased: player.stopShooting,
+      onCancelled: player.stopShooting,
     );
     await add(fireButton);
     void updateFireButtonColors() {


### PR DESCRIPTION
## Summary
- stop continuous firing when the HUD button's touch gesture is cancelled

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b943039eac8330a9c9ccaab97e6cf1