### PR TITLE
Ensure camera tracks player movement

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -58,7 +58,7 @@ class LifecycleManager {
       game.player.setSprite(game.selectedPlayerSprite);
       game.player.reset();
     }
-    game.camera.follow(game.player, snap: true);
+    game.camera.viewfinder.position = game.player.position;
     game.enemySpawner
       ..stop()
       ..start();

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -166,7 +166,7 @@ class SpaceGame extends FlameGame
     );
     await add(player);
     _playerInitialized = true;
-    camera.follow(player, snap: true);
+    camera.viewfinder.position = player.position;
     final laser = MiningLaserComponent(player: player);
     miningLaser = laser;
     await add(laser);
@@ -408,6 +408,13 @@ class SpaceGame extends FlameGame
     final scale = settingsService.hudButtonScale.value;
     (fireButton.button as CircleComponent).radius = 30 * scale;
     (fireButton.buttonDown as CircleComponent).radius = 30 * scale;
+  }
+
+  /// Ensures the camera stays centred on the player.
+  @override
+  void update(double dt) {
+    super.update(dt);
+    camera.viewfinder.position = player.position;
   }
 
   @override

--- a/test/camera_follows_player_test.dart
+++ b/test/camera_follows_player_test.dart
@@ -1,0 +1,41 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('camera tracks player movement', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.explosions]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    await game.ready();
+    game.onGameResize(Vector2.all(100));
+
+    game.joystick.removeFromParent();
+    await game.ready();
+
+    game.player.position.add(Vector2(10, 20));
+    game.update(0);
+
+    expect(game.camera.viewfinder.position, game.player.position);
+  });
+}


### PR DESCRIPTION
## Summary
- center camera on player when spawning and every frame
- reset camera when starting a new game
- test camera follows player

## Testing
- `./scripts/flutterw test test/camera_start_center_test.dart test/camera_follows_player_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_68b96e4e16808330899cc63dca196598