### PR TITLE
Prevent firing when game is paused

### DIFF
--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 
 import '../constants.dart';
 import '../game/key_dispatcher.dart';
+import '../game/game_state.dart';
 import '../game/space_game.dart';
 import 'bullet.dart';
 import 'player.dart';
@@ -104,7 +105,7 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
 
   /// Fires a bullet from the player's current position.
   void shoot() {
-    if (_shootCooldown > 0) {
+    if (game.stateMachine.state != GameState.playing || _shootCooldown > 0) {
       return;
     }
     final direction = Vector2(
@@ -121,6 +122,9 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
 
   /// Begins continuous shooting and fires immediately.
   void startShooting() {
+    if (game.stateMachine.state != GameState.playing) {
+      return;
+    }
     _isShooting = true;
     shoot();
   }

--- a/test/player_input_behavior_test.dart
+++ b/test/player_input_behavior_test.dart
@@ -10,6 +10,9 @@ import 'package:space_game/constants.dart';
 import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/pool_manager.dart';
 import 'package:space_game/game/space_game.dart';
+import 'package:space_game/game/game_state_machine.dart';
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/services/overlay_service.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
 
@@ -69,6 +72,15 @@ class _TestGame extends SpaceGame {
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);
+    overlayService = OverlayService(this);
+    stateMachine = GameStateMachine(
+      overlays: overlayService,
+      onStart: () {},
+      onPause: pauseEngine,
+      onResume: resumeEngine,
+      onGameOver: () {},
+      onMenu: () {},
+    );
     player.inputBehavior.game = this;
   }
 }
@@ -131,6 +143,7 @@ void main() {
     game.onGameResize(Vector2.all(500));
     await game.ready();
 
+    game.stateMachine.state = GameState.playing;
     game.player.startShooting();
     game.player.inputBehavior.update(0);
     expect(game.children.whereType<BulletComponent>().length, 1);


### PR DESCRIPTION
## Summary
- Avoid shooting or play sound while the game is paused by gating fire logic on `GameState.playing`
- Set up test game state machine and cover continuous shooting behavior

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68baabb9b974833093f6e4c2f7477b48