### PR TITLE
Guard mining laser during lifecycle pauses

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -46,9 +46,10 @@ class LifecycleManager {
         player.resetInput();
       }
       // Recreate the mining laser for the new player.
-      game.miningLaser.removeFromParent();
-      game.miningLaser = MiningLaserComponent(player: player);
-      game.add(game.miningLaser);
+      game.miningLaser?.removeFromParent();
+      final laser = MiningLaserComponent(player: player);
+      game.miningLaser = laser;
+      game.add(laser);
       // Update fire button callbacks.
       game.fireButton
         ..onPressed = player.startShooting

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -84,7 +84,7 @@ class SpaceGame extends FlameGame
 
   late final KeyDispatcher keyDispatcher;
   late PlayerComponent player;
-  late MiningLaserComponent miningLaser;
+  MiningLaserComponent? miningLaser;
   late JoystickComponent _joystick;
   JoystickComponent get joystick => _joystick;
   set joystick(JoystickComponent value) {
@@ -161,8 +161,9 @@ class SpaceGame extends FlameGame
     await add(player);
     _playerInitialized = true;
     camera.follow(player, snap: true);
-    miningLaser = MiningLaserComponent(player: player);
-    await add(miningLaser);
+    final laser = MiningLaserComponent(player: player);
+    miningLaser = laser;
+    await add(laser);
 
     final upButton = CircleComponent(
       radius: 30 * settingsService.hudButtonScale.value,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -108,7 +108,10 @@ class _AppLifecycleObserver extends WidgetsBindingObserver {
         state == AppLifecycleState.inactive ||
         state == AppLifecycleState.detached) {
       game.pauseEngine();
-      game.miningLaser.stopSound();
+      final laser = game.miningLaser;
+      if (laser != null && laser.isMounted) {
+        laser.stopSound();
+      }
       game.audioService.stopAll();
     } else if (state == AppLifecycleState.resumed) {
       game.resumeEngine();


### PR DESCRIPTION
## Summary
- Avoid LateInitializationError by making `miningLaser` nullable and guarding lifecycle pause access
- Recreate mining laser safely when restarting the game

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9418634f483308c0dfc715f302e87