### PR TITLE
Inject storage into externally provided SettingsService

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -53,10 +53,10 @@ class SpaceGame extends FlameGame
   })  : colorScheme = colorScheme ??
             ValueNotifier(ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
         gameColors = gameColors ?? ValueNotifier(GameColors.light),
-        settingsService =
-            settingsService ?? SettingsService(storage: storageService),
+        settingsService = settingsService ?? SettingsService(),
         focusNode = focusNode ?? FocusNode(),
         scoreService = ScoreService(storageService: storageService) {
+    this.settingsService.attachStorage(storageService);
     debugMode = kDebugMode;
     pools = createPoolManager();
     targetingService = TargetingService(eventBus);

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -76,7 +76,30 @@ class SettingsService {
   /// Maximum distance to auto-mine asteroids, in pixels.
   final ValueNotifier<double> miningRange;
 
-  final StorageService? _storage;
+  StorageService? _storage;
+
+  /// Attaches a [StorageService] after construction and loads any persisted
+  /// values into the existing notifiers. If storage has already been provided,
+  /// this call is ignored.
+  void attachStorage(StorageService storage) {
+    if (_storage != null) {
+      return;
+    }
+    _storage = storage;
+    hudButtonScale.value =
+        storage.getDouble(_hudScaleKey, hudButtonScale.value);
+    textScale.value = storage.getDouble(_textScaleKey, textScale.value);
+    joystickScale.value =
+        storage.getDouble(_joystickScaleKey, joystickScale.value);
+    themeMode.value =
+        ThemeMode.values[storage.getInt(_themeModeKey, themeMode.value.index)];
+    muteOnPause.value = storage.getBool(_muteOnPauseKey, muteOnPause.value);
+    targetingRange.value =
+        storage.getDouble(_targetingRangeKey, targetingRange.value);
+    tractorRange.value =
+        storage.getDouble(_tractorRangeKey, tractorRange.value);
+    miningRange.value = storage.getDouble(_miningRangeKey, miningRange.value);
+  }
 
   static const _hudScaleKey = 'hudButtonScale';
   static const _textScaleKey = 'textScale';

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -69,4 +69,18 @@ void main() {
     expect(settings.hudButtonScale.value, 1.2);
     expect(settings.muteOnPause.value, isFalse);
   });
+
+  test('attachStorage injects storage into existing instance', () async {
+    SharedPreferences.setMockInitialValues({'hudButtonScale': 0.9});
+    final storage = await StorageService.create();
+    final settings = SettingsService();
+    expect(
+        settings.hudButtonScale.value, SettingsService.defaultHudButtonScale);
+    settings.attachStorage(storage);
+    expect(settings.hudButtonScale.value, 0.9);
+    settings.hudButtonScale.value = 1.4;
+    await Future.delayed(Duration.zero);
+    final reloaded = SettingsService(storage: storage);
+    expect(reloaded.hudButtonScale.value, 1.4);
+  });
 }

--- a/test/space_game_settings_injection_test.dart
+++ b/test/space_game_settings_injection_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/settings_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('SpaceGame attaches storage to provided SettingsService', () async {
+    SharedPreferences.setMockInitialValues({'hudButtonScale': 0.8});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final settings = SettingsService();
+
+    final game = SpaceGame(
+      storageService: storage,
+      audioService: audio,
+      settingsService: settings,
+    );
+
+    expect(game.settingsService, same(settings));
+    expect(settings.hudButtonScale.value, 0.8);
+
+    settings.hudButtonScale.value = 1.3;
+    await Future.delayed(Duration.zero);
+    final reloaded = SettingsService(storage: storage);
+    expect(reloaded.hudButtonScale.value, 1.3);
+  });
+}


### PR DESCRIPTION
## Summary
- allow SettingsService to accept storage after construction and load persisted values
- ensure SpaceGame constructor attaches storage to any provided SettingsService
- cover storage injection with new tests

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68baaf0413088330a410f3a5bbeab2fb