### PR TITLE
fix: correct HUD overlay widget structure

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -55,6 +55,7 @@ class HudOverlay extends StatelessWidget {
                     child: Wrap(
                       alignment: WrapAlignment.end,
                       children: [
+                        // Shows or hides targeting, tractor and mining range rings.
                         IconButton(
                           iconSize: iconSize,
                           icon: Icon(
@@ -83,30 +84,8 @@ class HudOverlay extends StatelessWidget {
                             );
                           },
                         ),
-                        // Shows or hides targeting, tractor and mining range rings.
-                        onPressed: game.toggleAutoAimRadius,
-                      ),
-                      UpgradeButton(game: game, iconSize: iconSize),
-                      HelpButton(game: game, iconSize: iconSize),
-                      SettingsButton(game: game, iconSize: iconSize),
-                      MuteButton(game: game, iconSize: iconSize),
-                      ValueListenableBuilder<GameState>(
-                        valueListenable: game.stateMachine.stateNotifier,
-                        builder: (context, state, _) {
-                          final paused = state == GameState.paused;
-                          return IconButton(
-                            iconSize: iconSize,
-                            // Mirrors the Escape and P keyboard shortcuts.
-                            icon: Icon(
-                              paused ? Icons.play_arrow : Icons.pause,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                            onPressed:
-                                paused ? game.resumeGame : game.pauseGame,
-                          );
-                        },
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- fix HUD overlay children list and remove duplicate buttons
- document purpose of range-ring toggle

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9548ddccc8330bfebe3f7fbe60a55