### PR TITLE
fix: remove unused import in game state machine test

### DIFF
--- a/test/game_state_machine_test.dart
+++ b/test/game_state_machine_test.dart
@@ -1,5 +1,4 @@
 import 'package:flame/game.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:space_game/game/game_state.dart';


### PR DESCRIPTION
## Summary
- remove unused `flutter/foundation.dart` import from `game_state_machine_test`

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68b96de2b6808330b0e5594e7e36e44e