### PR TITLE
Ensure pooled components respect debug toggle

### DIFF
--- a/lib/game/pool_manager.dart
+++ b/lib/game/pool_manager.dart
@@ -77,6 +77,22 @@ class PoolManager {
   /// Returns the active components for type [T].
   List<T> components<T extends Component>() => _active[T] as List<T>? ?? <T>[];
 
+  /// Updates the debug flag on all pooled and active components.
+  void applyDebugMode(bool enabled) {
+    for (final list in _active.values) {
+      for (final component in list as List<Component>) {
+        component.debugMode = enabled;
+      }
+    }
+    for (final pool in _pools.values) {
+      for (final obj in pool.items) {
+        if (obj is Component) {
+          obj.debugMode = enabled;
+        }
+      }
+    }
+  }
+
   void updateAsteroidPosition(
     AsteroidComponent asteroid,
     Vector2 previousPosition,

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -337,6 +337,10 @@ class SpaceGame extends FlameGame
       _applyDebugMode(child, debugMode);
     }
 
+    // Ensure pooled components also reflect the new debug mode so reused
+    // instances don't retain stale debug flags.
+    pools.applyDebugMode(debugMode);
+
     if (debugMode) {
       if (_fpsText != null && !_fpsText!.isMounted) {
         add(_fpsText!);

--- a/lib/util/object_pool.dart
+++ b/lib/util/object_pool.dart
@@ -1,5 +1,3 @@
-import 'package:meta/meta.dart';
-
 /// Generic object pool to minimise allocations by reusing instances.
 class ObjectPool<T> {
   ObjectPool(this._create);
@@ -7,9 +5,8 @@ class ObjectPool<T> {
   final T Function() _create;
   final List<T> _items = [];
 
-  /// Retrieves an instance from the pool, applying [reset] if provided.
-  @visibleForTesting
-  List<T> get items => _items;
+  /// Returns the cached items currently in the pool.
+  Iterable<T> get items => _items;
 
   T acquire([void Function(T)? reset]) {
     final obj = _items.isNotEmpty ? _items.removeLast() : _create();

--- a/test/debug_mode_toggle_test.dart
+++ b/test/debug_mode_toggle_test.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/storage_service.dart';
 import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/components/enemy.dart';
 
 class _HitboxGame extends SpaceGame {
   _HitboxGame({required StorageService storage, required AudioService audio})
@@ -50,5 +51,18 @@ void main() {
     expect(game.hitbox.debugMode, isTrue);
     game.toggleDebug();
     expect(game.hitbox.debugMode, isFalse);
+  });
+
+  test('toggleDebug updates pooled component debugMode', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    final enemy = game.pools.acquire<EnemyComponent>((_) {});
+    enemy.debugMode = true;
+    game.pools.release(enemy);
+    game.toggleDebug();
+    final reused = game.pools.acquire<EnemyComponent>((_) {});
+    expect(reused.debugMode, isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- propagate debugMode changes to pooled components so reused enemies don't retain hitboxes
- add regression test for pooled enemy debug flag

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9526f8f0083309755e2f2ee480439