### PR TITLE
Ensure pooled children respect debug toggle

### DIFF
--- a/lib/game/pool_manager.dart
+++ b/lib/game/pool_manager.dart
@@ -78,18 +78,29 @@ class PoolManager {
   List<T> components<T extends Component>() => _active[T] as List<T>? ?? <T>[];
 
   /// Updates the debug flag on all pooled and active components.
+  ///
+  /// Components can have children that also render debug information. Ensure
+  /// the flag is applied recursively so pooled objects don't retain stale
+  /// debug state between spawns.
   void applyDebugMode(bool enabled) {
     for (final list in _active.values) {
-      for (final component in list as List<Component>) {
-        component.debugMode = enabled;
+      for (final component in list.cast<Component>()) {
+        _applyDebugRecursively(component, enabled);
       }
     }
     for (final pool in _pools.values) {
       for (final obj in pool.items) {
         if (obj is Component) {
-          obj.debugMode = enabled;
+          _applyDebugRecursively(obj, enabled);
         }
       }
+    }
+  }
+
+  void _applyDebugRecursively(Component component, bool enabled) {
+    component.debugMode = enabled;
+    for (final child in component.children) {
+      _applyDebugRecursively(child, enabled);
     }
   }
 

--- a/test/debug_mode_toggle_test.dart
+++ b/test/debug_mode_toggle_test.dart
@@ -65,4 +65,24 @@ void main() {
     final reused = game.pools.acquire<EnemyComponent>((_) {});
     expect(reused.debugMode, isFalse);
   });
+
+  test('toggleDebug updates pooled child debugMode', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+
+    final enemy = game.pools.acquire<EnemyComponent>((_) {});
+    enemy.game = game;
+    await enemy.onLoad();
+    final hitbox = enemy.children.query<CircleHitbox>().first;
+    enemy.debugMode = true;
+    hitbox.debugMode = true;
+    game.pools.release(enemy);
+
+    game.toggleDebug();
+    final reused = game.pools.acquire<EnemyComponent>((_) {});
+    final reusedHitbox = reused.children.query<CircleHitbox>().first;
+    expect(reusedHitbox.debugMode, isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
- apply debug flag recursively to pooled components and their children
- test that pooled components reset child debug flags after toggling

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b95efc73688330b7833fd47f8db087