### PR TITLE
Fix KeyDispatcher to handle lost focus key presses

### DIFF
--- a/lib/game/key_dispatcher.dart
+++ b/lib/game/key_dispatcher.dart
@@ -52,10 +52,19 @@ class KeyDispatcher extends Component with KeyboardHandler {
       return false;
     }
     var handled = false;
-    if (event is KeyDownEvent || event is KeyRepeatEvent) {
-      // Treat repeat events like additional down events but only fire the
-      // callback on the first press. Some browsers emit a repeat without an
-      // initial down event for keys like the spacebar.
+    if (event is KeyDownEvent) {
+      // Always fire the down callback on explicit down events. This avoids
+      // missing actions when a prior key up was skipped (e.g. focus loss).
+      _pressed.add(key);
+      final callback = _down[key];
+      if (callback != null) {
+        callback();
+        handled = true;
+      }
+    } else if (event is KeyRepeatEvent) {
+      // Treat repeat events like down events only if we haven't seen a
+      // preceding down. Some browsers emit repeats without an initial down
+      // (e.g. spacebar on web).
       final firstPress = _pressed.add(key);
       if (firstPress) {
         final callback = _down[key];

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -250,7 +250,7 @@ class SpaceGame extends FlameGame
       stateMachine.state = GameState.upgrades;
       overlayService.showUpgrades();
       pauseEngine();
-      miningLaser.stopSound();
+      miningLaser?.stopSound();
     }
   }
 
@@ -267,7 +267,7 @@ class SpaceGame extends FlameGame
       overlayService.showHelp();
       if (_helpWasPlaying) {
         pauseEngine();
-        miningLaser.stopSound();
+        miningLaser?.stopSound();
       }
     }
   }
@@ -296,7 +296,7 @@ class SpaceGame extends FlameGame
   void pauseGame() {
     stateMachine.pauseGame();
     if (settingsService.muteOnPause.value) {
-      miningLaser.stopSound();
+      miningLaser?.stopSound();
     } else {
       audioService.setMasterVolume(Constants.pausedAudioVolumeFactor);
     }

--- a/test/mining_laser_pause_test.dart
+++ b/test/mining_laser_pause_test.dart
@@ -49,7 +49,7 @@ void main() {
     await game.ready();
 
     final laser = _TestMiningLaser(player: game.player);
-    game.miningLaser.removeFromParent();
+    game.miningLaser?.removeFromParent();
     game.miningLaser = laser;
     await game.add(laser);
     await game.ready();
@@ -92,7 +92,7 @@ void main() {
     await game.ready();
 
     final laser = _TestMiningLaser(player: game.player);
-    game.miningLaser.removeFromParent();
+    game.miningLaser?.removeFromParent();
     game.miningLaser = laser;
     await game.add(laser);
     await game.ready();


### PR DESCRIPTION
## Summary
- always fire key down callbacks even if key appears pressed to recover from missing key ups
- make mining laser sound stops and test cleanups null-safe

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b94784253c83308e3ade34bf99ca09