### PR TITLE
test: cover state machine and shortcuts

### DIFF
--- a/test/game_state_machine_test.dart
+++ b/test/game_state_machine_test.dart
@@ -1,0 +1,143 @@
+import 'package:flame/game.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/game/game_state_machine.dart';
+import 'package:space_game/services/overlay_service.dart';
+
+class _FakeOverlayService implements OverlayService {
+  @override
+  final Game game = FlameGame();
+
+  bool showHudCalled = false;
+  bool showPauseCalled = false;
+  bool showGameOverCalled = false;
+  bool showMenuCalled = false;
+
+  @override
+  void showHud() => showHudCalled = true;
+  @override
+  void showPause() => showPauseCalled = true;
+  @override
+  void showGameOver() => showGameOverCalled = true;
+  @override
+  void showMenu() => showMenuCalled = true;
+
+  @override
+  void showHelp() {}
+  @override
+  void hideHelp() {}
+  @override
+  void showUpgrades() {}
+  @override
+  void hideUpgrades() {}
+  @override
+  void showSettings() {}
+  @override
+  void hideSettings() {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GameStateMachine', () {
+    test('startGame shows HUD and calls onStart', () {
+      final overlays = _FakeOverlayService();
+      var startCalled = false;
+      final stateMachine = GameStateMachine(
+        overlays: overlays,
+        onStart: () => startCalled = true,
+        onPause: () {},
+        onResume: () {},
+        onGameOver: () {},
+        onMenu: () {},
+      );
+
+      stateMachine.startGame();
+
+      expect(stateMachine.state, GameState.playing);
+      expect(overlays.showHudCalled, isTrue);
+      expect(startCalled, isTrue);
+    });
+
+    test('pauseGame shows pause overlay and calls onPause', () {
+      final overlays = _FakeOverlayService();
+      var pauseCalled = false;
+      final stateMachine = GameStateMachine(
+        overlays: overlays,
+        onStart: () {},
+        onPause: () => pauseCalled = true,
+        onResume: () {},
+        onGameOver: () {},
+        onMenu: () {},
+      )..startGame();
+
+      stateMachine.pauseGame();
+
+      expect(stateMachine.state, GameState.paused);
+      expect(overlays.showPauseCalled, isTrue);
+      expect(pauseCalled, isTrue);
+    });
+
+    test('resumeGame shows HUD and calls onResume', () {
+      final overlays = _FakeOverlayService();
+      var resumeCalled = false;
+      final stateMachine = GameStateMachine(
+        overlays: overlays,
+        onStart: () {},
+        onPause: () {},
+        onResume: () => resumeCalled = true,
+        onGameOver: () {},
+        onMenu: () {},
+      )
+        ..startGame()
+        ..pauseGame();
+
+      overlays.showHudCalled = false;
+      stateMachine.resumeGame();
+
+      expect(stateMachine.state, GameState.playing);
+      expect(overlays.showHudCalled, isTrue);
+      expect(resumeCalled, isTrue);
+    });
+
+    test('gameOver shows game over overlay and calls onGameOver', () {
+      final overlays = _FakeOverlayService();
+      var gameOverCalled = false;
+      final stateMachine = GameStateMachine(
+        overlays: overlays,
+        onStart: () {},
+        onPause: () {},
+        onResume: () {},
+        onGameOver: () => gameOverCalled = true,
+        onMenu: () {},
+      )..startGame();
+
+      stateMachine.gameOver();
+
+      expect(stateMachine.state, GameState.gameOver);
+      expect(overlays.showGameOverCalled, isTrue);
+      expect(gameOverCalled, isTrue);
+    });
+
+    test('returnToMenu shows menu overlay and calls onMenu', () {
+      final overlays = _FakeOverlayService();
+      var menuCalled = false;
+      final stateMachine = GameStateMachine(
+        overlays: overlays,
+        onStart: () {},
+        onPause: () {},
+        onResume: () {},
+        onGameOver: () {},
+        onMenu: () => menuCalled = true,
+      )..startGame();
+
+      stateMachine.returnToMenu();
+
+      expect(stateMachine.state, GameState.menu);
+      expect(overlays.showMenuCalled, isTrue);
+      expect(menuCalled, isTrue);
+    });
+  });
+}

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -1,0 +1,204 @@
+import 'package:flame/game.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/game/game_state_machine.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/shortcut_manager.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/overlay_service.dart';
+
+class _FakeOverlayService implements OverlayService {
+  @override
+  final Game game = FlameGame();
+
+  @override
+  void showHud() {}
+  @override
+  void showPause() {}
+  @override
+  void showGameOver() {}
+  @override
+  void showMenu() {}
+
+  @override
+  void showHelp() {}
+  @override
+  void hideHelp() {}
+  @override
+  void showUpgrades() {}
+  @override
+  void hideUpgrades() {}
+  @override
+  void showSettings() {}
+  @override
+  void hideSettings() {}
+}
+
+class _FakeAudioService implements AudioService {
+  bool toggled = false;
+
+  @override
+  final ValueNotifier<bool> muted = ValueNotifier(false);
+  double _volume = 1;
+
+  @override
+  double get masterVolume => _volume;
+
+  @override
+  void setMasterVolume(double volume) {
+    _volume = volume;
+  }
+
+  @override
+  Future<void> toggleMute() async {
+    toggled = true;
+  }
+
+  @override
+  void playShoot() {}
+
+  @override
+  void playExplosion() {}
+
+  @override
+  Future<void> startMiningLaser() async {}
+
+  @override
+  void stopMiningLaser() {}
+
+  @override
+  void stopAll() {}
+}
+
+class _Harness {
+  _Harness() {
+    stateMachine = GameStateMachine(
+      overlays: _FakeOverlayService(),
+      onStart: () {},
+      onPause: () {},
+      onResume: () {},
+      onGameOver: () {},
+      onMenu: () {},
+    );
+    ShortcutManager(
+      keyDispatcher: dispatcher,
+      stateMachine: stateMachine,
+      audioService: audio,
+      pauseGame: () => pauseCalled = true,
+      resumeGame: () => resumeCalled = true,
+      startGame: () => startCalled = true,
+      toggleHelp: () => helpCalled = true,
+      toggleUpgrades: () => upgradesCalled = true,
+      toggleDebug: () => debugCalled = true,
+    );
+  }
+
+  final dispatcher = KeyDispatcher();
+  late final GameStateMachine stateMachine;
+  final _FakeAudioService audio = _FakeAudioService();
+  bool pauseCalled = false;
+  bool resumeCalled = false;
+  bool startCalled = false;
+  bool helpCalled = false;
+  bool upgradesCalled = false;
+  bool debugCalled = false;
+
+  void press(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) {
+    dispatcher.onKeyEvent(
+      KeyDownEvent(
+        logicalKey: logical,
+        physicalKey: physical,
+        timeStamp: Duration.zero,
+      ),
+      {logical},
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ShortcutManager', () {
+    test('escape pauses and resumes based on state', () {
+      final h = _Harness()..stateMachine.state = GameState.playing;
+
+      h.press(LogicalKeyboardKey.escape, PhysicalKeyboardKey.escape);
+      expect(h.pauseCalled, isTrue);
+
+      h.pauseCalled = false;
+      h.stateMachine.state = GameState.paused;
+      h.press(LogicalKeyboardKey.escape, PhysicalKeyboardKey.escape);
+      expect(h.resumeCalled, isTrue);
+      expect(h.pauseCalled, isFalse);
+    });
+
+    test('P key mirrors escape for pause/resume', () {
+      final h = _Harness()..stateMachine.state = GameState.playing;
+
+      h.press(LogicalKeyboardKey.keyP, PhysicalKeyboardKey.keyP);
+      expect(h.pauseCalled, isTrue);
+
+      h.pauseCalled = false;
+      h.stateMachine.state = GameState.paused;
+      h.press(LogicalKeyboardKey.keyP, PhysicalKeyboardKey.keyP);
+      expect(h.resumeCalled, isTrue);
+      expect(h.pauseCalled, isFalse);
+    });
+
+    test('M toggles mute', () {
+      final h = _Harness();
+      h.press(LogicalKeyboardKey.keyM, PhysicalKeyboardKey.keyM);
+      expect(h.audio.toggled, isTrue);
+    });
+
+    test('Enter starts game from menu and game over', () {
+      final h = _Harness()..stateMachine.state = GameState.menu;
+
+      h.press(LogicalKeyboardKey.enter, PhysicalKeyboardKey.enter);
+      expect(h.startCalled, isTrue);
+
+      h.startCalled = false;
+      h.stateMachine.state = GameState.gameOver;
+      h.press(LogicalKeyboardKey.enter, PhysicalKeyboardKey.enter);
+      expect(h.startCalled, isTrue);
+    });
+
+    test('R restarts game from playing, paused, and game over', () {
+      final h = _Harness()..stateMachine.state = GameState.playing;
+
+      h.press(LogicalKeyboardKey.keyR, PhysicalKeyboardKey.keyR);
+      expect(h.startCalled, isTrue);
+
+      h.startCalled = false;
+      h.stateMachine.state = GameState.paused;
+      h.press(LogicalKeyboardKey.keyR, PhysicalKeyboardKey.keyR);
+      expect(h.startCalled, isTrue);
+
+      h.startCalled = false;
+      h.stateMachine.state = GameState.gameOver;
+      h.press(LogicalKeyboardKey.keyR, PhysicalKeyboardKey.keyR);
+      expect(h.startCalled, isTrue);
+    });
+
+    test('H toggles help', () {
+      final h = _Harness();
+      h.press(LogicalKeyboardKey.keyH, PhysicalKeyboardKey.keyH);
+      expect(h.helpCalled, isTrue);
+    });
+
+    test('U toggles upgrades', () {
+      final h = _Harness();
+      h.press(LogicalKeyboardKey.keyU, PhysicalKeyboardKey.keyU);
+      expect(h.upgradesCalled, isTrue);
+    });
+
+    test('F1 toggles debug', () {
+      final h = _Harness();
+      h.press(LogicalKeyboardKey.f1, PhysicalKeyboardKey.f1);
+      expect(h.debugCalled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for GameStateMachine lifecycle transitions
- verify ShortcutManager key bindings for pause/resume, mute, start, help, upgrades, and debug

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b9664daf188330a10a8650d69124b8