### PR TITLE
fix settings overlay material transparency

### DIFF
--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -35,6 +35,12 @@ class OverlayLayout extends StatelessWidget {
         final iconSize = responsiveIconSize(constraints);
 
         Widget child = Center(child: builder(context, spacing, iconSize));
+        // Ensure overlays have a Material ancestor so widgets like ListTile
+        // don't paint an opaque background that covers the game.
+        child = Material(
+          type: MaterialType.transparency,
+          child: child,
+        );
         if (dimmed) {
           final scheme = Theme.of(context).colorScheme;
           child = Container(


### PR DESCRIPTION
## Summary
- wrap overlay content in transparent Material to stop grey box appearing beneath Settings overlay

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68b95d62e3dc8330b65025b7c1293cff