### PR TITLE
refactor: consolidate audio service tests

### DIFF
--- a/test/audio_service_test.dart
+++ b/test/audio_service_test.dart
@@ -19,14 +19,16 @@ void main() {
     expect(service.masterVolume, 0);
   });
 
-  test('toggleMute flips flag', () async {
+  test('toggleMute flips flag and updates storage', () async {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final service = await AudioService.create(storage);
 
     expect(service.muted.value, isFalse);
+    expect(storage.isMuted(), isFalse);
     await service.toggleMute();
     expect(service.muted.value, isTrue);
+    expect(storage.isMuted(), isTrue);
   });
 
   test('start/stop mining laser loop and mute prevents playback', () async {

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:space_game/services/storage_service.dart';
-import 'package:space_game/services/audio_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -22,18 +21,6 @@ void main() {
       expect(storage.getHighScore(), 99);
       await storage.resetHighScore();
       expect(storage.getHighScore(), 0);
-    });
-  });
-
-  group('AudioService', () {
-    test('toggleMute updates storage', () async {
-      SharedPreferences.setMockInitialValues({});
-      final storage = await StorageService.create();
-      final audio = await AudioService.create(storage);
-      expect(audio.muted.value, isFalse);
-      await audio.toggleMute();
-      expect(audio.muted.value, isTrue);
-      expect(storage.isMuted(), isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- ensure audio service toggleMute updates storage alongside state
- drop duplicate audio test from services suite and rename to `storage_service_test.dart`

## Testing
- `./scripts/flutterw test`
- `./scripts/flutterw test test/audio_service_test.dart test/storage_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68ba9f18da3c8330a95126d392c9709b