### PR TITLE
fix: anchor starfield to camera

### DIFF
--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -2,13 +2,14 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
+import 'package:flame/game.dart';
 import 'package:flame/parallax.dart';
 import 'package:flutter/painting.dart' show ImageRepeat;
 
 import '../constants.dart';
 
 /// Persistent parallax starfield that caches its layers after the first build.
-class StarfieldComponent extends ParallaxComponent {
+class StarfieldComponent extends ParallaxComponent<FlameGame> {
   StarfieldComponent() : super(priority: -1);
 
   static Parallax? _cachedParallax;
@@ -23,6 +24,12 @@ class StarfieldComponent extends ParallaxComponent {
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
     this.size = size;
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    position = game.camera.viewfinder.position - size / 2;
   }
 
   static Future<Parallax> _buildParallax(Vector2 size) async {


### PR DESCRIPTION
## Summary
- keep starfield positioned at camera to avoid disappearing background

## Testing
- `scripts/flutterw analyze lib/components/starfield.dart`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b96399e18c83308783b36be8459a4d