### PR TITLE
Guard lifecycle resume before state machine init

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -108,6 +108,10 @@ class SpaceGame extends FlameGame
   FpsTextComponent? _fpsText;
   bool _playerInitialized = false;
 
+  /// Whether [onLoad] has finished and late fields are initialised.
+  bool _isLoaded = false;
+  bool get isLoaded => _isLoaded;
+
   late void Function() _updateFireButtonColors;
   late void Function() _updateJoystickColors;
 
@@ -225,6 +229,7 @@ class SpaceGame extends FlameGame
 
     settingsService.joystickScale.addListener(_updateJoystickScale);
     settingsService.hudButtonScale.addListener(_updateHudButtonScale);
+    _isLoaded = true;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -139,7 +139,7 @@ class _AppLifecycleObserver extends WidgetsBindingObserver {
       }
       game.audioService.stopAll();
     } else if (state == AppLifecycleState.resumed) {
-      if (game.stateMachine.state == GameState.playing) {
+      if (game.isLoaded && game.stateMachine.state == GameState.playing) {
         game.resumeEngine();
         game.focusGame();
       }


### PR DESCRIPTION
## Summary
- ensure lifecycle resume only resumes engine after SpaceGame state machine initialized
- track SpaceGame load completion with isLoaded flag

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b963a26c488330b5db86d3720d484c