### PR TITLE
docs: record expanded settings options

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -143,8 +143,9 @@ tree spanning weapons and ship systems.
   game when opened mid-run. `Esc` also closes it without triggering pause.
 - An upgrades overlay (placeholder) opens with the `U` key or HUD button and
   pauses gameplay until dismissed.
-- A settings overlay provides sliders for HUD, text and joystick scale along
-  with a dark theme toggle.
+- A settings overlay provides sliders for HUD, text, joystick, targeting,
+  Tractor Aura and mining ranges plus a dark theme selector and
+  "mute on pause" toggle.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -173,8 +173,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes)
 - Upgrades overlay placeholder opened with a HUD button or the `U` key and
   pausing gameplay for future ship upgrades
-- Settings overlay with sliders for HUD, text and joystick scale plus a dark
-  theme toggle
+- Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
+  and mining ranges, plus a dark theme selector and "mute on pause" toggle
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or

--- a/TASKS.md
+++ b/TASKS.md
@@ -73,8 +73,9 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Menu includes button to reset the high score.
 - [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
 - [x] HUD button toggles range rings for targeting, Tractor Aura and mining.
-- [x] Settings overlay with sliders for HUD, text and joystick scale plus a
-      dark theme toggle.
+- [x] Settings overlay with sliders for HUD, text, joystick, targeting,
+      Tractor Aura and mining ranges, plus a dark theme selector and
+      "mute on pause" toggle.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- document new gameplay range sliders and mute-on-pause option in settings overlay
- sync design and task docs with expanded settings controls

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `scripts/markdownlint.sh '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68baa39d3c688330b0f308537be3b5d8