### PR TITLE
feat: clamp camera to world bounds

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -155,8 +155,8 @@ tree spanning weapons and ship systems.
 
 ## Rendering & Camera
 
-- Fixed logical resolution scaled to the device.
-- Camera follows the player via `CameraComponent` and `FixedResolutionViewport`.
+- Camera follows the player via `CameraComponent` and clamps to the
+  `Constants.worldSize` bounds with a `BoundedPositionBehavior` so the starfield edges stay in view.
 - A parallax starfield provides the background.
 
 ## Assets

--- a/PLAN.md
+++ b/PLAN.md
@@ -136,9 +136,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   `HasGameReference<SpaceGame>` instead of using global singletons
 - Keep Flutter UI widgets separate from game state updates
 - If saving is needed later, add IDs and JSON‑serializable state
-- Fixed logical resolution scaled to device for consistent gameplay
-- Camera follows the player via `CameraComponent` and a `FixedResolutionViewport`
-  for consistent scaling across devices
+  - Camera follows the player via `CameraComponent` and clamps to the
+    `Constants.worldSize` bounds so blank space beyond the starfield isn't shown
 - Use `HasCollisionDetection` for collisions with simple `CircleHitbox`/`RectangleHitbox`
   shapes and a timer-based spawner
 - Top‑down view with a simple parallax starfield background using Flame's

--- a/TASKS.md
+++ b/TASKS.md
@@ -88,4 +88,4 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       upgrades.
 - [x] Implement upgrade effects and apply them to gameplay systems.
 - [ ] Add a minimap or other navigation aid for exploring the larger world.
-- [ ] Evaluate camera dead zones or world wrapping to handle map edges.
+- [x] Clamp camera to world bounds to keep the starfield edges in view.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -1,6 +1,8 @@
 import 'dart:ui';
 
+import 'package:flame/camera.dart';
 import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/foundation.dart';
@@ -164,6 +166,17 @@ class SpaceGame extends FlameGame
     await add(player);
     _playerInitialized = true;
     camera.follow(player, snap: true);
+    camera.add(
+      BoundedPositionBehavior(
+        bounds: Rectangle.fromLTWH(
+          0,
+          0,
+          Constants.worldSize.x,
+          Constants.worldSize.y,
+        ),
+        target: camera.viewfinder,
+      ),
+    );
     final laser = MiningLaserComponent(player: player);
     miningLaser = laser;
     await add(laser);

--- a/test/camera_start_center_test.dart
+++ b/test/camera_start_center_test.dart
@@ -1,4 +1,6 @@
+import 'package:flame/camera.dart';
 import 'package:flame/components.dart';
+import 'package:flame/experimental.dart';
 import 'package:flame/flame.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -32,5 +34,17 @@ void main() {
 
     expect(game.player.position, Constants.worldSize / 2);
     expect(game.camera.viewfinder.position, game.player.position);
+    final behavior =
+        game.camera.children.whereType<BoundedPositionBehavior>().single;
+    final rect = (behavior.bounds as Rectangle).toRect();
+    expect(
+      rect,
+      Rect.fromLTWH(
+        0,
+        0,
+        Constants.worldSize.x,
+        Constants.worldSize.y,
+      ),
+    );
   });
 }


### PR DESCRIPTION
## Summary
- clamp the camera to Constants.worldSize using a BoundedPositionBehavior
- document camera bounds and mark the task complete
- verify camera bounds in tests

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68b95031e1388330a7122a7566c9f152