### PR TITLE
Keep settings overlay when pausing

### DIFF
--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -32,11 +32,8 @@ class OverlayService {
       ..add(HudOverlay.id);
   }
 
-  void showPause() {
-    game.overlays
-      ..remove(SettingsOverlay.id)
-      ..add(PauseOverlay.id);
-  }
+  /// Shows the pause overlay without affecting other active overlays.
+  void showPause() => game.overlays.add(PauseOverlay.id);
 
   void showGameOver() {
     game.overlays

--- a/test/overlay_service_test.dart
+++ b/test/overlay_service_test.dart
@@ -80,7 +80,7 @@ void main() {
 
     service.showSettings();
     service.showPause();
-    expect(game.overlays.isActive(SettingsOverlay.id), isFalse);
+    expect(game.overlays.isActive(SettingsOverlay.id), isTrue);
     expect(game.overlays.isActive(PauseOverlay.id), isTrue);
 
     service.showSettings();


### PR DESCRIPTION
## Summary
- Don't hide the settings overlay when showing the pause overlay so players can keep adjusting settings while paused.
- Update overlay service tests to expect settings overlay remains visible when pausing.

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test` *(fails: LateInitializationError in player_space_key_reregister_test)*

------
https://chatgpt.com/codex/tasks/task_e_68ba891443b083309eeb73bbc0a16789