### PR TITLE
Preserve default brightness handler when applying theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,7 +55,10 @@ Future<void> main() async {
   }
 
   settings.themeMode.addListener(applyTheme);
-  WidgetsBinding.instance.platformDispatcher.onPlatformBrightnessChanged = () {
+  final dispatcher = WidgetsBinding.instance.platformDispatcher;
+  final defaultBrightnessHandler = dispatcher.onPlatformBrightnessChanged;
+  dispatcher.onPlatformBrightnessChanged = () {
+    defaultBrightnessHandler?.call();
     if (settings.themeMode.value == ThemeMode.system) {
       applyTheme();
     }


### PR DESCRIPTION
## Summary
- preserve existing onPlatformBrightnessChanged handler so Flutter still propagates brightness updates
- update theme colors only after invoking default brightness handler

## Testing
- `scripts/flutterw analyze` *(fails: unchecked_use_of_nullable_value in unrelated files)*
- `scripts/flutterw test` *(fails: stopSound/removeFromParent on nullable values in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b9460efcec8330a8ddacd8896ec748