### PR TITLE
Remove pause mute toggle and always dim audio

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -152,8 +152,7 @@ tree spanning weapons and ship systems.
 - An upgrades overlay (placeholder) opens with the `U` key or HUD button and
   pauses gameplay until dismissed.
 - A settings overlay provides sliders for HUD, text, joystick, targeting,
-  Tractor Aura and mining ranges plus a dark theme selector and
-  "mute on pause" toggle.
+  Tractor Aura and mining ranges plus a dark theme selector.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -171,11 +171,12 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `N` toggles the
   minimap, `F1` toggles debug overlays, `Enter` starts or restarts from the
   menu or game over, `R` restarts at any time, `H` shows a help overlay that
-  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes)
+  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes`)
+
 - Upgrades overlay placeholder opened with a HUD button or the `U` key and
   pausing gameplay for future ship upgrades
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
-  and mining ranges, plus a dark theme selector and "mute on pause" toggle
+  and mining ranges, plus a dark theme selector
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or

--- a/TASKS.md
+++ b/TASKS.md
@@ -74,8 +74,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
 - [x] HUD button toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text, joystick, targeting,
-      Tractor Aura and mining ranges, plus a dark theme selector and
-      "mute on pause" toggle.
+      Tractor Aura and mining ranges, plus a dark theme selector.
 
 ## Next Steps
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -308,11 +308,7 @@ class SpaceGame extends FlameGame
   /// Pauses the game and shows the `PAUSED` overlay.
   void pauseGame() {
     stateMachine.pauseGame();
-    if (settingsService.muteOnPause.value) {
-      miningLaser?.stopSound();
-    } else {
-      audioService.setMasterVolume(Constants.pausedAudioVolumeFactor);
-    }
+    audioService.setMasterVolume(Constants.pausedAudioVolumeFactor);
   }
 
   /// Resumes the game from a paused state.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -9,7 +9,6 @@ class SettingsService {
         textScale = ValueNotifier<double>(defaultTextScale),
         joystickScale = ValueNotifier<double>(defaultJoystickScale),
         themeMode = ValueNotifier<ThemeMode>(ThemeMode.system),
-        muteOnPause = ValueNotifier<bool>(true),
         targetingRange = ValueNotifier<double>(Constants.playerAutoAimRange),
         tractorRange = ValueNotifier<double>(Constants.playerTractorAuraRadius),
         miningRange = ValueNotifier<double>(Constants.playerMiningRange);
@@ -29,9 +28,6 @@ class SettingsService {
 
   /// Currently selected theme mode.
   final ValueNotifier<ThemeMode> themeMode;
-
-  /// Whether audio should fully mute when the game is paused.
-  final ValueNotifier<bool> muteOnPause;
 
   /// Distance used to auto-aim enemies when stationary.
   final ValueNotifier<double> targetingRange;

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -97,15 +97,6 @@ class SettingsOverlay extends StatelessWidget {
               ),
             ),
             SizedBox(height: spacing),
-            ValueListenableBuilder<bool>(
-              valueListenable: settings.muteOnPause,
-              builder: (context, muted, _) => SwitchListTile(
-                title: const GameText('Mute on Pause', maxLines: 1),
-                value: muted,
-                onChanged: (v) => settings.muteOnPause.value = v,
-              ),
-            ),
-            SizedBox(height: spacing),
             ElevatedButton(
               onPressed: game.toggleSettings,
               child: const GameText(

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -12,7 +12,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Implement `storage_service.dart` using `shared_preferences`
       to persist the local high score.
 - [x] Simple HUD and menus layered with Flutter overlays.
-- [x] Option to mute or dim audio when the game is paused.
+- [x] Audio dims when the game is paused.
 
 ## Design Notes
 

--- a/test/mining_laser_pause_test.dart
+++ b/test/mining_laser_pause_test.dart
@@ -11,7 +11,6 @@ import 'package:space_game/game/space_game.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
-import 'package:space_game/services/settings_service.dart';
 import 'package:space_game/ui/game_over_overlay.dart';
 import 'package:space_game/ui/hud_overlay.dart';
 import 'package:space_game/ui/menu_overlay.dart';
@@ -32,56 +31,13 @@ class _TestMiningLaser extends MiningLaserComponent {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('Escape key stops mining laser sound', () async {
+  test('Escape key lowers volume without stopping laser', () async {
     SharedPreferences.setMockInitialValues({});
     await Flame.images.loadAll([...Assets.players]);
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     audio.muted.value = true;
     final game = SpaceGame(storageService: storage, audioService: audio);
-    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
-    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
-    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
-    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
-    await game.onLoad();
-    game.onGameResize(Vector2.all(100));
-    game.startGame();
-    await game.ready();
-
-    final laser = _TestMiningLaser(player: game.player);
-    game.miningLaser?.removeFromParent();
-    game.miningLaser = laser;
-    await game.add(laser);
-    await game.ready();
-
-    const down = KeyDownEvent(
-      physicalKey: PhysicalKeyboardKey.escape,
-      logicalKey: LogicalKeyboardKey.escape,
-      timeStamp: Duration.zero,
-    );
-    const up = KeyUpEvent(
-      physicalKey: PhysicalKeyboardKey.escape,
-      logicalKey: LogicalKeyboardKey.escape,
-      timeStamp: Duration.zero,
-    );
-    game.keyDispatcher.onKeyEvent(down, {});
-    game.keyDispatcher.onKeyEvent(up, {});
-
-    expect(laser.stopped, isTrue);
-  });
-
-  test('Escape key lowers volume when muteOnPause disabled', () async {
-    SharedPreferences.setMockInitialValues({});
-    await Flame.images.loadAll([...Assets.players]);
-    final storage = await StorageService.create();
-    final audio = await AudioService.create(storage);
-    audio.muted.value = true;
-    final settings = SettingsService()..muteOnPause.value = false;
-    final game = SpaceGame(
-      storageService: storage,
-      audioService: audio,
-      settingsService: settings,
-    );
     game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
@@ -124,12 +80,7 @@ void main() {
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     audio.muted.value = true;
-    final settings = SettingsService()..muteOnPause.value = false;
-    final game = SpaceGame(
-      storageService: storage,
-      audioService: audio,
-      settingsService: settings,
-    );
+    final game = SpaceGame(storageService: storage, audioService: audio);
     game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());

--- a/test/settings_overlay_test.dart
+++ b/test/settings_overlay_test.dart
@@ -10,7 +10,7 @@ import 'package:space_game/ui/settings_overlay.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('slider and toggle modify settings', (tester) async {
+  testWidgets('slider modifies settings', (tester) async {
     SharedPreferences.setMockInitialValues({});
     final view = tester.view;
     view.physicalSize = const Size(800, 1200);
@@ -29,11 +29,5 @@ void main() {
     await tester.drag(slider, const Offset(50, 0));
     await tester.pump();
     expect(game.settingsService.hudButtonScale.value, isNot(initial));
-
-    final toggle = find.byType(Switch);
-    expect(game.settingsService.muteOnPause.value, isTrue);
-    await tester.tap(toggle, warnIfMissed: false);
-    await tester.pump();
-    expect(game.settingsService.muteOnPause.value, isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- remove mute-on-pause option and always dim audio when the game is paused
- drop the mute-on-pause switch from settings overlay
- adjust tests and docs for new pause audio behaviour

## Testing
- `scripts/markdownlint.sh DESIGN.md PLAN.md TASKS.md milestone-polish.md`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68baac2f35488330a6f2717236132cbb