### PR TITLE
Fix range downloader progress loop termination

### DIFF
--- a/scripts/bootstrap_flutter.sh
+++ b/scripts/bootstrap_flutter.sh
@@ -121,7 +121,7 @@ if [ "$needs_download" = true ]; then
   done
   local start_time
   start_time=$(date +%s)
-  while jobs -p >/dev/null 2>&1; do
+  while [[ -n "$(jobs -p)" ]]; do
     local size=0
     for f in "${tmpfiles[@]}"; do
       if [ -f "$f" ]; then


### PR DESCRIPTION
## Summary
- ensure range download progress loop exits once background curl jobs finish

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b941d61d54833099762f7d4b061bf4