### PR TITLE
Enable manual analyze workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,8 @@
 
 CI/CD automation for the project.
 
-- `analyze.yml` – runs static analysis and tests.
+- `analyze.yml` – runs static analysis and tests on pull requests or can
+  be triggered manually from the GitHub Actions tab.
 - `deploy.yml` – builds the web release and publishes it. It runs on
   pushes to `main` and `develop` and can be triggered manually from the
   GitHub Actions tab.

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -2,6 +2,7 @@ name: Analyze and Test
 
 on:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- allow Analyze and Test workflow to run manually via GitHub UI
- document manual trigger for analyze workflow

## Testing
- `./scripts/flutterw analyze` *(fails: process terminated before completion)*
- `./scripts/flutterw test` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9f6398f483309db305cd80174cd0