### PR TITLE
Clear settings overlay during overlay transitions

### DIFF
--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -19,6 +19,7 @@ class OverlayService {
       ..remove(HudOverlay.id)
       ..remove(PauseOverlay.id)
       ..remove(GameOverOverlay.id)
+      ..remove(SettingsOverlay.id)
       ..add(MenuOverlay.id);
   }
 
@@ -27,17 +28,21 @@ class OverlayService {
       ..remove(MenuOverlay.id)
       ..remove(PauseOverlay.id)
       ..remove(GameOverOverlay.id)
+      ..remove(SettingsOverlay.id)
       ..add(HudOverlay.id);
   }
 
   void showPause() {
-    game.overlays.add(PauseOverlay.id);
+    game.overlays
+      ..remove(SettingsOverlay.id)
+      ..add(PauseOverlay.id);
   }
 
   void showGameOver() {
     game.overlays
       ..remove(HudOverlay.id)
       ..remove(PauseOverlay.id)
+      ..remove(SettingsOverlay.id)
       ..add(GameOverOverlay.id);
   }
 
@@ -48,12 +53,14 @@ class OverlayService {
   void showUpgrades() {
     game.overlays
       ..remove(HudOverlay.id)
+      ..remove(SettingsOverlay.id)
       ..add(UpgradesOverlay.id);
   }
 
   void hideUpgrades() {
     game.overlays
       ..remove(UpgradesOverlay.id)
+      ..remove(SettingsOverlay.id)
       ..add(HudOverlay.id);
   }
 

--- a/test/overlay_service_test.dart
+++ b/test/overlay_service_test.dart
@@ -67,5 +67,35 @@ void main() {
     expect(game.overlays.isActive(SettingsOverlay.id), isTrue);
     service.hideSettings();
     expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+
+    service.showSettings();
+    service.showMenu();
+    expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+    expect(game.overlays.isActive(MenuOverlay.id), isTrue);
+
+    service.showSettings();
+    service.showHud();
+    expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+    expect(game.overlays.isActive(HudOverlay.id), isTrue);
+
+    service.showSettings();
+    service.showPause();
+    expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+    expect(game.overlays.isActive(PauseOverlay.id), isTrue);
+
+    service.showSettings();
+    service.showGameOver();
+    expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+    expect(game.overlays.isActive(GameOverOverlay.id), isTrue);
+
+    service.showSettings();
+    service.showUpgrades();
+    expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+    expect(game.overlays.isActive(UpgradesOverlay.id), isTrue);
+
+    service.showSettings();
+    service.hideUpgrades();
+    expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+    expect(game.overlays.isActive(HudOverlay.id), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- remove SettingsOverlay when switching to menu, HUD, pause, game over, and upgrades overlays
- ensure hideUpgrades clears SettingsOverlay
- test overlay transitions to confirm settings overlay is cleared

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b941c81ca08330af528cecc67791c7