### PR TITLE
Handle system theme mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,19 +27,40 @@ Future<void> main() async {
 
   final lightScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
   final darkScheme = ColorScheme.fromSeed(
-      seedColor: Colors.deepPurple, brightness: Brightness.dark);
-  final colorScheme = ValueNotifier<ColorScheme>(lightScheme);
-  final gameColors = ValueNotifier<GameColors>(GameColors.light);
+    seedColor: Colors.deepPurple,
+    brightness: Brightness.dark,
+  );
+  final initialBrightness =
+      WidgetsBinding.instance.platformDispatcher.platformBrightness;
+  final colorScheme = ValueNotifier<ColorScheme>(
+    initialBrightness == Brightness.dark ? darkScheme : lightScheme,
+  );
+  final gameColors = ValueNotifier<GameColors>(
+    initialBrightness == Brightness.dark ? GameColors.dark : GameColors.light,
+  );
 
-  settings.themeMode.addListener(() {
-    if (settings.themeMode.value == ThemeMode.dark) {
+  void applyTheme() {
+    final brightness = settings.themeMode.value == ThemeMode.system
+        ? WidgetsBinding.instance.platformDispatcher.platformBrightness
+        : (settings.themeMode.value == ThemeMode.dark
+            ? Brightness.dark
+            : Brightness.light);
+    if (brightness == Brightness.dark) {
       colorScheme.value = darkScheme;
       gameColors.value = GameColors.dark;
     } else {
       colorScheme.value = lightScheme;
       gameColors.value = GameColors.light;
     }
-  });
+  }
+
+  settings.themeMode.addListener(applyTheme);
+  WidgetsBinding.instance.platformDispatcher.onPlatformBrightnessChanged = () {
+    if (settings.themeMode.value == ThemeMode.system) {
+      applyTheme();
+    }
+  };
+  applyTheme();
 
   final game = SpaceGame(
     storageService: storage,

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -6,7 +6,7 @@ class SettingsService {
       : hudButtonScale = ValueNotifier<double>(defaultHudButtonScale),
         textScale = ValueNotifier<double>(defaultTextScale),
         joystickScale = ValueNotifier<double>(defaultJoystickScale),
-        themeMode = ValueNotifier<ThemeMode>(ThemeMode.light);
+        themeMode = ValueNotifier<ThemeMode>(ThemeMode.system);
 
   static const double defaultHudButtonScale = 0.75;
   static const double defaultTextScale = 1.5;

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -47,11 +47,30 @@ class SettingsOverlay extends StatelessWidget {
             ),
             ValueListenableBuilder<ThemeMode>(
               valueListenable: settings.themeMode,
-              builder: (context, mode, _) => SwitchListTile(
-                title: const GameText('Dark Theme', maxLines: 1),
-                value: mode == ThemeMode.dark,
-                onChanged: (v) => settings.themeMode.value =
-                    v ? ThemeMode.dark : ThemeMode.light,
+              builder: (context, mode, _) => ListTile(
+                title: const GameText('Theme', maxLines: 1),
+                trailing: DropdownButton<ThemeMode>(
+                  value: mode,
+                  onChanged: (newMode) {
+                    if (newMode != null) {
+                      settings.themeMode.value = newMode;
+                    }
+                  },
+                  items: const [
+                    DropdownMenuItem(
+                      value: ThemeMode.system,
+                      child: GameText('System', maxLines: 1),
+                    ),
+                    DropdownMenuItem(
+                      value: ThemeMode.light,
+                      child: GameText('Light', maxLines: 1),
+                    ),
+                    DropdownMenuItem(
+                      value: ThemeMode.dark,
+                      child: GameText('Dark', maxLines: 1),
+                    ),
+                  ],
+                ),
               ),
             ),
             SizedBox(height: spacing),


### PR DESCRIPTION
## Summary
- allow selecting light, dark, or system theme mode
- sync color schemes with system brightness and changes

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9419680d88330b6e484ada24a5542