### PR TITLE
Avoid consuming unhandled key events

### DIFF
--- a/lib/game/key_dispatcher.dart
+++ b/lib/game/key_dispatcher.dart
@@ -51,19 +51,29 @@ class KeyDispatcher extends Component with KeyboardHandler {
       _pressed.remove(key);
       return false;
     }
+    var handled = false;
     if (event is KeyDownEvent || event is KeyRepeatEvent) {
       // Treat repeat events like additional down events but only fire the
       // callback on the first press. Some browsers emit a repeat without an
       // initial down event for keys like the spacebar.
       final firstPress = _pressed.add(key);
       if (firstPress) {
-        _down[key]?.call();
+        final callback = _down[key];
+        if (callback != null) {
+          callback();
+          handled = true;
+        }
       }
     } else if (event is KeyUpEvent) {
       _pressed.remove(key);
-      _up[key]?.call();
+      final callback = _up[key];
+      if (callback != null) {
+        callback();
+        handled = true;
+      }
     }
-    // Consume the event so browser defaults like page scrolling don't trigger.
-    return true;
+    // Return whether a callback handled the event. Unhandled keys propagate so
+    // other components or widgets (like text fields) can respond.
+    return handled;
   }
 }

--- a/test/key_dispatcher_propagation_test.dart
+++ b/test/key_dispatcher_propagation_test.dart
@@ -6,7 +6,8 @@ import 'package:space_game/game/key_dispatcher.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('KeyDispatcher tracks pressed and released keys', () {
+  test('KeyDispatcher tracks key state but lets unhandled events propagate',
+      () {
     final dispatcher = KeyDispatcher();
 
     final handledDown = dispatcher.onKeyEvent(
@@ -17,7 +18,7 @@ void main() {
       ),
       {LogicalKeyboardKey.space},
     );
-    expect(handledDown, isTrue);
+    expect(handledDown, isFalse);
     expect(dispatcher.isPressed(LogicalKeyboardKey.space), isTrue);
 
     final handledUp = dispatcher.onKeyEvent(
@@ -28,7 +29,7 @@ void main() {
       ),
       <LogicalKeyboardKey>{},
     );
-    expect(handledUp, isTrue);
+    expect(handledUp, isFalse);
     expect(dispatcher.isPressed(LogicalKeyboardKey.space), isFalse);
   });
 }

--- a/test/key_dispatcher_test.dart
+++ b/test/key_dispatcher_test.dart
@@ -38,4 +38,17 @@ void main() {
     );
     expect(result, isFalse);
   });
+
+  test('unhandled keys propagate', () {
+    final dispatcher = KeyDispatcher();
+    final result = dispatcher.onKeyEvent(
+      KeyDownEvent(
+        logicalKey: LogicalKeyboardKey.space,
+        physicalKey: PhysicalKeyboardKey.space,
+        timeStamp: Duration.zero,
+      ),
+      {LogicalKeyboardKey.space},
+    );
+    expect(result, isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
- Return `false` from `KeyDispatcher.onKeyEvent` when no callback runs so that unregistered keys propagate to other widgets
- Adjust existing tests and add coverage for unhandled key propagation

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b942bbae548330b18e1d33a6e8b594