### PR TITLE
Add lifecycle and settings persistence tests

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -53,7 +53,8 @@ class SpaceGame extends FlameGame
   })  : colorScheme = colorScheme ??
             ValueNotifier(ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
         gameColors = gameColors ?? ValueNotifier(GameColors.light),
-        settingsService = settingsService ?? SettingsService(),
+        settingsService =
+            settingsService ?? SettingsService(storage: storageService),
         focusNode = focusNode ?? FocusNode(),
         scoreService = ScoreService(storageService: storageService) {
     debugMode = kDebugMode;

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,18 +1,52 @@
 import 'package:flutter/material.dart';
 
 import '../constants.dart';
+import 'storage_service.dart';
 
 /// Holds tweakable UI scale values and gameplay ranges for live prototyping.
 class SettingsService {
-  SettingsService()
-      : hudButtonScale = ValueNotifier<double>(defaultHudButtonScale),
-        textScale = ValueNotifier<double>(defaultTextScale),
-        joystickScale = ValueNotifier<double>(defaultJoystickScale),
-        themeMode = ValueNotifier<ThemeMode>(ThemeMode.system),
-        muteOnPause = ValueNotifier<bool>(true),
-        targetingRange = ValueNotifier<double>(Constants.playerAutoAimRange),
-        tractorRange = ValueNotifier<double>(Constants.playerTractorAuraRadius),
-        miningRange = ValueNotifier<double>(Constants.playerMiningRange);
+  SettingsService({StorageService? storage})
+      : _storage = storage,
+        hudButtonScale = ValueNotifier<double>(
+            storage?.getDouble(_hudScaleKey, defaultHudButtonScale) ??
+                defaultHudButtonScale),
+        textScale = ValueNotifier<double>(
+            storage?.getDouble(_textScaleKey, defaultTextScale) ??
+                defaultTextScale),
+        joystickScale = ValueNotifier<double>(
+            storage?.getDouble(_joystickScaleKey, defaultJoystickScale) ??
+                defaultJoystickScale),
+        themeMode = ValueNotifier<ThemeMode>(ThemeMode.values[
+            storage?.getInt(_themeModeKey, ThemeMode.system.index) ??
+                ThemeMode.system.index]),
+        muteOnPause = ValueNotifier<bool>(
+            storage?.getBool(_muteOnPauseKey, true) ?? true),
+        targetingRange = ValueNotifier<double>(storage?.getDouble(
+                _targetingRangeKey, Constants.playerAutoAimRange) ??
+            Constants.playerAutoAimRange),
+        tractorRange = ValueNotifier<double>(storage?.getDouble(
+                _tractorRangeKey, Constants.playerTractorAuraRadius) ??
+            Constants.playerTractorAuraRadius),
+        miningRange = ValueNotifier<double>(
+            storage?.getDouble(_miningRangeKey, Constants.playerMiningRange) ??
+                Constants.playerMiningRange) {
+    hudButtonScale.addListener(
+        () => _storage?.setDouble(_hudScaleKey, hudButtonScale.value));
+    textScale
+        .addListener(() => _storage?.setDouble(_textScaleKey, textScale.value));
+    joystickScale.addListener(
+        () => _storage?.setDouble(_joystickScaleKey, joystickScale.value));
+    themeMode.addListener(
+        () => _storage?.setInt(_themeModeKey, themeMode.value.index));
+    muteOnPause.addListener(
+        () => _storage?.setBool(_muteOnPauseKey, muteOnPause.value));
+    targetingRange.addListener(
+        () => _storage?.setDouble(_targetingRangeKey, targetingRange.value));
+    tractorRange.addListener(
+        () => _storage?.setDouble(_tractorRangeKey, tractorRange.value));
+    miningRange.addListener(
+        () => _storage?.setDouble(_miningRangeKey, miningRange.value));
+  }
 
   static const double defaultHudButtonScale = 0.75;
   static const double defaultTextScale = 1.5;
@@ -41,4 +75,15 @@ class SettingsService {
 
   /// Maximum distance to auto-mine asteroids, in pixels.
   final ValueNotifier<double> miningRange;
+
+  final StorageService? _storage;
+
+  static const _hudScaleKey = 'hudButtonScale';
+  static const _textScaleKey = 'textScale';
+  static const _joystickScaleKey = 'joystickScale';
+  static const _themeModeKey = 'themeMode';
+  static const _muteOnPauseKey = 'muteOnPause';
+  static const _targetingRangeKey = 'targetingRange';
+  static const _tractorRangeKey = 'tractorRange';
+  static const _miningRangeKey = 'miningRange';
 }

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -38,4 +38,31 @@ class StorageService {
   Future<void> setMuted(bool value) async {
     await _prefs.setBool(_mutedKey, value);
   }
+
+  /// Retrieves a double value for [key] or returns [defaultValue] if unset.
+  double getDouble(String key, double defaultValue) =>
+      _prefs.getDouble(key) ?? defaultValue;
+
+  /// Persists a double [value] for [key].
+  Future<void> setDouble(String key, double value) async {
+    await _prefs.setDouble(key, value);
+  }
+
+  /// Retrieves a boolean for [key] or returns [defaultValue] if unset.
+  bool getBool(String key, bool defaultValue) =>
+      _prefs.getBool(key) ?? defaultValue;
+
+  /// Persists a boolean [value] for [key].
+  Future<void> setBool(String key, bool value) async {
+    await _prefs.setBool(key, value);
+  }
+
+  /// Retrieves an integer for [key] or returns [defaultValue] if unset.
+  int getInt(String key, int defaultValue) =>
+      _prefs.getInt(key) ?? defaultValue;
+
+  /// Persists an integer [value] for [key].
+  Future<void> setInt(String key, int value) async {
+    await _prefs.setInt(key, value);
+  }
 }

--- a/test/full_game_lifecycle_test.dart
+++ b/test/full_game_lifecycle_test.dart
@@ -1,0 +1,51 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('full lifecycle from start to menu', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.explosions]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(200));
+
+    expect(game.stateMachine.state, GameState.menu);
+    expect(game.overlays.isActive(MenuOverlay.id), isTrue);
+
+    game.startGame();
+    expect(game.stateMachine.state, GameState.playing);
+    expect(game.overlays.isActive(HudOverlay.id), isTrue);
+
+    for (var i = 0; i < Constants.playerMaxHealth; i++) {
+      game.hitPlayer();
+    }
+    expect(game.stateMachine.state, GameState.gameOver);
+    expect(game.overlays.isActive(GameOverOverlay.id), isTrue);
+
+    game.returnToMenu();
+    expect(game.stateMachine.state, GameState.menu);
+    expect(game.overlays.isActive(MenuOverlay.id), isTrue);
+    expect(game.overlays.isActive(GameOverOverlay.id), isFalse);
+    expect(game.overlays.isActive(HudOverlay.id), isFalse);
+  });
+}

