### PR TITLE
Recenter starfield on camera to maintain visibility

### DIFF
--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -26,14 +26,15 @@ class StarfieldComponent extends ParallaxComponent<FlameGame> {
     this.size = size;
   }
 
-  // The starfield should behave like a distant background anchored in the
-  // game world. Previously the component followed the camera, which caused the
-  // stars to appear fixed to the player's ship. By letting the `Camera` handle
-  // translation we allow the starfield to scroll naturally as the player moves
-  // through space.
+  @override
+  void update(double dt) {
+    super.update(dt);
+    position = game.camera.viewfinder.position - size / 2;
+  }
 
-  // No explicit update override is needed; the component remains at world
-  // coordinates and the camera movement provides the desired parallax effect.
+  // Keep the starfield centred on the camera so it always covers the viewport.
+  // Parallax layers still provide depth, but without this recentering the
+  // background would vanish once the player moves away from the origin.
 
   static Future<Parallax> _buildParallax(Vector2 size) async {
     final random = Random();

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -5,6 +5,8 @@ Background starfield using Flame's `ParallaxComponent`.
 - Generates three random star layers with speeds from `constants.dart` for
   parallax depth.
 - Stars are rendered once into images and the parallax system manages scroll
-  and wrapping, so no per-frame star updates are needed.
+  and wrapping.
+- Recenters on the camera each frame to keep the starfield visible as the
+  player moves.
 - Added to `SpaceGame` with a negative priority so it always renders beneath
   gameplay components.


### PR DESCRIPTION
## Summary
- Recenter starfield component on camera each frame to ensure background covers viewport
- Document starfield behaviour in component docs

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b96c07d3c48330aed5e1d32bac5684