### PR TITLE
feat: add minimap toggle shortcut

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,7 +22,8 @@ Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 Space Miner focuses on hunting asteroids for mineral pickups while timed enemy
 groups add bursts of combat. The ship mounts an auto-firing mining laser that
 locks onto nearby rocks and a primary cannon that automatically targets the
-closest enemy. Minerals gathered during play will later fund a wide upgrade
+closest enemy. A blue Tractor Aura around the ship pulls in nearby pickups.
+Minerals gathered during play will later fund a wide upgrade
 tree spanning weapons and ship systems.
 
 ## Design Principles
@@ -150,6 +151,7 @@ tree spanning weapons and ship systems.
 
 - On-screen joystick and fire button mirror keyboard controls (WASD + Space).
 - Input handling stays isolated from rendering for easier testing.
+- `N` toggles a minimap overlay for navigation.
 - `H` toggles a help overlay for quick reference, and `Esc` closes it when
   visible.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -164,9 +164,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Basic sound effects using `flame_audio` with mute toggle (button or `M` key)
   available on menu, HUD and game over overlays
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
-  shoot, `Escape` or `P` to pause or resume, `M` to mute, `Enter` starts or
-  restarts from the menu or game over, `R` restarts at any time, `H` shows a help
-  overlay that `Esc` also closes)
+  shoot, `Escape` or `P` to pause or resume, `M` to mute, `N` toggles the
+  minimap, `F1` toggles debug overlays, `Enter` starts or restarts from the
+  menu or game over, `R` restarts at any time, `H` shows a help overlay that
+  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes)
 - Upgrades overlay placeholder opened with a HUD button or the `U` key and
   pausing gameplay for future ship upgrades
 - Settings overlay with sliders for HUD, text and joystick scale plus a dark

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -10,6 +10,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Bullets travel in the direction the ship is facing
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
 - [ ] Target button toggles range rings display
+- [ ] Minimap icon or `N` key toggles minimap visibility
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ dedicated server or NAT traversal.
 - Pause or resume via keyboard or HUD button with a `PAUSED` indicator and a
   hint to press `Esc` or `P` to resume, leaving the interface visible
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
-  shoot, `Escape` or `P` to pause or resume, `M` to mute, `F1` toggles debug
-  overlays, `Enter` starts or restarts from the menu or game over, `R` restarts at
-  any time, `H` shows a help overlay that `Esc` also closes, `U`
-  opens an upgrades overlay that `Esc` also closes)
+  shoot, `Escape` or `P` to pause or resume, `M` to mute, `N` toggles the
+  minimap, `F1` toggles debug overlays, `Enter` starts or restarts from the
+  menu or game over, `R` restarts at any time, `H` shows a help overlay that
+  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes)
 - Game works offline after the first load
 - Parallax starfield background
 

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -17,6 +17,7 @@ class ShortcutManager {
     required void Function() toggleHelp,
     required void Function() toggleUpgrades,
     required void Function() toggleDebug,
+    required void Function() toggleMinimap,
   }) {
     keyDispatcher.register(LogicalKeyboardKey.escape, onDown: () {
       if (stateMachine.state == GameState.playing) {
@@ -67,6 +68,11 @@ class ShortcutManager {
     keyDispatcher.register(
       LogicalKeyboardKey.f1,
       onDown: toggleDebug,
+    );
+
+    keyDispatcher.register(
+      LogicalKeyboardKey.keyN,
+      onDown: toggleMinimap,
     );
   }
 }

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -229,6 +229,7 @@ class SpaceGame extends FlameGame
       toggleHelp: toggleHelp,
       toggleUpgrades: toggleUpgrades,
       toggleDebug: toggleDebug,
+      toggleMinimap: toggleMinimap,
     );
     stateMachine.returnToMenu();
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -14,7 +14,8 @@ Flutter overlays and HUD widgets.
 - [MenuOverlay](menu_overlay.md) – start button (or `Enter`), high score with
   reset, help (`H`) and mute toggle.
 - [HudOverlay](hud_overlay.md) – shows score, health and minerals (with icon)
-    with range rings toggle, help, upgrades, mute and pause buttons.
+    with minimap toggle, range rings toggle, help, upgrades, mute and pause
+    buttons.
 - [PauseOverlay](pause_overlay.md) – displays a centered "PAUSED" label with
   instructions to press `Esc` or `P` to resume while the game is paused.
 - [GameOverOverlay](game_over_overlay.md) – shows final and high scores with
@@ -28,6 +29,7 @@ Flutter overlays and HUD widgets.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,
-  `U` opens upgrades, and `Esc` also closes overlays when visible.
+  `U` opens upgrades, `N` toggles the minimap, and `Esc` also closes overlays
+  when visible.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -32,6 +32,7 @@ class HelpOverlay extends StatelessWidget {
               'Move: WASD / Arrow keys\n'
               'Shoot: Space\n'
               'Mute: M\n'
+              'Toggle Minimap: N or HUD button\n'
               'Toggle Debug: F1\n'
               'Auto-aim Radius: Target Button\n'
               'Upgrades: U or HUD button\n'

--- a/lib/ui/help_overlay.md
+++ b/lib/ui/help_overlay.md
@@ -8,5 +8,6 @@ Lists available touch and keyboard controls.
 - Activated via the `H` key or help buttons on other overlays.
 - Pauses gameplay when opened during a run and resumes when closed.
 - Dismiss with the on-screen close button or by pressing `H` again or `Esc`.
+- Lists the `N` key for toggling the minimap.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -15,6 +15,7 @@ Heads-up display shown during play.
 - `M` key also toggles audio mute.
 - `Escape` or `P` keys also pause or resume.
 - Press `R` to restart the current run without using on-screen buttons.
+- Press `N` to toggle the minimap without tapping the icon.
 - Visible in the `playing` and `paused` states.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -97,6 +97,7 @@ class _Harness {
       toggleHelp: () => helpCalled = true,
       toggleUpgrades: () => upgradesCalled = true,
       toggleDebug: () => debugCalled = true,
+      toggleMinimap: () => minimapCalled = true,
     );
   }
 
@@ -109,6 +110,7 @@ class _Harness {
   bool helpCalled = false;
   bool upgradesCalled = false;
   bool debugCalled = false;
+  bool minimapCalled = false;
 
   void press(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) {
     dispatcher.onKeyEvent(
@@ -203,6 +205,12 @@ void main() {
       final h = _Harness();
       h.press(LogicalKeyboardKey.f1, PhysicalKeyboardKey.f1);
       expect(h.debugCalled, isTrue);
+    });
+
+    test('N toggles minimap', () {
+      final h = _Harness();
+      h.press(LogicalKeyboardKey.keyN, PhysicalKeyboardKey.keyN);
+      expect(h.minimapCalled, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- allow `N` key to toggle minimap
- display minimap shortcut in help text and docs
- note Tractor Aura and minimap toggle in design and playtest docs

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx -y markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68ba9313358c83308b67a22cad2be60d