### PR TITLE
docs: document text scaling and settings service

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,7 +58,12 @@ tree spanning weapons and ship systems.
 
 - `main.dart` starts the Flutter app using the Flutter SDK pinned via FVM (3.32.8).
 - It wraps `SpaceGame` in a `GameWidget`, ensures the PWA manifest loads and
-  preloads assets through `Assets.load()` before play.
+- preloads assets through `Assets.load()` before play.
+- It initialises `StorageService`, `AudioService` and `SettingsService`, applies
+  light or dark `ColorScheme`s, and attaches global text scaling via
+  `GameText.attachTextScale`.
+- An app lifecycle observer pauses the engine and audio when the window loses
+  focus.
 - Run all development commands through FVM (`fvm flutter`, `fvm dart`) to keep
   the toolchain consistent.
 
@@ -72,6 +77,8 @@ tree spanning weapons and ship systems.
   and scoring. Hooks for resource mining, inventory, networking and save/load
   will slot in later milestones.
 - Flutter overlays handle menus and the HUD so UI stays outside the game loop.
+- A shared `GameText` widget standardises overlay text styling and listens for
+  global text scale changes.
 - A `GameState` enum tracks **menu → playing → paused → game over** transitions.
 - `SpaceGame` exposes `ValueNotifier`s for score, minerals, health and high
   score so overlays can react without touching the game loop.
@@ -105,7 +112,8 @@ tree spanning weapons and ship systems.
   high score and settings.
 - `score_service.dart` tracks score, minerals and health values.
 - `overlay_service.dart` shows and hides the Flutter overlays.
-- `settings_service.dart` holds tweakable UI scale values and theme mode.
+- `settings_service.dart` holds tweakable UI and text scale values, gameplay
+  range multipliers and theme mode.
 - `targeting_service.dart` assists auto-aim queries.
 - `upgrade_service.dart` manages purchasing upgrades with minerals and exposes
   a `ValueListenable` for bought upgrade ids.

--- a/PLAN.md
+++ b/PLAN.md
@@ -96,7 +96,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   - `assets.dart` – central asset registry that preloads sprites, audio and fonts
   - `constants.dart` – central place for tunable values
   - `log.dart` – tiny `log()` helper wrapping `debugPrint`
-  - `services/` – optional helpers such as storage or audio, added only when needed
+  - `ui/game_text.dart` – text widget applying global scaling for consistent style
+  - `services/` – storage, audio, settings and other helpers added only when needed
 - `assets/` – images, audio and fonts
 - `web/` – PWA manifest, icons and service worker
 - `test/` – placeholder for future automated tests

--- a/lib/main.md
+++ b/lib/main.md
@@ -6,7 +6,12 @@ Entry point launching the Flutter app and `SpaceGame`.
 
 - Bootstraps the Flutter app using the FVM-pinned SDK.
 - Preloads assets via `Assets.load()` before gameplay.
-- Wraps `SpaceGame` in a `GameWidget` so overlays can render Flutter UI.
+- Creates core services (`StorageService`, `AudioService`, `SettingsService`).
+- Configures light and dark `ColorScheme`s based on the selected theme.
+- Attaches global text scaling via `GameText.attachTextScale`.
+- Wraps `SpaceGame` in a `GameWidget` so overlays can render Flutter UI and
+  registers overlay builders for menus, HUD and dialogs.
+- Observes app lifecycle changes to pause the engine and audio when unfocused.
 - Ensures the PWA manifest and other web configuration are loaded before play.
 - Serves as a thin launcher; game logic lives in `SpaceGame` and components.
 

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -7,6 +7,8 @@ Flutter overlays and HUD widgets.
   game loop.
 - UI reads and updates game state through simple `ValueNotifier`s or
   callbacks exposed by `SpaceGame`.
+- Text is rendered with `GameText` to keep styling consistent and honour the
+  global text scale factor.
 - Keep rendering separate from gameplay logic to simplify testing.
 
 ## Overlays


### PR DESCRIPTION
## Summary
- document `GameText` helper and settings service in plan and design docs
- expand `main.dart` and UI docs to explain theme and text scaling setup

## Testing
- `npx -y markdownlint-cli '**/*.md'`
- `./scripts/dartw format lib test`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68baa64fbebc8330a76f4539fde44efa