### PR TITLE
Add tests for game spawning, input, overlays and enemy damage

### DIFF
--- a/lib/components/asteroid_spawner.dart
+++ b/lib/components/asteroid_spawner.dart
@@ -62,4 +62,7 @@ class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
 
   @visibleForTesting
   bool get isRunning => _timer.isRunning();
+
+  @visibleForTesting
+  void spawn() => _spawn();
 }

--- a/test/asteroid_spawner_test.dart
+++ b/test/asteroid_spawner_test.dart
@@ -1,0 +1,102 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/asteroid.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/components/asteroid_spawner.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+import 'test_joystick.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: Assets.players.first);
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    keyDispatcher = KeyDispatcher();
+    await add(keyDispatcher);
+    joystick = TestJoystick();
+    await add(joystick);
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+    asteroidSpawner = AsteroidSpawner();
+    await add(asteroidSpawner);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.asteroids, ...Assets.players]);
+  });
+
+  test('start and stop toggle running state', () async {
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(1000));
+    await game.ready();
+
+    game.asteroidSpawner.stop();
+    expect(game.asteroidSpawner.isRunning, isFalse);
+
+    game.asteroidSpawner.start();
+    expect(game.asteroidSpawner.isRunning, isTrue);
+
+    game.asteroidSpawner.stop();
+    expect(game.asteroidSpawner.isRunning, isFalse);
+  });
+
+  test('spawns ahead of moving player with correct speed', () async {
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(2000));
+    await game.ready();
+    game.asteroidSpawner.stop();
+    game.children.whereType<AsteroidComponent>().forEach((a) {
+      a.removeFromParent();
+    });
+    game.update(0);
+
+    game.player
+      ..angle = 0
+      ..isMoving = true
+      ..position.setZero();
+
+    game.asteroidSpawner.spawn();
+    await game.ready();
+    final asteroid = game.children.whereType<AsteroidComponent>().first;
+    final delta = asteroid.position - game.player.position;
+    expect(delta.y, lessThan(0)); // spawned above player
+    expect(
+      delta.length,
+      closeTo(Constants.despawnRadius * 0.9, Constants.despawnRadius * 0.3),
+    );
+
+    final before = asteroid.position.clone();
+    game.update(1);
+    final moved = asteroid.position - before;
+    expect(moved.length, closeTo(Constants.asteroidSpeed, 0.1));
+  });
+}

--- a/test/enemy_damage_test.dart
+++ b/test/enemy_damage_test.dart
@@ -1,0 +1,112 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flame_audio/flame_audio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/enemy.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/components/explosion.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/audio_service.dart';
+
+import 'test_joystick.dart';
+
+class _FakeAudioService implements AudioService {
+  final ValueNotifier<bool> muted = ValueNotifier(false);
+  int explosions = 0;
+  double _masterVolume = 1;
+
+  @override
+  double get masterVolume => _masterVolume;
+
+  @override
+  AudioPlayer? get miningLoop => null;
+
+  @override
+  Future<void> startMiningLaser() async {}
+
+  @override
+  void stopAll() {}
+
+  @override
+  void stopMiningLaser() {}
+
+  @override
+  void playShoot() {}
+
+  @override
+  void playExplosion() {
+    explosions++;
+  }
+
+  @override
+  Future<void> toggleMute() async {
+    muted.value = !muted.value;
+  }
+
+  @override
+  void setMasterVolume(double volume) {
+    _masterVolume = volume;
+  }
+}
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: Assets.players.first);
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    keyDispatcher = KeyDispatcher();
+    await add(keyDispatcher);
+    joystick = TestJoystick();
+    await add(joystick);
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images
+        .loadAll([...Assets.enemies, ...Assets.explosions, ...Assets.players]);
+  });
+
+  test('enemy takeDamage awards score, plays audio and removes enemy',
+      () async {
+    final storage = await StorageService.create();
+    final audio = _FakeAudioService();
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(1000));
+    await game.ready();
+
+    final enemy = EnemyComponent()..reset(Vector2.zero());
+    await game.add(enemy);
+    game.update(0);
+    expect(game.score.value, 0);
+
+    enemy.takeDamage(Constants.enemyMaxHealth);
+    game.update(0);
+    expect(game.score.value, Constants.enemyScore);
+    expect(audio.explosions, 1);
+    expect(enemy.parent, isNull);
+    expect(game.children.whereType<ExplosionComponent>().length, 1);
+  });
+}

--- a/test/menu_overlay_test.dart
+++ b/test/menu_overlay_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('shows high score when non-zero', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.highScore.value = 42;
+    await tester.pumpWidget(MaterialApp(home: MenuOverlay(game: game)));
+    expect(find.text('High Score: 42'), findsOneWidget);
+  });
+
+  testWidgets('player selection updates index', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    await tester.pumpWidget(MaterialApp(home: MenuOverlay(game: game)));
+
+    final imageFinder =
+        find.image(AssetImage('assets/images/${Assets.players[1]}'));
+    await tester.tap(imageFinder);
+    await tester.pump();
+    expect(game.selectedPlayerIndex.value, 1);
+  });
+}

