### PR TITLE
feat: apply basic upgrade effects

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -86,6 +86,6 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Refine auto-aim targeting behaviour for smoother updates.
 - [x] Design a broad upgrade system where minerals purchase new weapon and ship
       upgrades.
-- [ ] Implement upgrade effects and apply them to gameplay systems.
+- [x] Implement upgrade effects and apply them to gameplay systems.
 - [ ] Add a minimap or other navigation aid for exploring the larger world.
 - [ ] Evaluate camera dead zones or world wrapping to handle map edges.

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -40,6 +40,7 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
   @override
   void update(double dt) {
     super.update(dt);
+    _pulseTimer.limit = game.upgradeService.miningPulseInterval;
     if (!player.isMounted) {
       _target = null;
       _pulseTimer.stop();

--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -121,7 +121,7 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
     );
     game.add(bullet);
     game.audioService.playShoot();
-    _shootCooldown = Constants.bulletCooldown;
+    _shootCooldown = game.upgradeService.bulletCooldown;
   }
 
   /// Begins continuous shooting and fires immediately.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -32,6 +32,10 @@ class Constants {
   /// Seconds between mining laser pulses.
   static const double miningPulseInterval = 0.5;
 
+  /// Multiplier applied to [miningPulseInterval] when the mining speed
+  /// upgrade is purchased.
+  static const double miningPulseIntervalUpgradeFactor = 0.8;
+
   /// Volume for the mining laser sound effect (0-1).
   static const double miningLaserVolume = 0.25;
 
@@ -58,6 +62,10 @@ class Constants {
 
   /// Minimum time between player shots in seconds.
   static const double bulletCooldown = 0.2;
+
+  /// Multiplier applied to [bulletCooldown] when the fire rate upgrade is
+  /// purchased.
+  static const double bulletCooldownUpgradeFactor = 0.8;
 
   /// Damage dealt by player bullets.
   static const int bulletDamage = 1;

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -10,7 +10,8 @@ Optional helpers for cross-cutting concerns.
 - `overlay_service.dart` shows and hides overlays on the `GameWidget`.
 - `settings_service.dart` holds UI scale values and theme mode.
 - `targeting_service.dart` assists auto-aim queries.
-- `upgrade_service.dart` manages purchasing upgrades with minerals.
+- `upgrade_service.dart` manages purchasing upgrades with minerals and
+  derives gameplay modifiers like fire rate and mining speed.
 - Keep services lightweight; add them only when a milestone needs them.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/services/upgrade_service.dart
+++ b/lib/services/upgrade_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../constants.dart';
 import 'score_service.dart';
 
 /// Simple upgrade data.
@@ -30,6 +31,24 @@ class UpgradeService {
 
   bool canAfford(Upgrade upgrade) =>
       scoreService.minerals.value >= upgrade.cost && !isPurchased(upgrade.id);
+
+  /// Current bullet cooldown factoring in purchased upgrades.
+  double get bulletCooldown {
+    var cooldown = Constants.bulletCooldown;
+    if (isPurchased('fireRate1')) {
+      cooldown *= Constants.bulletCooldownUpgradeFactor;
+    }
+    return cooldown;
+  }
+
+  /// Current mining pulse interval factoring in purchased upgrades.
+  double get miningPulseInterval {
+    var interval = Constants.miningPulseInterval;
+    if (isPurchased('miningSpeed1')) {
+      interval *= Constants.miningPulseIntervalUpgradeFactor;
+    }
+    return interval;
+  }
 
   /// Attempts to buy [upgrade], returning `true` on success.
   bool buy(Upgrade upgrade) {

--- a/lib/services/upgrade_service.md
+++ b/lib/services/upgrade_service.md
@@ -8,6 +8,7 @@ Manages purchasing upgrades using collected minerals.
 - Track which upgrades have been purchased.
 - Deduct mineral costs via `ScoreService` when buying.
 - Provide a `ValueListenable` of purchased upgrade ids for UI widgets.
-- Future work: apply upgrade effects to gameplay systems.
+- Provide derived values like bullet cooldown and mining pulse interval based
+  on purchased upgrades.
 
 See [../../PLAN.md](../../PLAN.md) for progression goals.

--- a/milestone-core-loop.md
+++ b/milestone-core-loop.md
@@ -29,4 +29,4 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Auto-aim the main weapon at the closest enemy.
 - [x] Design a broad upgrade system where minerals purchase new weapon and ship
   upgrades.
-- [ ] Implement upgrade effects and apply them to gameplay systems.
+- [x] Implement upgrade effects and apply them to gameplay systems.

--- a/test/upgrade_effects_test.dart
+++ b/test/upgrade_effects_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/constants.dart';
+import 'package:space_game/services/score_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/upgrade_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('Faster Cannon reduces bullet cooldown', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final service = UpgradeService(scoreService: score);
+    final upgrade = service.upgrades.firstWhere((u) => u.id == 'fireRate1');
+    expect(service.bulletCooldown, Constants.bulletCooldown);
+    score.addMinerals(upgrade.cost);
+    service.buy(upgrade);
+    expect(service.bulletCooldown, lessThan(Constants.bulletCooldown));
+  });
+
+  test('Efficient Mining shortens pulse interval', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final service = UpgradeService(scoreService: score);
+    final upgrade = service.upgrades.firstWhere((u) => u.id == 'miningSpeed1');
+    expect(service.miningPulseInterval, Constants.miningPulseInterval);
+    score.addMinerals(upgrade.cost);
+    service.buy(upgrade);
+    expect(
+        service.miningPulseInterval, lessThan(Constants.miningPulseInterval));
+  });
+}


### PR DESCRIPTION
## Summary
- add upgrade multipliers for fire rate and mining speed
- use purchased upgrades when shooting or mining
- document and test upgrade effects

## Testing
- `./scripts/dartw format lib/constants.dart lib/services/upgrade_service.dart lib/components/player_input_behavior.dart lib/components/mining_laser.dart test/upgrade_effects_test.dart`
- `./scripts/dartw analyze`
- `npx markdownlint-cli '**/*.md'`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b94d2a7de48330b2f927a214d54382