### PR TITLE
feat: add upgrade service and overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -106,6 +106,8 @@ tree spanning weapons and ship systems.
 - `overlay_service.dart` shows and hides the Flutter overlays.
 - `settings_service.dart` holds tweakable UI scale values and theme mode.
 - `targeting_service.dart` assists auto-aim queries.
+- `upgrade_service.dart` manages purchasing upgrades with minerals and exposes
+  a `ValueListenable` for bought upgrade ids.
 - Add services only when needed to keep the project lightweight.
 
 ## State and Data
@@ -122,6 +124,7 @@ tree spanning weapons and ship systems.
   milestones.
 - Design upgrades to modify mining efficiency, combat power and utility systems
   without bloating the core game loop.
+- `UpgradeService` tracks available upgrades and purchases using minerals.
 
 ## Game State Flow
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -84,7 +84,8 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Pull nearby pickups toward the player with a Tractor Aura.
 - [x] Auto-aim the primary weapon at the closest enemy when stationary.
 - [x] Refine auto-aim targeting behaviour for smoother updates.
-- [ ] Design a broad upgrade system where minerals purchase new weapon and ship
+- [x] Design a broad upgrade system where minerals purchase new weapon and ship
       upgrades.
+- [ ] Implement upgrade effects and apply them to gameplay systems.
 - [ ] Add a minimap or other navigation aid for exploring the larger world.
 - [ ] Evaluate camera dead zones or world wrapping to handle map edges.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -23,6 +23,7 @@ import '../services/overlay_service.dart';
 import '../services/storage_service.dart';
 import '../services/audio_service.dart';
 import '../services/targeting_service.dart';
+import '../services/upgrade_service.dart';
 import '../services/settings_service.dart';
 import '../theme/game_theme.dart';
 import '../ui/help_overlay.dart';
@@ -58,6 +59,7 @@ class SpaceGame extends FlameGame
     debugMode = kDebugMode;
     pools = createPoolManager();
     targetingService = TargetingService(eventBus);
+    upgradeService = UpgradeService(scoreService: scoreService);
   }
 
   /// Handles persistence for the high score.
@@ -113,6 +115,7 @@ class SpaceGame extends FlameGame
   ValueNotifier<int> get highScore => scoreService.highScore;
   ValueNotifier<int> get minerals => scoreService.minerals;
   ValueNotifier<int> get health => scoreService.health;
+  late final UpgradeService upgradeService;
 
   /// Selected player sprite index for menu selection.
   final ValueNotifier<int> selectedPlayerIndex = ValueNotifier<int>(0);

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -10,6 +10,7 @@ Optional helpers for cross-cutting concerns.
 - `overlay_service.dart` shows and hides overlays on the `GameWidget`.
 - `settings_service.dart` holds UI scale values and theme mode.
 - `targeting_service.dart` assists auto-aim queries.
+- `upgrade_service.dart` manages purchasing upgrades with minerals.
 - Keep services lightweight; add them only when a milestone needs them.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/services/upgrade_service.dart
+++ b/lib/services/upgrade_service.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+
+import 'score_service.dart';
+
+/// Simple upgrade data.
+class Upgrade {
+  Upgrade({required this.id, required this.name, required this.cost});
+
+  final String id;
+  final String name;
+  final int cost;
+}
+
+/// Handles purchasing upgrades with minerals.
+class UpgradeService {
+  UpgradeService({required this.scoreService});
+
+  final ScoreService scoreService;
+
+  final List<Upgrade> upgrades = [
+    Upgrade(id: 'fireRate1', name: 'Faster Cannon', cost: 10),
+    Upgrade(id: 'miningSpeed1', name: 'Efficient Mining', cost: 15),
+  ];
+
+  final ValueNotifier<Set<String>> _purchased =
+      ValueNotifier<Set<String>>(<String>{});
+  ValueListenable<Set<String>> get purchased => _purchased;
+
+  bool isPurchased(String id) => _purchased.value.contains(id);
+
+  bool canAfford(Upgrade upgrade) =>
+      scoreService.minerals.value >= upgrade.cost && !isPurchased(upgrade.id);
+
+  /// Attempts to buy [upgrade], returning `true` on success.
+  bool buy(Upgrade upgrade) {
+    if (!canAfford(upgrade)) {
+      return false;
+    }
+    scoreService.addMinerals(-upgrade.cost);
+    final newSet = Set<String>.from(_purchased.value)..add(upgrade.id);
+    _purchased.value = newSet;
+    return true;
+  }
+}

--- a/lib/services/upgrade_service.md
+++ b/lib/services/upgrade_service.md
@@ -1,0 +1,13 @@
+# UpgradeService
+
+Manages purchasing upgrades using collected minerals.
+
+## Responsibilities
+
+- Expose a list of available upgrades with ids, names and costs.
+- Track which upgrades have been purchased.
+- Deduct mineral costs via `ScoreService` when buying.
+- Provide a `ValueListenable` of purchased upgrade ids for UI widgets.
+- Future work: apply upgrade effects to gameplay systems.
+
+See [../../PLAN.md](../../PLAN.md) for progression goals.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -21,8 +21,8 @@ Flutter overlays and HUD widgets.
   restart (button or `Enter`/`R`), menu, help and mute options.
 - [HelpOverlay](help_overlay.md) – lists all controls; toggled with `H` and
   pauses gameplay when opened mid-run; `Esc` also closes it.
