### PR TITLE
Fix HUD overlay overlap with control buttons

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -28,63 +28,63 @@ class HudOverlay extends StatelessWidget {
           child: SizedBox.expand(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-              child: Stack(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Align(
-                    alignment: Alignment.topCenter,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8),
-                          child: ScoreDisplay(game: game),
-                        ),
-                        const SizedBox(width: 8),
-                        MineralDisplay(game: game),
-                        const SizedBox(width: 8),
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8),
-                          child: HealthDisplay(game: game),
-                        ),
-                      ],
+                  Expanded(
+                    child: Align(
+                      alignment: Alignment.topCenter,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.only(top: 8),
+                            child: ScoreDisplay(game: game),
+                          ),
+                          const SizedBox(width: 8),
+                          MineralDisplay(game: game),
+                          const SizedBox(width: 8),
+                          Padding(
+                            padding: const EdgeInsets.only(top: 8),
+                            child: HealthDisplay(game: game),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                  Align(
-                    alignment: Alignment.topRight,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        IconButton(
-                          iconSize: iconSize,
-                          icon: Icon(
-                            Icons.gps_fixed,
-                            color: Theme.of(context).colorScheme.onSurface,
-                          ),
-                          onPressed: game.toggleAutoAimRadius,
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        iconSize: iconSize,
+                        icon: Icon(
+                          Icons.gps_fixed,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
-                        UpgradeButton(game: game, iconSize: iconSize),
-                        HelpButton(game: game, iconSize: iconSize),
-                        SettingsButton(game: game, iconSize: iconSize),
-                        MuteButton(game: game, iconSize: iconSize),
-                        ValueListenableBuilder<GameState>(
-                          valueListenable: game.stateMachine.stateNotifier,
-                          builder: (context, state, _) {
-                            final paused = state == GameState.paused;
-                            return IconButton(
-                              iconSize: iconSize,
-                              // Mirrors the Escape and P keyboard shortcuts.
-                              icon: Icon(
-                                paused ? Icons.play_arrow : Icons.pause,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                              onPressed:
-                                  paused ? game.resumeGame : game.pauseGame,
-                            );
-                          },
-                        ),
-                      ],
-                    ),
+                        onPressed: game.toggleAutoAimRadius,
+                      ),
+                      UpgradeButton(game: game, iconSize: iconSize),
+                      HelpButton(game: game, iconSize: iconSize),
+                      SettingsButton(game: game, iconSize: iconSize),
+                      MuteButton(game: game, iconSize: iconSize),
+                      ValueListenableBuilder<GameState>(
+                        valueListenable: game.stateMachine.stateNotifier,
+                        builder: (context, state, _) {
+                          final paused = state == GameState.paused;
+                          return IconButton(
+                            iconSize: iconSize,
+                            // Mirrors the Escape and P keyboard shortcuts.
+                            icon: Icon(
+                              paused ? Icons.play_arrow : Icons.pause,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                            onPressed:
+                                paused ? game.resumeGame : game.pauseGame,
+                          );
+                        },
+                      ),
+                    ],
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- prevent HUD metric pills from overlapping the control buttons by replacing Stack with a Row that reserves space for both groups

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b94d4a9bf88330974c0734eb13ff0e