### PR TITLE
feat: add minimap overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,8 +135,8 @@ tree spanning weapons and ship systems.
 - Players can pause the game from the HUD or with the Escape or `P` key,
   showing a centered `PAUSED` label with a hint to press `Esc` or `P` to
   resume while gameplay halts.
-- During play the HUD provides score, minerals, health, pause and
-  mute controls.
+- During play the HUD provides score, minerals, health, a minimap toggle, pause
+  and mute controls.
 - On player death, a game over overlay appears with restart, menu and mute buttons.
 - A help overlay lists controls and can be toggled with the `H` key, pausing the
   game when opened mid-run. `Esc` also closes it without triggering pause.

--- a/PLAN.md
+++ b/PLAN.md
@@ -245,7 +245,7 @@ the world beyond the viewport and have the camera track the ship.
 - Continuously spawn asteroids, enemies and pickups ahead of the ship and
   despawn any far behind to keep the scene light.
 - Tile the parallax starfield or otherwise prevent gaps as the camera moves.
-- Navigation aids like a minimap can follow once exploration works.
+- A small togglable minimap in the top-left aids navigation through the endless world.
 
 ## 🔮 Future Ideas
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ dedicated server or NAT traversal.
 - Single endless level with quick restart
 - Player score, health and minerals displayed in the HUD; health drops on
   collision and minerals increase when collecting pickups from mined asteroids
+- Toggable top-left minimap shows nearby asteroids, enemies and pickups
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
   screens, plus an `M` key shortcut

--- a/TASKS.md
+++ b/TASKS.md
@@ -92,4 +92,4 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Spawn asteroids and enemies just ahead of the player and despawn those
       far behind.
 - [x] Tile the parallax starfield so it scrolls seamlessly.
-- [ ] Add a minimap or other navigation aid for exploring the larger world.
+- [x] Add a minimap or other navigation aid for exploring the larger world.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -107,6 +107,7 @@ class SpaceGame extends FlameGame
   StarfieldComponent? _starfield;
   FpsTextComponent? _fpsText;
   bool _playerInitialized = false;
+  final ValueNotifier<bool> showMinimap = ValueNotifier<bool>(true);
 
   /// Whether [onLoad] has finished and late fields are initialised.
   bool _isLoaded = false;
@@ -128,6 +129,10 @@ class SpaceGame extends FlameGame
 
   void selectPlayer(int index) {
     selectedPlayerIndex.value = index.clamp(0, Assets.players.length - 1);
+  }
+
+  void toggleMinimap() {
+    showMinimap.value = !showMinimap.value;
   }
 
   /// Tracks whether the game was playing when the help overlay opened.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -14,7 +14,7 @@ Flutter overlays and HUD widgets.
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
 - [HudOverlay](hud_overlay.md) – shows score, minerals (with icon) and health
