### PR TITLE
Show multiple configurable range rings around player

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -9,7 +9,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Player can shoot and destroy a basic enemy
 - [ ] Bullets travel in the direction the ship is facing
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
-- [ ] Target button toggles auto-aim radius display
+- [ ] Target button toggles range rings display
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score
@@ -35,8 +35,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it
-- [ ] Settings overlay sliders adjust HUD button, text and joystick sizes
-      (default 0.75 for buttons and text)
+- [ ] Settings overlay sliders adjust HUD button, text, joystick sizes and
+      gameplay ranges (default 0.75 for buttons and text)
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/lib/components/auto_aim_behavior.dart
+++ b/lib/components/auto_aim_behavior.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'package:flame/components.dart';
 
-import '../constants.dart';
 import '../game/space_game.dart';
 import '../util/nearest_component.dart';
 import 'enemy.dart';
@@ -20,7 +19,7 @@ class AutoAimBehavior extends Component
     final enemies = game.pools.components<EnemyComponent>();
     final target = enemies.findClosest(
       parent.position,
-      Constants.playerAutoAimRange,
+      game.settingsService.targetingRange.value,
     );
     if (target != null) {
       parent.targetAngle = _normalizeAngle(

--- a/lib/components/mineral.dart
+++ b/lib/components/mineral.dart
@@ -52,8 +52,8 @@ class MineralComponent extends SpriteComponent
     }
     final toPlayer = playerPos - position;
     final distanceSquared = toPlayer.length2;
-    final rangeSquared =
-        Constants.playerTractorAuraRadius * Constants.playerTractorAuraRadius;
+    final range = game.settingsService.tractorRange.value;
+    final rangeSquared = range * range;
     if (distanceSquared == 0 || distanceSquared > rangeSquared) {
       return;
     }

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -52,18 +52,18 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
       return;
     }
 
-    final rangeSquared =
-        Constants.playerMiningRange * Constants.playerMiningRange;
+    final miningRange = game.settingsService.miningRange.value;
+    final rangeSquared = miningRange * miningRange;
     if (_target == null ||
         !_target!.isMounted ||
         _target!.position.distanceToSquared(player.position) > rangeSquared) {
       final asteroids = game.pools.nearbyAsteroids(
         player.position,
-        Constants.playerMiningRange,
+        miningRange,
       );
       _target = asteroids.findClosest(
         player.position,
-        Constants.playerMiningRange,
+        miningRange,
       );
       _pulseTimer
         ..stop()

--- a/lib/components/mining_laser.md
+++ b/lib/components/mining_laser.md
@@ -3,8 +3,8 @@
 Automatically targets the nearest asteroid within range and mines it with
 discrete pulses.
 
-- Searches for the closest `AsteroidComponent` within
-  `Constants.playerMiningRange`.
+- Searches for the closest `AsteroidComponent` within the
+  `SettingsService.miningRange` (defaults to `Constants.playerMiningRange`).
 - Fires a pulse every `Constants.miningPulseInterval` seconds that deals
   `Constants.miningPulseDamage` damage.
 - Renders a line between the player and target that widens as the pulse

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -48,7 +48,7 @@ class PlayerComponent extends SpriteComponent
 
   String _spritePath;
 
-  /// Whether to render the auto-aim radius around the player.
+  /// Whether to render range rings around the player.
   bool showAutoAimRadius = false;
 
   /// Angle the ship should currently rotate towards.
@@ -57,9 +57,20 @@ class PlayerComponent extends SpriteComponent
   /// Whether the player moved during the latest update.
   bool isMoving = false;
 
-  /// Paint used when drawing the auto-aim radius.
-  final Paint _autoAimPaint = Paint()..style = PaintingStyle.stroke;
-  late void Function() _autoAimColorListener;
+  /// Paint used when drawing the targeting range.
+  final Paint _targetingPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..color = const Color(0x66ff0000);
+
+  /// Paint used when drawing the Tractor Aura range.
+  final Paint _tractorPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..color = const Color(0x660000ff);
+
+  /// Paint used when drawing the mining laser range.
+  final Paint _miningPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..color = const Color(0x66ffff00);
 
   static final _damageFilter =
       ColorFilter.mode(const Color(0xffff0000), BlendMode.srcATop);
@@ -97,7 +108,7 @@ class PlayerComponent extends SpriteComponent
     _input.joystick = joystick;
   }
 
