### PR TITLE
feat: add minimap navigation aid

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,7 +135,7 @@ tree spanning weapons and ship systems.
 - Players can pause the game from the HUD or with the Escape or `P` key,
   showing a centered `PAUSED` label with a hint to press `Esc` or `P` to
   resume while gameplay halts.
-- During play the HUD provides score, minerals, health, pause and
+- During play the HUD provides score, minerals, health, a minimap, pause and
   mute controls.
 - On player death, a game over overlay appears with restart, menu and mute buttons.
 - A help overlay lists controls and can be toggled with the `H` key, pausing the

--- a/PLAN.md
+++ b/PLAN.md
@@ -245,7 +245,7 @@ the world beyond the viewport and have the camera track the ship.
 - Continuously spawn asteroids, enemies and pickups ahead of the ship and
   despawn any far behind to keep the scene light.
 - Tile the parallax starfield or otherwise prevent gaps as the camera moves.
-- Navigation aids like a minimap can follow once exploration works.
+- A minimap in the HUD shows nearby asteroids and enemies to assist navigation.
 
 ## 🔮 Future Ideas
 

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -17,6 +17,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Score resets when restarting the game
 - [ ] Minerals reset when restarting the game
 - [ ] HUD shows current score, minerals and health during play
+- [ ] HUD displays a minimap with nearby asteroids and enemies
 - [ ] Collisions reduce player health; game over when health reaches zero
 - [ ] Player ship flashes red when taking damage
 - [ ] Game states transition: menu → playing → upgrades → paused → game over

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ dedicated server or NAT traversal.
 - Single endless level with quick restart
 - Player score, health and minerals displayed in the HUD; health drops on
   collision and minerals increase when collecting pickups from mined asteroids
+- A minimap in the HUD shows nearby asteroids and enemies for navigation
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
   screens, plus an `M` key shortcut

--- a/TASKS.md
+++ b/TASKS.md
@@ -92,4 +92,4 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Spawn asteroids and enemies just ahead of the player and despawn those
       far behind.
 - [x] Tile the parallax starfield so it scrolls seamlessly.
-- [ ] Add a minimap or other navigation aid for exploring the larger world.
+- [x] Add a minimap or other navigation aid for exploring the larger world.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -13,8 +13,8 @@ Flutter overlays and HUD widgets.
 
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
-- [HudOverlay](hud_overlay.md) – shows score, minerals (with icon) and health
-    with range rings toggle, help, upgrades, mute and pause buttons.
+- [HudOverlay](hud_overlay.md) – shows score, minerals (with icon), health and
+    a minimap with range rings toggle, help, upgrades, mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label with
   instructions to press `Esc` or `P` to resume while the game is paused.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -7,6 +7,7 @@ import 'overlay_widgets.dart';
 import 'mineral_display.dart';
 import 'score_display.dart';
 import 'health_display.dart';
+import 'minimap.dart';
 
 /// Simple heads-up display shown during play.
 class HudOverlay extends StatelessWidget {
@@ -30,6 +31,13 @@ class HudOverlay extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
               child: Stack(
                 children: [
+                  Align(
+                    alignment: Alignment.topLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: Minimap(game: game),
+                    ),
+                  ),
                   Align(
                     alignment: Alignment.topCenter,
                     child: Row(

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -6,6 +6,7 @@ Heads-up display shown during play.
 
 - Shows current score, minerals and health using centred pill-shaped displays
   driven by `ValueNotifier`s from `SpaceGame`.
+- Includes a minimap showing nearby asteroids and enemies to aid navigation.
 - Provides range rings toggle, upgrades, help, mute and pause/resume button
   bound to `SpaceGame` and `AudioService`.
 - Icon sizes scale with screen size for better usability on different devices.

--- a/lib/ui/minimap.dart
+++ b/lib/ui/minimap.dart
@@ -1,0 +1,80 @@
+import 'package:flame/extensions.dart';
+import 'package:flutter/material.dart';
+
+import '../components/asteroid.dart';
+import '../components/enemy.dart';
+import '../game/space_game.dart';
+
+/// Simple minimap widget showing nearby asteroids and enemies.
+class Minimap extends StatelessWidget {
+  const Minimap({super.key, required this.game});
+
+  /// Running game instance used to query entity positions.
+  final SpaceGame game;
+
+  /// Visual size of the minimap widget.
+  static const double size = 80;
+
+  /// World-space radius displayed by the minimap around the player.
+  static const double worldRadius = 600;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        painter: _MinimapPainter(game),
+      ),
+    );
+  }
+}
+
+class _MinimapPainter extends CustomPainter {
+  _MinimapPainter(this.game);
+
+  final SpaceGame game;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final playerPos = game.player.position;
+
+    // Background and border
+    final bgPaint = Paint()..color = Colors.black.withValues(alpha: 0.5);
+    canvas.drawRect(Offset.zero & size, bgPaint);
+    final border = Paint()
+      ..style = PaintingStyle.stroke
+      ..color = Colors.white.withValues(alpha: 0.7);
+    canvas.drawRect(Offset.zero & size, border);
+
+    final scale = size.width / (Minimap.worldRadius * 2);
+
+    void drawEntity(Vector2 worldPos, Color color, double radius) {
+      final rel = (worldPos - playerPos) * scale;
+      if (rel.length <= size.width / 2) {
+        canvas.drawCircle(
+          Offset(size.width / 2 + rel.x, size.height / 2 + rel.y),
+          radius,
+          Paint()..color = color,
+        );
+      }
+    }
+
+    for (final asteroid in game.children.whereType<AsteroidComponent>()) {
+      drawEntity(asteroid.position, Colors.grey, 2);
+    }
+    for (final enemy in game.children.whereType<EnemyComponent>()) {
+      drawEntity(enemy.position, Colors.redAccent, 3);
+    }
+
+    // Player marker
+    canvas.drawCircle(
+      Offset(size.width / 2, size.height / 2),
+      3,
+      Paint()..color = Colors.greenAccent,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _MinimapPainter oldDelegate) => true;
+}


### PR DESCRIPTION
## Summary
- render minimap in the HUD showing nearby asteroids and enemies
- document minimap and mark navigation task complete

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68ba898f09048330a7e5de8bf57bfea1