### PR TITLE
Attach test joystick to player in orientation reset test

### DIFF
--- a/test/player_reset_orientation_test.dart
+++ b/test/player_reset_orientation_test.dart
@@ -35,6 +35,9 @@ void main() {
     game.joystick.removeFromParent();
     game.joystick = TestJoystick();
     await game.add(game.joystick);
+    game.player
+      ..setJoystick(game.joystick)
+      ..resetInput();
     game.update(0);
     game.update(0);
 


### PR DESCRIPTION
## Summary
- Ensure player reset orientation test assigns swapped joystick to player and clears input

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9425424d4833097fa504df915fa10