-- [UpgradesOverlay](upgrades_overlay.md) – placeholder screen for future ship
-  upgrades; opened with `U` and pauses gameplay.
+- [UpgradesOverlay](upgrades_overlay.md) – lists purchasable ship upgrades;
+  opened with `U` and pauses gameplay.
 - [SettingsOverlay](settings_overlay.md) – adjust HUD, text and joystick scale
   and toggle the dark theme; opened via HUD button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;

--- a/lib/ui/upgrades_overlay.dart
+++ b/lib/ui/upgrades_overlay.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import '../services/upgrade_service.dart';
 import 'game_text.dart';
 import 'overlay_widgets.dart';
 
 /// Overlay shown for choosing upgrades.
-class UpgradesOverlay extends StatelessWidget {
+class UpgradesOverlay extends StatefulWidget {
   const UpgradesOverlay({super.key, required this.game});
 
   /// Reference to the running game.
@@ -15,7 +16,13 @@ class UpgradesOverlay extends StatelessWidget {
   static const String id = 'upgradesOverlay';
 
   @override
+  State<UpgradesOverlay> createState() => _UpgradesOverlayState();
+}
+
+class _UpgradesOverlayState extends State<UpgradesOverlay> {
+  @override
   Widget build(BuildContext context) {
+    final service = widget.game.upgradeService;
     return OverlayLayout(
       dimmed: true,
       builder: (context, spacing, iconSize) {
@@ -28,14 +35,20 @@ class UpgradesOverlay extends StatelessWidget {
               maxLines: 1,
             ),
             SizedBox(height: spacing),
-            const GameText(
-              'Coming soon',
-              maxLines: 1,
+            ValueListenableBuilder<int>(
+              valueListenable: widget.game.minerals,
+              builder: (context, minerals, _) {
+                return Column(
+                  children: [
+                    for (final upgrade in service.upgrades)
+                      _buildUpgradeRow(upgrade, minerals, service),
+                  ],
+                );
+              },
             ),
             SizedBox(height: spacing),
             ElevatedButton(
-              // Mirrors the U and Escape keyboard shortcuts.
-              onPressed: game.toggleUpgrades,
+              onPressed: widget.game.toggleUpgrades,
               child: const GameText(
                 'Resume',
                 maxLines: 1,
@@ -43,10 +56,44 @@ class UpgradesOverlay extends StatelessWidget {
               ),
             ),
             SizedBox(height: spacing),
-            MuteButton(game: game, iconSize: iconSize),
+            MuteButton(game: widget.game, iconSize: iconSize),
           ],
         );
       },
+    );
+  }
+
+  Widget _buildUpgradeRow(
+    Upgrade upgrade,
+    int minerals,
+    UpgradeService service,
+  ) {
+    final purchased = service.isPurchased(upgrade.id);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          GameText(
+            '${upgrade.name} (${upgrade.cost})',
+            maxLines: 1,
+          ),
+          const SizedBox(width: 8),
+          if (purchased)
+            const GameText('Purchased', maxLines: 1)
+          else
+            ElevatedButton(
+              onPressed: minerals >= upgrade.cost
+                  ? () {
+                      setState(() {
+                        service.buy(upgrade);
+                      });
+                    }
+                  : null,
+              child: const GameText('Buy', maxLines: 1),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/upgrades_overlay.md
+++ b/lib/ui/upgrades_overlay.md
@@ -1,10 +1,11 @@
 # UpgradesOverlay
 
-Placeholder overlay for future ship and ability upgrades.
+Overlay for purchasing ship and ability upgrades.
 
 ## Features
 
-- Displays a temporary "Coming soon" message.
+- Lists available upgrades with their mineral costs.
+- Buy buttons deduct minerals via `UpgradeService` and mark upgrades as purchased.
 - Pauses gameplay when opened from a run and resumes when closed.
 - Activated via the `U` key or HUD button.
 - Dismiss with the on-screen resume button or by pressing `U` or `Esc`.

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -27,5 +27,6 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Equip the player with an auto-firing mining laser for nearby asteroids.
 - [x] Drop minerals from mined asteroids and track the currency.
 - [x] Auto-aim the main weapon at the closest enemy.
-- [ ] Design a broad upgrade system where minerals purchase new weapon and ship
+- [x] Design a broad upgrade system where minerals purchase new weapon and ship
   upgrades.
+- [ ] Implement upgrade effects and apply them to gameplay systems.

--- a/test/upgrade_service_test.dart
+++ b/test/upgrade_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/services/score_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/upgrade_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('buy deducts minerals and marks upgrade purchased', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final service = UpgradeService(scoreService: score);
+    score.addMinerals(20);
+    final upgrade = service.upgrades.first;
+    final success = service.buy(upgrade);
+    expect(success, isTrue);
+    expect(score.minerals.value, 10);
+    expect(service.isPurchased(upgrade.id), isTrue);
+  });
+
+  test('buy fails without enough minerals', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final service = UpgradeService(scoreService: score);
+    final upgrade = service.upgrades.first;
+    final success = service.buy(upgrade);
+    expect(success, isFalse);
+    expect(score.minerals.value, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add `UpgradeService` to manage mineral purchases
- show purchasable upgrades in the upgrades overlay
- document upgrade system and mark design task complete

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx -y markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68b9494ae2e483309d85bf92d6280255