### PR TITLE
fix deprecated window usage in settings overlay test

### DIFF
--- a/test/settings_overlay_test.dart
+++ b/test/settings_overlay_test.dart
@@ -12,11 +12,11 @@ void main() {
 
   testWidgets('slider and toggle modify settings', (tester) async {
     SharedPreferences.setMockInitialValues({});
-    final binding = TestWidgetsFlutterBinding.ensureInitialized();
-    binding.window.physicalSizeTestValue = const Size(800, 1200);
-    binding.window.devicePixelRatioTestValue = 1;
-    addTearDown(binding.window.clearPhysicalSizeTestValue);
-    addTearDown(binding.window.clearDevicePixelRatioTestValue);
+    final view = tester.view;
+    view.physicalSize = const Size(800, 1200);
+    view.devicePixelRatio = 1;
+    addTearDown(view.resetPhysicalSize);
+    addTearDown(view.resetDevicePixelRatio);
 
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);


### PR DESCRIPTION
## Summary
- replace deprecated TestWidgetsFlutterBinding.window calls with WidgetTester.view in settings overlay test

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68baa466c598833083b628c4f048fa6a