### PR TITLE
Spawn bullets from player front

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -8,6 +8,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Touch and keyboard controls move the player
 - [ ] Player can shoot and destroy a basic enemy
 - [ ] Bullets travel in the direction the ship is facing
+- [ ] Bullets spawn from the front of the player's ship
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
 - [ ] Target button toggles range rings display
 - [ ] Minimap icon or `N` key toggles minimap visibility

--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -111,8 +111,10 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
       math.cos(player.angle - math.pi / 2),
       math.sin(player.angle - math.pi / 2),
     );
+    final spawnOffset =
+        direction * (player.height / 2 + Constants.bulletSize / 2);
     final bullet = game.pools.acquire<BulletComponent>(
-      (b) => b.reset(player.position.clone(), direction),
+      (b) => b.reset(player.position + spawnOffset, direction),
     );
     game.add(bullet);
     game.audioService.playShoot();


### PR DESCRIPTION
## Summary
- spawn bullets ahead of the player ship rather than from its center
- note bullet spawn behavior in playtest checklist

## Testing
- `scripts/flutterw test`
- `scripts/markdownlint.sh PLAYTEST_CHECKLIST.md`


------
https://chatgpt.com/codex/tasks/task_e_68baab4a128c83308155af06b5ca816d