--- a/test/key_dispatcher_test.dart
+++ b/test/key_dispatcher_test.dart
@@ -153,5 +153,19 @@ void main() {
         isFalse,
       );
     });
+
+    test('register with no callbacks leaves key unhandled', () {
+      final dispatcher = KeyDispatcher();
+      dispatcher.register(LogicalKeyboardKey.space);
+      final handled = dispatcher.onKeyEvent(
+        const KeyDownEvent(
+          logicalKey: LogicalKeyboardKey.space,
+          physicalKey: PhysicalKeyboardKey.space,
+          timeStamp: Duration.zero,
+        ),
+        {LogicalKeyboardKey.space},
+      );
+      expect(handled, isFalse);
+    });
   });
 }

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/services/settings_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -54,5 +56,17 @@ void main() {
     expect(settings.targetingRange.value, 350);
     expect(settings.tractorRange.value, 250);
     expect(settings.miningRange.value, 180);
+  });
+
+  test('values persist across sessions', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    var settings = SettingsService(storage: storage);
+    settings.hudButtonScale.value = 1.2;
+    settings.muteOnPause.value = false;
+    await Future.delayed(Duration.zero);
+    settings = SettingsService(storage: storage);
+    expect(settings.hudButtonScale.value, 1.2);
+    expect(settings.muteOnPause.value, isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- persist settings via StorageService and wire into SpaceGame
- cover full lifecycle from start to menu in new integration test
- verify settings persistence and key dispatcher edge cases

## Testing
- `./scripts/flutterw test test/full_game_lifecycle_test.dart test/settings_service_test.dart test/key_dispatcher_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_68baa626c8b08330b7ecad3a45dda8b0