### PR TITLE
Make settings overlay non-dimmed

### DIFF
--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -16,7 +16,6 @@ class SettingsOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     final settings = game.settingsService;
     return OverlayLayout(
-      dimmed: true,
       builder: (context, spacing, iconSize) {
         return Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -7,5 +7,6 @@ Overlay providing runtime UI scaling controls and a dark theme toggle.
 - Sliders adjust HUD button, text and joystick scales.
 - Switch toggles between light and dark themes.
 - Opens from the HUD; closing returns to the game.
+- Overlay remains transparent so adjustments can be viewed immediately.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- remove dim background from settings overlay so game stays visible while adjusting UI
- document that settings overlay stays transparent for immediate feedback

## Testing
- `scripts/dartw format lib/ui/settings_overlay.dart`
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b94a345d2c833096e1925f0c9e68b5