### PR TITLE
Adjust mineral pickup scaling for cropped icon

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -137,7 +137,10 @@ class Constants {
   static const double mineralSize = 16;
 
   /// Extra scale applied on top of [spriteScale] for mineral sprites.
-  static const double mineralScale = 0;
+  // The mineral icon was cropped from 256x256 to 180x180, reducing empty
+  // padding. Shrink the in-game sprite slightly to keep its on-screen size
+  // consistent with the previous version.
+  static const double mineralScale = -0.9;
 
   /// Distance from an asteroid where mineral drops may appear.
   static const double mineralDropRadius = 16;

--- a/lib/ui/mineral_display.dart
+++ b/lib/ui/mineral_display.dart
@@ -15,7 +15,9 @@ class MineralDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     return HudValueDisplay(
       valueListenable: game.minerals,
-      baseIconSize: 48,
+      // Mineral icon now tightly fits its contents, so the HUD no longer needs
+      // an oversized base to compensate for transparent padding.
+      baseIconSize: 24,
       iconBuilder: (size) => Image.asset(
         'assets/images/${Assets.mineralIcon}',
         width: size,


### PR DESCRIPTION
## Summary
- Shrink mineral pickup sprite to offset tighter 180x180 icon
- Normalize mineral HUD icon size now that padding was removed

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9618c2eb08330807d00fe4473ac35