### PR TITLE
docs: document range ring toggle and settings overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -136,8 +136,8 @@ tree spanning weapons and ship systems.
 - Players can pause the game from the HUD or with the Escape or `P` key,
   showing a centered `PAUSED` label with a hint to press `Esc` or `P` to
   resume while gameplay halts.
-- During play the HUD provides score, minerals, health, a minimap toggle, pause
-  and mute controls.
+- During play the HUD provides score, minerals, health, a minimap toggle, range
+  rings toggle, pause and mute controls.
 - On player death, a game over overlay appears with restart, menu and mute buttons.
 - A help overlay lists controls and can be toggled with the `H` key, pausing the
   game when opened mid-run. `Esc` also closes it without triggering pause.
@@ -152,6 +152,7 @@ tree spanning weapons and ship systems.
 - On-screen joystick and fire button mirror keyboard controls (WASD + Space).
 - Input handling stays isolated from rendering for easier testing.
 - `N` toggles a minimap overlay for navigation.
+- HUD button toggles range rings showing targeting, Tractor Aura and mining radii.
 - `H` toggles a help overlay for quick reference, and `Esc` closes it when
   visible.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -156,9 +156,12 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Enemy groups spawn periodically; the main weapon smoothly auto-aims at the closest foe
 - Asteroids drop mineral pickups when mined with an auto-targeting laser;
   destroying enemies also grants points
+- A blue Tractor Aura around the ship pulls in nearby pickups
 - Single endless level without progression for now
 - Player score, minerals and health shown in the HUD with simple
   start/game‑over screens
+- Toggable top-left minimap shows nearby asteroids, enemies and pickups
+- HUD button toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Local high score stored on device (e.g., shared preferences)
 - Menu offers a reset button to clear the high score
 - Basic sound effects using `flame_audio` with mute toggle (button or `M` key)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ dedicated server or NAT traversal.
 - Player score, health and minerals displayed in the HUD; health drops on
   collision and minerals increase when collecting pickups from mined asteroids
 - Toggable top-left minimap shows nearby asteroids, enemies and pickups
+- HUD button toggles coloured range rings showing targeting, Tractor Aura and mining radii
+- Placeholder upgrades overlay accessible via a HUD button or the `U` key
+- Settings overlay adjusts HUD, text and joystick scale and offers light or dark themes
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
   screens, plus an `M` key shortcut

--- a/TASKS.md
+++ b/TASKS.md
@@ -72,6 +72,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Option to mute audio or lower volume when the game is paused.
 - [x] Menu includes button to reset the high score.
 - [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
+- [x] HUD button toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text and joystick scale plus a
       dark theme toggle.
 


### PR DESCRIPTION
## Summary
- document HUD range ring toggle and settings overlay in plan, design, tasks and README

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `markdownlint README.md PLAN.md DESIGN.md TASKS.md`


------
https://chatgpt.com/codex/tasks/task_e_68ba9cce0f848330a242e6f0c9b5da35