-    with range rings toggle, help, upgrades, mute and pause buttons.
+    with range rings toggle, minimap toggle, help, upgrades, mute and pause buttons.
 - [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label with
   instructions to press `Esc` or `P` to resume while the game is paused.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -7,6 +7,7 @@ import 'overlay_widgets.dart';
 import 'mineral_display.dart';
 import 'score_display.dart';
 import 'health_display.dart';
+import 'minimap_display.dart';
 
 /// Simple heads-up display shown during play.
 class HudOverlay extends StatelessWidget {
@@ -30,6 +31,21 @@ class HudOverlay extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
               child: Stack(
                 children: [
+                  Align(
+                    alignment: Alignment.topLeft,
+                    child: ValueListenableBuilder<bool>(
+                      valueListenable: game.showMinimap,
+                      builder: (context, show, _) {
+                        if (!show) {
+                          return const SizedBox.shrink();
+                        }
+                        return Padding(
+                          padding: const EdgeInsets.only(top: 8, left: 8),
+                          child: MiniMapDisplay(game: game, size: 80 * scale),
+                        );
+                      },
+                    ),
+                  ),
                   Align(
                     alignment: Alignment.topCenter,
                     child: Row(
@@ -67,6 +83,7 @@ class HudOverlay extends StatelessWidget {
                           ),
                           onPressed: game.toggleAutoAimRadius,
                         ),
+                        MinimapButton(game: game, iconSize: iconSize),
                         UpgradeButton(game: game, iconSize: iconSize),
                         HelpButton(game: game, iconSize: iconSize),
                         SettingsButton(game: game, iconSize: iconSize),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -8,6 +8,7 @@ Heads-up display shown during play.
   driven by `ValueNotifier`s from `SpaceGame`.
 - Provides range rings toggle, upgrades, help, mute and pause/resume button
   bound to `SpaceGame` and `AudioService`.
+- Toggles a top-left minimap for navigation.
 - Icon sizes scale with screen size for better usability on different devices.
 - `U` opens the upgrades overlay; `Esc` closes it.
 - `H` opens the help overlay showing controls; `Esc` closes it.

--- a/lib/ui/minimap_display.dart
+++ b/lib/ui/minimap_display.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flame/components.dart';
+
+import '../components/asteroid.dart';
+import '../components/enemy.dart';
+import '../components/mineral.dart';
+import '../game/space_game.dart';
+
+/// Simple circular minimap showing nearby entities relative to the player.
+class MiniMapDisplay extends StatefulWidget {
+  const MiniMapDisplay({super.key, required this.game, this.size = 80});
+
+  final SpaceGame game;
+  final double size;
+
+  @override
+  State<MiniMapDisplay> createState() => _MiniMapDisplayState();
+}
+
+class _MiniMapDisplayState extends State<MiniMapDisplay>
+    with SingleTickerProviderStateMixin {
+  late final Ticker _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = createTicker((_) => setState(() {}))..start();
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: CustomPaint(
+        painter: _MiniMapPainter(widget.game),
+      ),
+    );
+  }
+}
+
+class _MiniMapPainter extends CustomPainter {
+  _MiniMapPainter(this.game);
+
+  final SpaceGame game;
+  static const double _scale = 0.05;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius = size.width / 2;
+    final center = Offset(radius, radius);
+    final borderPaint = Paint()
+      ..color = game.colorScheme.value.primary
+      ..style = PaintingStyle.stroke;
+    canvas.drawCircle(center, radius, borderPaint);
+
+    final playerPaint = Paint()..color = game.colorScheme.value.primary;
+    canvas.drawCircle(center, 3, playerPaint);
+
+    final enemyPaint = Paint()..color = Colors.redAccent;
+    final asteroidPaint = Paint()..color = Colors.grey;
+    final mineralPaint = Paint()..color = Colors.amber;
+
+    final playerPos = game.player.position;
+
+    void drawDot(PositionComponent c, Paint paint) {
+      final offset = (c.position - playerPos) * _scale;
+      if (offset.length <= radius) {
+        canvas.drawCircle(center + Offset(offset.x, offset.y), 2, paint);
+      }
+    }
+
+    for (final enemy in game.children.whereType<EnemyComponent>()) {
+      drawDot(enemy, enemyPaint);
+    }
+    for (final asteroid in game.children.whereType<AsteroidComponent>()) {
+      drawDot(asteroid, asteroidPaint);
+    }
+    for (final mineral in game.children.whereType<MineralComponent>()) {
+      drawDot(mineral, mineralPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _MiniMapPainter oldDelegate) => true;
+}

--- a/lib/ui/minimap_display.md
+++ b/lib/ui/minimap_display.md
@@ -1,0 +1,6 @@
+# MiniMapDisplay
+
+Flutter widget that paints a simple circular radar in the top-left of the HUD.
+It draws dots for nearby asteroids, enemies and mineral pickups relative to the
+player. The map listens to the game for repaints and can be toggled via the HUD
+map button.

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -148,3 +148,23 @@ class SettingsButton extends StatelessWidget {
     );
   }
 }
+
+/// Icon button that toggles the minimap visibility.
+class MinimapButton extends StatelessWidget {
+  const MinimapButton({super.key, required this.game, required this.iconSize});
+
+  final SpaceGame game;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      iconSize: iconSize,
+      icon: Icon(
+        Icons.map,
+        color: Theme.of(context).colorScheme.onSurface,
+      ),
+      onPressed: game.toggleMinimap,
+    );
+  }
+}

--- a/test/minimap_toggle_test.dart
+++ b/test/minimap_toggle_test.dart
@@ -1,0 +1,63 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: 'players/player1.png');
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    final keyDispatcher = KeyDispatcher();
+    add(keyDispatcher);
+    joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+    onGameResize(
+      Vector2.all(Constants.playerSize *
+          (Constants.spriteScale + Constants.playerScale) *
+          2),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('toggle minimap visibility', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+
+    expect(game.showMinimap.value, isTrue);
+    game.toggleMinimap();
+    expect(game.showMinimap.value, isFalse);
+    game.toggleMinimap();
+    expect(game.showMinimap.value, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add HUD minimap widget and toggle button
- document new navigation aid across design docs and task list
- cover minimap toggle with unit test

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68ba898f09048330a7e5de8bf57bfea1