### PR TITLE
Add fading damage flash

### DIFF
--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -72,8 +72,7 @@ class PlayerComponent extends SpriteComponent
     ..style = PaintingStyle.stroke
     ..color = const Color(0x66ffff00);
 
-  static final _damageFilter =
-      ColorFilter.mode(const Color(0xffff0000), BlendMode.srcATop);
+  static const _damageColor = Color(0xffff0000);
 
   /// Remaining time for the damage flash effect.
   double _damageFlashTime = 0;
@@ -113,10 +112,10 @@ class PlayerComponent extends SpriteComponent
     showAutoAimRadius = !showAutoAimRadius;
   }
 
-  /// Triggers a short red flash to indicate damage taken.
+  /// Triggers a short red flash that fades out to indicate damage taken.
   void flashDamage() {
     _damageFlashTime = Constants.playerDamageFlashDuration;
-    paint.colorFilter = _damageFilter;
+    paint.colorFilter = ColorFilter.mode(_damageColor, BlendMode.srcATop);
   }
 
   /// Allows external callers to fire a bullet.
@@ -184,6 +183,15 @@ class PlayerComponent extends SpriteComponent
       _damageFlashTime -= dt;
       if (_damageFlashTime <= 0) {
         paint.colorFilter = null;
+      } else {
+        final alpha =
+            (255 * (_damageFlashTime / Constants.playerDamageFlashDuration))
+                .clamp(0, 255)
+                .toInt();
+        paint.colorFilter = ColorFilter.mode(
+          _damageColor.withAlpha(alpha),
+          BlendMode.srcATop,
+        );
       }
     }
   }

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -8,7 +8,7 @@ Controllable ship for the player.
 - Fires `BulletComponent`s with a short cooldown when the shoot button or space
   bar is pressed, in the direction the ship is facing.
 - Colliding with enemies or asteroids reduces health via `SpaceGame.hitPlayer`
-  and briefly tints the ship red to show damage.
+  and briefly tints the ship red with a quick fade to show damage.
 - When stationary, periodically rotates to face the nearest enemy within range.
 - Collects `MineralComponent`s on contact to increase the mineral counter.
 - A blue Tractor Aura pulls nearby pickups toward the ship.


### PR DESCRIPTION
## Summary
- Fade player damage tint to transparent for a smoother hit effect
- Document fading red tint in PlayerComponent behavior

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b95e97b1b48330a796da0280d502f6