### PR TITLE
Ensure OffscreenCleanup initializes in pooled components

### DIFF
--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -56,6 +56,7 @@ class AsteroidComponent extends SpriteComponent
 
   @override
   Future<void> onLoad() async {
+    await super.onLoad();
     add(CircleHitbox());
   }
 

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -36,6 +36,7 @@ class BulletComponent extends SpriteComponent
 
   @override
   Future<void> onLoad() async {
+    await super.onLoad();
     sprite = await Sprite.load(Assets.bullet);
     add(CircleHitbox());
   }

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -47,6 +47,7 @@ class EnemyComponent extends SpriteComponent
 
   @override
   Future<void> onLoad() async {
+    await super.onLoad();
     add(CircleHitbox());
   }
 

--- a/lib/components/offscreen_cleanup.dart
+++ b/lib/components/offscreen_cleanup.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flame/components.dart';
 
 import '../constants.dart';
@@ -26,7 +28,11 @@ class _OffscreenCleanupBehavior extends Component {
         _host.y > Constants.worldSize.y + _host.height ||
         _host.x < -_host.width ||
         _host.x > Constants.worldSize.x + _host.width) {
-      _host.removeFromParent();
+      // Removing a component during the update cycle can trigger concurrent
+      // modification errors if collision detection is iterating over the
+      // component tree. Scheduling the removal defers it until after the
+      // current microtask, avoiding those issues.
+      scheduleMicrotask(_host.removeFromParent);
     }
   }
 }


### PR DESCRIPTION
## Summary
- call `super.onLoad` in bullet, asteroid, and enemy components so OffscreenCleanup attaches its cleanup behavior
- defer offscreen removal to a microtask to avoid concurrent modification during updates

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b94269399c83308be99d1e3ffc3645