### PR TITLE
feat: add camera follow and infinite world

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -136,8 +136,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   `HasGameReference<SpaceGame>` instead of using global singletons
 - Keep Flutter UI widgets separate from game state updates
 - If saving is needed later, add IDs and JSON‑serializable state
-  - Camera follows the player via `CameraComponent` and clamps to the
-    `Constants.worldSize` bounds so blank space beyond the starfield isn't shown
+  - Camera follows the player via `CameraComponent` with no world bounds,
+    and the parallax starfield tiles infinitely to avoid blank space
 - Use `HasCollisionDetection` for collisions with simple `CircleHitbox`/`RectangleHitbox`
   shapes and a timer-based spawner
 - Top‑down view with a simple parallax starfield background using Flame's

--- a/TASKS.md
+++ b/TASKS.md
@@ -87,8 +87,8 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Design a broad upgrade system where minerals purchase new weapon and ship
       upgrades.
 - [x] Implement upgrade effects and apply them to gameplay systems.
-- [ ] Expand the game world beyond the current single-screen map.
-- [ ] Attach a `CameraComponent` that follows the player with no fixed bounds.
+- [x] Expand the game world beyond the current single-screen map.
+- [x] Attach a `CameraComponent` that follows the player with no fixed bounds.
 - [ ] Spawn asteroids, enemies and pickups just ahead of the player and
       despawn those far behind.
 - [ ] Tile the parallax starfield so it scrolls seamlessly.

--- a/lib/components/asteroid_spawner.dart
+++ b/lib/components/asteroid_spawner.dart
@@ -77,7 +77,6 @@ class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
           (_random.nextDouble() - 0.5) * Constants.asteroidSpeed,
         );
     }