--- a/test/offscreen_cleanup_test.dart
+++ b/test/offscreen_cleanup_test.dart
@@ -1,0 +1,90 @@
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/components/player.dart';
+import 'package:space_game/components/offscreen_cleanup.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+import 'test_joystick.dart';
+import 'package:space_game/assets.dart';
+import 'package:flame/flame.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: Assets.players.first);
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _CleanupComponent extends PositionComponent
+    with HasGameReference<SpaceGame>, OffscreenCleanup {
+  _CleanupComponent(Vector2 position) {
+    this.position.setFrom(position);
+    size = Vector2.all(10);
+  }
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    keyDispatcher = KeyDispatcher();
+    await add(keyDispatcher);
+    joystick = TestJoystick();
+    await add(joystick);
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players]);
+  });
+
+  test('removes components beyond despawn radius', () async {
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(1000));
+    await game.ready();
+
+    final comp = _CleanupComponent(Vector2(Constants.despawnRadius + 10, 0));
+    await game.add(comp);
+    game.update(0);
+    await game.ready();
+    expect(comp.parent, isNull);
+  });
+
+  test('retains components within despawn radius', () async {
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(1000));
+    await game.ready();
+
+    final comp = _CleanupComponent(Vector2(Constants.despawnRadius - 10, 0));
+    await game.add(comp);
+    game.update(0);
+    await game.ready();
+    expect(comp.parent, isNotNull);
+  });
+}

--- a/test/player_input_behavior_test.dart
+++ b/test/player_input_behavior_test.dart
@@ -1,0 +1,145 @@
+import 'package:flame/components.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/bullet.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/pool_manager.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+import 'test_joystick.dart';
+
+class _TestBullet extends BulletComponent {
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: Assets.players.first);
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestPoolManager extends PoolManager {
+  _TestPoolManager({required super.events});
+
+  final List<_TestBullet> _bullets = [];
+
+  @override
+  T acquire<T extends Component>(void Function(T) reset) {
+    if (T == BulletComponent) {
+      final bullet =
+          _bullets.isNotEmpty ? _bullets.removeLast() : _TestBullet();
+      reset(bullet as T);
+      return bullet as T;
+    }
+    return super.acquire<T>(reset);
+  }
+
+  @override
+  void release<T extends Component>(T component) {
+    if (component is BulletComponent) {
+      _bullets.add(component as _TestBullet);
+      return;
+    }
+    super.release(component);
+  }
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  PoolManager createPoolManager() => _TestPoolManager(events: eventBus);
+
+  @override
+  Future<void> onLoad() async {
+    keyDispatcher = KeyDispatcher();
+    await add(keyDispatcher);
+    joystick = TestJoystick();
+    await add(joystick);
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+    player.inputBehavior.game = this;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('keyboard movement when joystick idle', () async {
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(500));
+    await game.ready();
+
+    game.keyDispatcher.onKeyEvent(
+      const KeyDownEvent(
+        logicalKey: LogicalKeyboardKey.keyW,
+        physicalKey: PhysicalKeyboardKey.keyW,
+        timeStamp: Duration.zero,
+      ),
+      {LogicalKeyboardKey.keyW},
+    );
+    game.player.inputBehavior.update(1);
+    expect(game.player.position.y, lessThan(0));
+  });
+
+  test('joystick movement overrides keyboard', () async {
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(500));
+    await game.ready();
+
+    game.keyDispatcher.onKeyEvent(
+      const KeyDownEvent(
+        logicalKey: LogicalKeyboardKey.keyW,
+        physicalKey: PhysicalKeyboardKey.keyW,
+        timeStamp: Duration.zero,
+      ),
+      {LogicalKeyboardKey.keyW},
+    );
+    game.joystick.delta.setValues(1, 0);
+    game.joystick.relativeDelta.setValues(1, 0);
+    game.player.inputBehavior.update(1);
+    expect(game.player.position.x, greaterThan(0));
+    expect(game.player.position.y, closeTo(0, 0.001));
+  });
+
+  test('continuous shooting fires repeatedly', () async {
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(500));
+    await game.ready();
+
+    game.player.startShooting();
+    game.player.inputBehavior.update(0);
+    expect(game.children.whereType<BulletComponent>().length, 1);
+
+    game.player.inputBehavior.update(Constants.bulletCooldown);
+    expect(game.children.whereType<BulletComponent>().length, 2);
+
+    game.player.stopShooting();
+    game.player.inputBehavior.update(Constants.bulletCooldown);
+    expect(game.children.whereType<BulletComponent>().length, 2);
+  });
+}

--- a/test/settings_overlay_test.dart
+++ b/test/settings_overlay_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/settings_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('slider and toggle modify settings', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.window.physicalSizeTestValue = const Size(800, 1200);
+    binding.window.devicePixelRatioTestValue = 1;
+    addTearDown(binding.window.clearPhysicalSizeTestValue);
+    addTearDown(binding.window.clearDevicePixelRatioTestValue);
+
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+
+    await tester.pumpWidget(MaterialApp(home: SettingsOverlay(game: game)));
+
+    final slider = find.byType(Slider).first;
+    final initial = game.settingsService.hudButtonScale.value;
+    await tester.drag(slider, const Offset(50, 0));
+    await tester.pump();
+    expect(game.settingsService.hudButtonScale.value, isNot(initial));
+
+    final toggle = find.byType(Switch);
+    expect(game.settingsService.muteOnPause.value, isTrue);
+    await tester.tap(toggle, warnIfMissed: false);
+    await tester.pump();
+    expect(game.settingsService.muteOnPause.value, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- expose `AsteroidSpawner.spawn()` for testing
- add tests for asteroid spawning, offscreen cleanup, input behavior, overlays, and enemy damage

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68ba93802ae88330b1856a7619f2cade