### PR TITLE
test: cover asset loading and audio persistence

### DIFF
--- a/test/assets_test.dart
+++ b/test/assets_test.dart
@@ -1,0 +1,42 @@
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flame/flame.dart';
+import 'package:flame_audio/flame_audio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:space_game/assets.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Assets.load', () {
+    setUp(() {
+      Flame.images.clearCache();
+      Flame.images.prefix = 'assets/images/';
+      FlameAudio.audioCache = _StubAudioCache();
+    });
+
+    test('preloads images and is idempotent', () async {
+      await Assets.load();
+      final initialCount = Flame.images.keys.length;
+      expect(initialCount, greaterThan(0));
+      expect(Flame.images.containsKey(Assets.players.first), isTrue);
+
+      await Assets.load();
+      expect(Flame.images.keys.length, initialCount);
+    });
+
+    test('fromCache throws for missing image', () {
+      expect(
+        () => Flame.images.fromCache('does_not_exist.png'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}
+
+class _StubAudioCache extends AudioCache {
+  _StubAudioCache() : super(prefix: '');
+
+  @override
+  Future<List<Uri>> loadAll(List<String> files) async => [];
+}

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -35,5 +35,16 @@ void main() {
       expect(audio.muted.value, isTrue);
       expect(storage.isMuted(), isTrue);
     });
+
+    test('mute state persists across instances', () async {
+      SharedPreferences.setMockInitialValues({});
+      var storage = await StorageService.create();
+      var audio = await AudioService.create(storage);
+      await audio.toggleMute();
+
+      storage = await StorageService.create();
+      audio = await AudioService.create(storage);
+      expect(audio.muted.value, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- add asset loading test ensuring Assets.load is idempotent and missing images raise errors
- verify audio mute flag persists across service instances

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68baa018efc08330a298fbe7f385f911