### PR TITLE
Center player and decouple starfield from camera

### DIFF
--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -26,11 +26,14 @@ class StarfieldComponent extends ParallaxComponent<FlameGame> {
     this.size = size;
   }
 
-  @override
-  void update(double dt) {
-    super.update(dt);
-    position = game.camera.viewfinder.position - size / 2;
-  }
+  // The starfield should behave like a distant background anchored in the
+  // game world. Previously the component followed the camera, which caused the
+  // stars to appear fixed to the player's ship. By letting the `Camera` handle
+  // translation we allow the starfield to scroll naturally as the player moves
+  // through space.
+
+  // No explicit update override is needed; the component remains at world
+  // coordinates and the camera movement provides the desired parallax effect.
 
   static Future<Parallax> _buildParallax(Vector2 size) async {
     final random = Random();

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -410,6 +410,12 @@ class SpaceGame extends FlameGame
     (fireButton.buttonDown as CircleComponent).radius = 30 * scale;
   }
 
+  @override
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    camera.viewfinder.anchor = Anchor.center;
+  }
+
   /// Requests keyboard focus for the surrounding [GameWidget].
   void focusGame() => focusNode.requestFocus();
 }


### PR DESCRIPTION
## Summary
- Center the camera on the player once the game has layout
- Let the starfield scroll naturally by removing camera-follow behavior

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b966e114808330bf5e23522af22173