### PR TITLE
fix: guard mining laser stop sound

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -250,7 +250,7 @@ class SpaceGame extends FlameGame
       stateMachine.state = GameState.upgrades;
       overlayService.showUpgrades();
       pauseEngine();
-      miningLaser.stopSound();
+      miningLaser?.stopSound();
     }
   }
 
@@ -267,7 +267,7 @@ class SpaceGame extends FlameGame
       overlayService.showHelp();
       if (_helpWasPlaying) {
         pauseEngine();
-        miningLaser.stopSound();
+        miningLaser?.stopSound();
       }
     }
   }
@@ -296,7 +296,7 @@ class SpaceGame extends FlameGame
   void pauseGame() {
     stateMachine.pauseGame();
     if (settingsService.muteOnPause.value) {
-      miningLaser.stopSound();
+      miningLaser?.stopSound();
     } else {
       audioService.setMasterVolume(Constants.pausedAudioVolumeFactor);
     }

--- a/test/mining_laser_pause_test.dart
+++ b/test/mining_laser_pause_test.dart
@@ -49,7 +49,7 @@ void main() {
     await game.ready();
 
     final laser = _TestMiningLaser(player: game.player);
-    game.miningLaser.removeFromParent();
+    game.miningLaser?.removeFromParent();
     game.miningLaser = laser;
     await game.add(laser);
     await game.ready();
@@ -92,7 +92,7 @@ void main() {
     await game.ready();
 
     final laser = _TestMiningLaser(player: game.player);
-    game.miningLaser.removeFromParent();
+    game.miningLaser?.removeFromParent();
     game.miningLaser = laser;
     await game.add(laser);
     await game.ready();


### PR DESCRIPTION
## Summary
- prevent null mining laser from throwing when pausing or opening overlays
- fix tests to use null-aware removal of existing mining laser

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `./scripts/flutterw build web --release --base-href "/space-game/"`


------
https://chatgpt.com/codex/tasks/task_e_68b948f49f6c8330b118ddcec3f0623b