### PR TITLE
Reorder HUD pillboxes

### DIFF
--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -13,7 +13,7 @@ Flutter overlays and HUD widgets.
 
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
-- [HudOverlay](hud_overlay.md) – shows score, minerals (with icon) and health
+- [HudOverlay](hud_overlay.md) – shows score, health and minerals (with icon)
     with range rings toggle, help, upgrades, mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label with
   instructions to press `Esc` or `P` to resume while the game is paused.

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -43,12 +43,12 @@ class HudOverlay extends StatelessWidget {
                         const SizedBox(width: 8),
                         Padding(
                           padding: const EdgeInsets.only(top: 8),
-                          child: MineralDisplay(game: game),
+                          child: HealthDisplay(game: game),
                         ),
                         const SizedBox(width: 8),
                         Padding(
                           padding: const EdgeInsets.only(top: 8),
-                          child: HealthDisplay(game: game),
+                          child: MineralDisplay(game: game),
                         ),
                       ],
                     ),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -4,7 +4,7 @@ Heads-up display shown during play.
 
 ## Features
 
-- Shows current score, minerals and health using centred pill-shaped displays
+- Shows current score, health and minerals using centred pill-shaped displays
   driven by `ValueNotifier`s from `SpaceGame`.
 - Provides range rings toggle, upgrades, help, mute and pause/resume button
   bound to `SpaceGame` and `AudioService`.


### PR DESCRIPTION
## Summary
- Move minerals pillbox to follow health in HUD row
- Update HUD overlay docs to reflect score, health and minerals order

## Testing
- `./scripts/markdownlint.sh lib/ui/README.md lib/ui/hud_overlay.md`
- `./scripts/dartw analyze`
- `./scripts/flutterw test` *(fails: LateInitializationError in player_space_key_reregister_test.dart)*

------
https://chatgpt.com/codex/tasks/task_e_68ba88e70e348330a77b12cf568144ef