### PR TITLE
Align mineral HUD pillbox with others

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -41,7 +41,10 @@ class HudOverlay extends StatelessWidget {
                           child: ScoreDisplay(game: game),
                         ),
                         const SizedBox(width: 8),
-                        MineralDisplay(game: game),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: MineralDisplay(game: game),
+                        ),
                         const SizedBox(width: 8),
                         Padding(
                           padding: const EdgeInsets.only(top: 8),


### PR DESCRIPTION
## Summary
- Add top padding to mineral HUD pillbox so it aligns with score and health displays

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b964b69cc083309a6470f8e157f4e1