-    position.clamp(Vector2.zero(), Constants.worldSize);
     game.add(
       game.pools.acquire<AsteroidComponent>(
         (a) => a.reset(position, velocity),

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -63,13 +63,10 @@ class EnemySpawner extends Component with HasGameReference<SpaceGame> {
           rect.top + _random.nextDouble() * rect.height,
         );
     }
-    base.clamp(Vector2.zero(), Constants.worldSize);
-
     for (var i = 0; i < Constants.enemyGroupSize; i++) {
       final offset = (Vector2.random(_random) - Vector2.all(0.5)) *
           (Constants.enemyGroupSpread * 2);
       final position = base + offset;
-      position.clamp(Vector2.zero(), Constants.worldSize);
       game.add(
         game.pools.acquire<EnemyComponent>((e) => e.reset(position)),
       );

--- a/lib/components/offscreen_cleanup.dart
+++ b/lib/components/offscreen_cleanup.dart
@@ -3,31 +3,31 @@ import 'dart:async';
 import 'package:flame/components.dart';
 
 import '../constants.dart';
+import '../game/space_game.dart';
 
 /// Mixin that removes a component once it leaves the world bounds.
 ///
 /// When applied to a [PositionComponent], a child updater is attached that
 /// checks the component's position each frame and removes it when offscreen.
-mixin OffscreenCleanup on PositionComponent {
+mixin OffscreenCleanup on PositionComponent, HasGameReference<SpaceGame> {
   @override
   Future<void> onLoad() async {
     await super.onLoad();
-    add(_OffscreenCleanupBehavior(this));
+    add(_OffscreenCleanupBehavior(this, game));
   }
 }
 
 class _OffscreenCleanupBehavior extends Component {
-  _OffscreenCleanupBehavior(this._host);
+  _OffscreenCleanupBehavior(this._host, this._game);
 
   final PositionComponent _host;
+  final SpaceGame _game;
 
   @override
   void update(double dt) {
     super.update(dt);
-    if (_host.y < -_host.height ||
-        _host.y > Constants.worldSize.y + _host.height ||
-        _host.x < -_host.width ||
-        _host.x > Constants.worldSize.x + _host.width) {
+    if (_host.position.distanceTo(_game.player.position) >
+        Constants.despawnRadius) {
       // Removing a component during the update cycle can trigger concurrent
       // modification errors if collision detection is iterating over the
       // component tree. Scheduling the removal defers it until after the

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -89,7 +89,7 @@ class PlayerComponent extends SpriteComponent
 
   /// Resets position and orientation to defaults.
   void reset() {
-    position = Constants.worldSize / 2;
+    position.setZero();
     angle = 0;
     targetAngle = 0;
   }

--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -95,11 +95,6 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
     if (!input.isZero()) {
       input = input.normalized();
       player.position += input * Constants.playerSpeed * dt;
-      final halfSize = Vector2.all(player.size.x / 2);
-      player.position.clamp(
-        halfSize,
-        Constants.worldSize - halfSize,
-      );
       player.targetAngle = math.atan2(input.y, input.x) + math.pi / 2;
       player.isMoving = true;
       return true;

--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -15,8 +15,14 @@ class StarfieldComponent extends ParallaxComponent {
 
   @override
   Future<void> onLoad() async {
-    size = Constants.worldSize;
-    parallax = _cachedParallax ??= await _buildParallax(size);
+    parallax = _cachedParallax ??=
+        await _buildParallax(Vector2.all(Constants.starfieldTileSize));
+  }
+
+  @override
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size = size;
   }
 
   static Future<Parallax> _buildParallax(Vector2 size) async {

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,9 +1,10 @@
-import 'package:flame/components.dart';
-
 /// Centralised tunable values for the game.
 class Constants {
-  /// Dimensions of the playable world in pixels.
-  static final Vector2 worldSize = Vector2(2000, 2000);
+  /// Distance from the player after which entities are removed.
+  static const double despawnRadius = 1500;
+
+  /// Size of a single generated starfield tile in pixels.
+  static const double starfieldTileSize = 512;
 
   /// Player movement speed in pixels per second.
   static const double playerSpeed = 200;

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -1,8 +1,6 @@
 import 'dart:ui';
 
-import 'package:flame/camera.dart';
 import 'package:flame/components.dart';
-import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
 import 'package:flame/input.dart';
 import 'package:flutter/foundation.dart';
@@ -162,21 +160,9 @@ class SpaceGame extends FlameGame
       keyDispatcher: keyDispatcher,
       spritePath: selectedPlayerSprite,
     );
-    player.position = Constants.worldSize / 2;
     await add(player);
     _playerInitialized = true;
     camera.follow(player, snap: true);
-    camera.add(
-      BoundedPositionBehavior(
-        bounds: Rectangle.fromLTWH(
-          0,
-          0,
-          Constants.worldSize.x,
-          Constants.worldSize.y,
-        ),
-        target: camera.viewfinder,
-      ),
-    );
     final laser = MiningLaserComponent(player: player);
     miningLaser = laser;
     await add(laser);

--- a/test/camera_start_center_test.dart
+++ b/test/camera_start_center_test.dart
@@ -1,13 +1,10 @@
-import 'package:flame/camera.dart';
 import 'package:flame/components.dart';
-import 'package:flame/experimental.dart';
 import 'package:flame/flame.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:space_game/assets.dart';
-import 'package:space_game/constants.dart';
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
@@ -32,19 +29,7 @@ void main() {
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
 
-    expect(game.player.position, Constants.worldSize / 2);
+    expect(game.player.position, Vector2.zero());
     expect(game.camera.viewfinder.position, game.player.position);
-    final behavior =
-        game.camera.children.whereType<BoundedPositionBehavior>().single;
-    final rect = (behavior.bounds as Rectangle).toRect();
-    expect(
-      rect,
-      Rect.fromLTWH(
-        0,
-        0,
-        Constants.worldSize.x,
-        Constants.worldSize.y,
-      ),
-    );
   });
 }

--- a/test/player_reset_orientation_test.dart
+++ b/test/player_reset_orientation_test.dart
@@ -12,7 +12,6 @@ import 'package:space_game/ui/game_over_overlay.dart';
 import 'package:space_game/ui/hud_overlay.dart';
 import 'package:space_game/ui/menu_overlay.dart';
 import 'package:space_game/ui/pause_overlay.dart';
-import 'package:space_game/constants.dart';
 import 'test_joystick.dart';
 
 void main() {
@@ -57,11 +56,11 @@ void main() {
     game.update(0);
     game.update(0);
     expect(game.player.angle, 0);
-    expect(game.player.position, Constants.worldSize / 2);
+    expect(game.player.position, Vector2.zero());
 
     // After update with no input, angle and position should remain unchanged.
     game.update(0.1);
     expect(game.player.angle, 0);
-    expect(game.player.position, Constants.worldSize / 2);
+    expect(game.player.position, Vector2.zero());
   });
 }

--- a/test/player_respawn_test.dart
+++ b/test/player_respawn_test.dart
@@ -41,6 +41,6 @@ void main() {
     expect(game.stateMachine.state, GameState.gameOver);
 
     game.startGame();
-    expect(game.player.position, Constants.worldSize / 2);
+    expect(game.player.position, Vector2.zero());
   });
 }

--- a/test/restart_removes_old_player_test.dart
+++ b/test/restart_removes_old_player_test.dart
@@ -44,6 +44,6 @@ void main() {
     game.startGame();
     final players = game.children.whereType<PlayerComponent>().toList();
     expect(players.length, 1);
-    expect(players.first.position, Constants.worldSize / 2);
+    expect(players.first.position, Vector2.zero());
   });
 }


### PR DESCRIPTION
## Summary
- remove fixed world bounds and follow player with the camera
- despawn components using a distance-based cleanup radius
- generate a tiling starfield and mark world-expansion tasks complete

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68b95bdcc97483309b5f8e5dff945624