### PR TITLE
Rebuild joystick when scale changes

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -363,10 +363,12 @@ class SpaceGame extends FlameGame
   }
 
   void _updateJoystickScale() {
-    final scale = settingsService.joystickScale.value;
-    (joystick.knob as CircleComponent).radius = 20 * scale;
-    (joystick.background as CircleComponent).radius = 50 * scale;
-    joystick.onGameResize(size);
+    final oldJoystick = joystick;
+    final newJoystick = _buildJoystick();
+    joystick = newJoystick;
+    add(newJoystick);
+    _updateJoystickColors();
+    oldJoystick.removeFromParent();
   }
 
   void _updateHudButtonScale() {


### PR DESCRIPTION
## Summary
- Recreate joystick component when the joystick scale changes so hit radius matches visual size

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b94164b46483308b242c065758f85a