-  /// Toggles visibility of the auto-aim radius.
+  /// Toggles visibility of the player's range rings.
   void toggleAutoAimRadius() {
     showAutoAimRadius = !showAutoAimRadius;
   }
@@ -138,14 +149,6 @@ class PlayerComponent extends SpriteComponent
     if (!contains(_autoAim)) {
       add(_autoAim);
     }
-    void updateAutoAimColor() {
-      _autoAimPaint.color =
-          game.colorScheme.value.primary.withValues(alpha: 0.4);
-    }
-
-    updateAutoAimColor();
-    _autoAimColorListener = updateAutoAimColor;
-    game.colorScheme.addListener(_autoAimColorListener);
     keyDispatcher.register(
       LogicalKeyboardKey.space,
       onDown: startShooting,
@@ -156,7 +159,6 @@ class PlayerComponent extends SpriteComponent
   @override
   void onRemove() {
     keyDispatcher.unregister(LogicalKeyboardKey.space);
-    game.colorScheme.removeListener(_autoAimColorListener);
     super.onRemove();
   }
 
@@ -190,10 +192,21 @@ class PlayerComponent extends SpriteComponent
   void render(Canvas canvas) {
     super.render(canvas);
     if (showAutoAimRadius) {
+      final center = Offset(size.x / 2, size.y / 2);
       canvas.drawCircle(
-        Offset(size.x / 2, size.y / 2),
-        Constants.playerAutoAimRange,
-        _autoAimPaint,
+        center,
+        game.settingsService.targetingRange.value,
+        _targetingPaint,
+      );
+      canvas.drawCircle(
+        center,
+        game.settingsService.tractorRange.value,
+        _tractorPaint,
+      );
+      canvas.drawCircle(
+        center,
+        game.settingsService.miningRange.value,
+        _miningPaint,
       );
     }
   }

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -12,6 +12,8 @@ Controllable ship for the player.
 - When stationary, periodically rotates to face the nearest enemy within range.
 - Collects `MineralComponent`s on contact to increase the mineral counter.
 - A blue Tractor Aura pulls nearby pickups toward the ship.
+- HUD button toggles coloured rings for targeting, Tractor Aura and mining
+  ranges.
 - Pulls sprites from `assets.dart` and tuning values from `constants.dart`.
 - Uses `CircleHitbox` and `HasGameReference<SpaceGame>`.
 

--- a/lib/components/tractor_aura_renderer.dart
+++ b/lib/components/tractor_aura_renderer.dart
@@ -2,18 +2,19 @@ import 'dart:ui';
 
 import 'package:flame/components.dart';
 
-import '../constants.dart';
+import '../game/space_game.dart';
 import 'player.dart';
 
 /// Renders the player's tractor aura as a radial gradient.
-class TractorAuraRenderer extends Component with ParentIsA<PlayerComponent> {
+class TractorAuraRenderer extends Component
+    with ParentIsA<PlayerComponent>, HasGameReference<SpaceGame> {
   final Paint _paint = Paint()..style = PaintingStyle.fill;
 
   @override
   void render(Canvas canvas) {
     super.render(canvas);
     final auraCenter = Offset(parent.size.x / 2, parent.size.y / 2);
-    final auraRadius = Constants.playerTractorAuraRadius;
+    final auraRadius = game.settingsService.tractorRange.value;
     _paint.shader = Gradient.radial(
       auraCenter,
       auraRadius,

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -353,7 +353,7 @@ class SpaceGame extends FlameGame
     }
   }
 
-  /// Toggles rendering of the player's auto-aim radius.
+  /// Toggles rendering of the player's range rings.
   void toggleAutoAimRadius() {
     player.toggleAutoAimRadius();
   }

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -8,7 +8,7 @@ Optional helpers for cross-cutting concerns.
   `shared_preferences`.
 - `score_service.dart` tracks score, minerals and health values.
 - `overlay_service.dart` shows and hides overlays on the `GameWidget`.
-- `settings_service.dart` holds UI scale values and theme mode.
+- `settings_service.dart` holds UI scale values, theme mode and gameplay ranges.
 - `targeting_service.dart` assists auto-aim queries.
 - `upgrade_service.dart` manages purchasing upgrades with minerals and
   derives gameplay modifiers like fire rate and mining speed.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
 
-/// Holds tweakable UI scale values for live prototyping.
+import '../constants.dart';
+
+/// Holds tweakable UI scale values and gameplay ranges for live prototyping.
 class SettingsService {
   SettingsService()
       : hudButtonScale = ValueNotifier<double>(defaultHudButtonScale),
         textScale = ValueNotifier<double>(defaultTextScale),
         joystickScale = ValueNotifier<double>(defaultJoystickScale),
         themeMode = ValueNotifier<ThemeMode>(ThemeMode.system),
-        muteOnPause = ValueNotifier<bool>(true);
+        muteOnPause = ValueNotifier<bool>(true),
+        targetingRange = ValueNotifier<double>(Constants.playerAutoAimRange),
+        tractorRange = ValueNotifier<double>(Constants.playerTractorAuraRadius),
+        miningRange = ValueNotifier<double>(Constants.playerMiningRange);
 
   static const double defaultHudButtonScale = 0.75;
   static const double defaultTextScale = 1.5;
@@ -27,4 +32,13 @@ class SettingsService {
 
   /// Whether audio should fully mute when the game is paused.
   final ValueNotifier<bool> muteOnPause;
+
+  /// Distance used to auto-aim enemies when stationary.
+  final ValueNotifier<double> targetingRange;
+
+  /// Radius of the player's Tractor Aura in pixels.
+  final ValueNotifier<double> tractorRange;
+
+  /// Maximum distance to auto-mine asteroids, in pixels.
+  final ValueNotifier<double> miningRange;
 }

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -14,7 +14,7 @@ Flutter overlays and HUD widgets.
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
 - [HudOverlay](hud_overlay.md) – shows score, minerals (with icon) and health
-    with auto-aim radius toggle, help, upgrades, mute and pause buttons.
+    with range rings toggle, help, upgrades, mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label with
   instructions to press `Esc` or `P` to resume while the game is paused.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with
@@ -23,8 +23,8 @@ Flutter overlays and HUD widgets.
   pauses gameplay when opened mid-run; `Esc` also closes it.
 - [UpgradesOverlay](upgrades_overlay.md) – lists purchasable ship upgrades;
   opened with `U` and pauses gameplay.
-- [SettingsOverlay](settings_overlay.md) – adjust HUD, text and joystick scale
-  and toggle the dark theme; opened via HUD button.
+- [SettingsOverlay](settings_overlay.md) – adjust HUD, text, joystick scale and
+  gameplay ranges, and toggle the dark theme; opened via HUD button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -62,6 +62,7 @@ class HudOverlay extends StatelessWidget {
                           Icons.gps_fixed,
                           color: Theme.of(context).colorScheme.onSurface,
                         ),
+                        // Shows or hides targeting, tractor and mining range rings.
                         onPressed: game.toggleAutoAimRadius,
                       ),
                       UpgradeButton(game: game, iconSize: iconSize),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -6,7 +6,7 @@ Heads-up display shown during play.
 
 - Shows current score, minerals and health using centred pill-shaped displays
   driven by `ValueNotifier`s from `SpaceGame`.
-- Provides auto-aim radius toggle, upgrades, help, mute and pause/resume button
+- Provides range rings toggle, upgrades, help, mute and pause/resume button
   bound to `SpaceGame` and `AudioService`.
 - Icon sizes scale with screen size for better usability on different devices.
 - `U` opens the upgrades overlay; `Esc` closes it.

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -4,7 +4,7 @@ import '../game/space_game.dart';
 import 'game_text.dart';
 import 'overlay_widgets.dart';
 
-/// Overlay providing runtime UI scaling sliders.
+/// Overlay providing runtime UI scaling and range sliders.
 class SettingsOverlay extends StatelessWidget {
   const SettingsOverlay({super.key, required this.game});
 
@@ -43,6 +43,30 @@ class SettingsOverlay extends StatelessWidget {
               'Joypad',
               settings.joystickScale,
               spacing,
+            ),
+            _buildSlider(
+              context,
+              'Targeting Range',
+              settings.targetingRange,
+              spacing,
+              min: 50,
+              max: 600,
+            ),
+            _buildSlider(
+              context,
+              'Tractor Range',
+              settings.tractorRange,
+              spacing,
+              min: 50,
+              max: 600,
+            ),
+            _buildSlider(
+              context,
+              'Mining Range',
+              settings.miningRange,
+              spacing,
+              min: 50,
+              max: 600,
             ),
             ValueListenableBuilder<ThemeMode>(
               valueListenable: settings.themeMode,
@@ -100,8 +124,10 @@ class SettingsOverlay extends StatelessWidget {
     BuildContext context,
     String label,
     ValueNotifier<double> notifier,
-    double spacing,
-  ) {
+    double spacing, {
+    double min = 0.5,
+    double max = 2.0,
+  }) {
     return ValueListenableBuilder<double>(
       valueListenable: notifier,
       builder: (context, value, _) => Column(
@@ -110,8 +136,8 @@ class SettingsOverlay extends StatelessWidget {
           GameText('$label: ${value.toStringAsFixed(2)}'),
           Slider(
             value: value,
-            min: 0.5,
-            max: 2.0,
+            min: min,
+            max: max,
             onChanged: (v) => notifier.value = v,
           ),
           SizedBox(height: spacing),

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -1,10 +1,10 @@
 # SettingsOverlay
 
-Overlay providing runtime UI scaling controls and a dark theme toggle.
+Overlay providing runtime UI scaling and range controls plus a dark theme toggle.
 
 ## Features
 
-- Sliders adjust HUD button, text and joystick scales.
+- Sliders adjust HUD button, text, joystick scales and gameplay ranges.
 - Switch toggles between light and dark themes.
 - Opens from the HUD; closing returns to the game.
 - Overlay remains transparent so adjustments can be viewed immediately.

--- a/test/player_auto_aim_radius_toggle_test.dart
+++ b/test/player_auto_aim_radius_toggle_test.dart
@@ -46,7 +46,7 @@ class _TestGame extends SpaceGame {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('toggle auto-aim radius', () async {
+  test('toggle range rings', () async {
     SharedPreferences.setMockInitialValues({});
     await Flame.images.loadAll([...Assets.players]);
     final storage = await StorageService.create();

--- a/test/tractor_aura_test.dart
+++ b/test/tractor_aura_test.dart
@@ -11,7 +11,6 @@ import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
-import 'package:space_game/constants.dart';
 
 class _TestGame extends SpaceGame {
   _TestGame({required StorageService storage, required AudioService audio})
@@ -51,7 +50,7 @@ void main() {
     game.update(0);
     game.update(0);
 
-    final start = Vector2(Constants.playerTractorAuraRadius - 10, 0);
+    final start = Vector2(game.settingsService.tractorRange.value - 10, 0);
     final pickup = game.pools.acquire<MineralComponent>(
       (m) => m.reset(start.clone()),
     );
@@ -78,7 +77,7 @@ void main() {
     game.update(0);
     game.update(0);
 
-    final start = Vector2(Constants.playerTractorAuraRadius + 10, 0);
+    final start = Vector2(game.settingsService.tractorRange.value + 10, 0);
     final pickup = game.pools.acquire<MineralComponent>(
       (m) => m.reset(start.clone()),
     );


### PR DESCRIPTION
## Summary
- Display targeting, Tractor Aura, and mining ranges as red, blue, and yellow rings around the player.
- Expose range distances via `SettingsService` and add sliders in Settings overlay for live tuning.
- Apply configurable ranges across auto-aim, mining laser, and tractor aura logic.

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b950f66c348330ba3a8dc2ff54af27