### PR TITLE
Scale HUD icons with text size

### DIFF
--- a/lib/ui/health_display.dart
+++ b/lib/ui/health_display.dart
@@ -16,10 +16,10 @@ class HealthDisplay extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     return HudValueDisplay(
       valueListenable: game.health,
-      icon: ImageIcon(
+      iconBuilder: (size) => ImageIcon(
         AssetImage('assets/images/${Assets.healthIcon}'),
         color: scheme.error,
-        size: 24,
+        size: size,
       ),
     );
   }

--- a/lib/ui/hud_value_display.dart
+++ b/lib/ui/hud_value_display.dart
@@ -7,12 +7,16 @@ import 'game_text.dart';
 class HudValueDisplay extends StatelessWidget {
   const HudValueDisplay({
     super.key,
-    required this.icon,
+    required this.iconBuilder,
     required this.valueListenable,
+    this.baseIconSize = 24,
   });
 
-  /// Icon widget shown before the value.
-  final Widget icon;
+  /// Builds the icon widget, allowing the size to scale with text.
+  final Widget Function(double size) iconBuilder;
+
+  /// Base size for the icon before scaling is applied.
+  final double baseIconSize;
 
   /// Notifier providing the current value to render.
   final ValueListenable<int> valueListenable;
@@ -20,9 +24,9 @@ class HudValueDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    return ValueListenableBuilder<int>(
-      valueListenable: valueListenable,
-      builder: (context, value, _) => Container(
+    Widget buildDisplay(int value, double scale) {
+      final iconSize = baseIconSize * scale;
+      return Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
         decoration: BoxDecoration(
           color: scheme.surface.withValues(alpha: 0.7),
@@ -32,12 +36,28 @@ class HudValueDisplay extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            icon,
+            iconBuilder(iconSize),
             const SizedBox(width: 8),
             GameText('$value', maxLines: 1),
           ],
         ),
-      ),
+      );
+    }
+
+    final textScale = GameText.textScale;
+    if (textScale != null) {
+      return ValueListenableBuilder<double>(
+        valueListenable: textScale,
+        builder: (context, scale, _) => ValueListenableBuilder<int>(
+          valueListenable: valueListenable,
+          builder: (context, value, _) => buildDisplay(value, scale),
+        ),
+      );
+    }
+
+    return ValueListenableBuilder<int>(
+      valueListenable: valueListenable,
+      builder: (context, value, _) => buildDisplay(value, 1),
     );
   }
 }

--- a/lib/ui/mineral_display.dart
+++ b/lib/ui/mineral_display.dart
@@ -15,10 +15,11 @@ class MineralDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     return HudValueDisplay(
       valueListenable: game.minerals,
-      icon: Image.asset(
+      baseIconSize: 48,
+      iconBuilder: (size) => Image.asset(
         'assets/images/${Assets.mineralIcon}',
-        width: 48,
-        height: 48,
+        width: size,
+        height: size,
       ),
     );
   }

--- a/lib/ui/score_display.dart
+++ b/lib/ui/score_display.dart
@@ -18,10 +18,10 @@ class ScoreDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     return HudValueDisplay(
       valueListenable: game.score,
-      icon: ImageIcon(
+      iconBuilder: (size) => ImageIcon(
         AssetImage('assets/images/${Assets.scoreIcon}'),
-        color:  _goldColor,
-        size: 24,
+        color: _goldColor,
+        size: size,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Scale HUD pill icons relative to GameText's current size
- Update health, score, and mineral displays to use new icon builder

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9515d9620833080215d717aa5e8b8