### PR TITLE
Always dim audio on pause

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -152,8 +152,7 @@ tree spanning weapons and ship systems.
 - An upgrades overlay (placeholder) opens with the `U` key or HUD button and
   pauses gameplay until dismissed.
 - A settings overlay provides sliders for HUD, text, joystick, targeting,
-  Tractor Aura and mining ranges plus a dark theme selector and
-  "mute on pause" toggle.
+  Tractor Aura and mining ranges plus a dark theme selector.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -175,7 +175,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Upgrades overlay placeholder opened with a HUD button or the `U` key and
   pausing gameplay for future ship upgrades
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
-  and mining ranges, plus a dark theme selector and "mute on pause" toggle
+  and mining ranges, plus a dark theme selector
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -32,7 +32,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Explosion animation and sound play when a ship is destroyed
 - [ ] Mining laser emits a looping sound while active
 - [ ] Game can be paused and resumed
-- [ ] Pausing mutes audio or lowers volume according to settings
+- [ ] Pausing lowers audio volume
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it

--- a/TASKS.md
+++ b/TASKS.md
@@ -69,13 +69,12 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] HUD displays current score, minerals and health.
 - [x] Limit player fire rate with a brief cooldown.
 - [x] Keyboard shortcut `F1` toggles debug overlays.
-- [x] Option to mute audio or lower volume when the game is paused.
+- [x] Audio volume lowers when the game is paused.
 - [x] Menu includes button to reset the high score.
 - [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
 - [x] HUD button toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text, joystick, targeting,
-      Tractor Aura and mining ranges, plus a dark theme selector and
-      "mute on pause" toggle.
+      Tractor Aura and mining ranges, plus a dark theme selector.
 
 ## Next Steps
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -40,7 +40,7 @@ class Constants {
   /// Volume for the mining laser sound effect (0-1).
   static const double miningLaserVolume = 0.25;
 
-  /// Volume multiplier used when audio is dimmed instead of muted on pause.
+  /// Volume multiplier applied to audio while the game is paused.
   static const double pausedAudioVolumeFactor = 0.2;
 
   /// Starting health for the player.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -309,11 +309,7 @@ class SpaceGame extends FlameGame
   /// Pauses the game and shows the `PAUSED` overlay.
   void pauseGame() {
     stateMachine.pauseGame();
-    if (settingsService.muteOnPause.value) {
-      miningLaser?.stopSound();
-    } else {
-      audioService.setMasterVolume(Constants.pausedAudioVolumeFactor);
-    }
+    audioService.setMasterVolume(Constants.pausedAudioVolumeFactor);
   }
 
   /// Resumes the game from a paused state.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -19,8 +19,6 @@ class SettingsService {
         themeMode = ValueNotifier<ThemeMode>(ThemeMode.values[
             storage?.getInt(_themeModeKey, ThemeMode.system.index) ??
                 ThemeMode.system.index]),
-        muteOnPause = ValueNotifier<bool>(
-            storage?.getBool(_muteOnPauseKey, true) ?? true),
         targetingRange = ValueNotifier<double>(storage?.getDouble(
                 _targetingRangeKey, Constants.playerAutoAimRange) ??
             Constants.playerAutoAimRange),
@@ -38,8 +36,6 @@ class SettingsService {
         () => _storage?.setDouble(_joystickScaleKey, joystickScale.value));
     themeMode.addListener(
         () => _storage?.setInt(_themeModeKey, themeMode.value.index));
-    muteOnPause.addListener(
-        () => _storage?.setBool(_muteOnPauseKey, muteOnPause.value));
     targetingRange.addListener(
         () => _storage?.setDouble(_targetingRangeKey, targetingRange.value));
     tractorRange.addListener(
@@ -64,9 +60,6 @@ class SettingsService {
   /// Currently selected theme mode.
   final ValueNotifier<ThemeMode> themeMode;
 
-  /// Whether audio should fully mute when the game is paused.
-  final ValueNotifier<bool> muteOnPause;
-
   /// Distance used to auto-aim enemies when stationary.
   final ValueNotifier<double> targetingRange;
 
@@ -82,7 +75,6 @@ class SettingsService {
   static const _textScaleKey = 'textScale';
   static const _joystickScaleKey = 'joystickScale';
   static const _themeModeKey = 'themeMode';
-  static const _muteOnPauseKey = 'muteOnPause';
   static const _targetingRangeKey = 'targetingRange';
   static const _tractorRangeKey = 'tractorRange';
   static const _miningRangeKey = 'miningRange';

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -97,15 +97,6 @@ class SettingsOverlay extends StatelessWidget {
               ),
             ),
             SizedBox(height: spacing),
-            ValueListenableBuilder<bool>(
-              valueListenable: settings.muteOnPause,
-              builder: (context, muted, _) => SwitchListTile(
-                title: const GameText('Mute on Pause', maxLines: 1),
-                value: muted,
-                onChanged: (v) => settings.muteOnPause.value = v,
-              ),
-            ),
-            SizedBox(height: spacing),
             ElevatedButton(
               onPressed: game.toggleSettings,
               child: const GameText(

--- a/test/mining_laser_pause_test.dart
+++ b/test/mining_laser_pause_test.dart
@@ -11,7 +11,6 @@ import 'package:space_game/game/space_game.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
-import 'package:space_game/services/settings_service.dart';
 import 'package:space_game/ui/game_over_overlay.dart';
 import 'package:space_game/ui/hud_overlay.dart';
 import 'package:space_game/ui/menu_overlay.dart';
@@ -32,56 +31,13 @@ class _TestMiningLaser extends MiningLaserComponent {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('Escape key stops mining laser sound', () async {
+  test('Escape key lowers volume but keeps mining laser running', () async {
     SharedPreferences.setMockInitialValues({});
     await Flame.images.loadAll([...Assets.players]);
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     audio.muted.value = true;
     final game = SpaceGame(storageService: storage, audioService: audio);
-    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
-    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
-    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
-    game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
-    await game.onLoad();
-    game.onGameResize(Vector2.all(100));
-    game.startGame();
-    await game.ready();
-
-    final laser = _TestMiningLaser(player: game.player);
-    game.miningLaser?.removeFromParent();
-    game.miningLaser = laser;
-    await game.add(laser);
-    await game.ready();
-
-    const down = KeyDownEvent(
-      physicalKey: PhysicalKeyboardKey.escape,
-      logicalKey: LogicalKeyboardKey.escape,
-      timeStamp: Duration.zero,
-    );
-    const up = KeyUpEvent(
-      physicalKey: PhysicalKeyboardKey.escape,
-      logicalKey: LogicalKeyboardKey.escape,
-      timeStamp: Duration.zero,
-    );
-    game.keyDispatcher.onKeyEvent(down, {});
-    game.keyDispatcher.onKeyEvent(up, {});
-
-    expect(laser.stopped, isTrue);
-  });
-
-  test('Escape key lowers volume when muteOnPause disabled', () async {
-    SharedPreferences.setMockInitialValues({});
-    await Flame.images.loadAll([...Assets.players]);
-    final storage = await StorageService.create();
-    final audio = await AudioService.create(storage);
-    audio.muted.value = true;
-    final settings = SettingsService()..muteOnPause.value = false;
-    final game = SpaceGame(
-      storageService: storage,
-      audioService: audio,
-      settingsService: settings,
-    );
     game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
@@ -124,12 +80,7 @@ void main() {
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     audio.muted.value = true;
-    final settings = SettingsService()..muteOnPause.value = false;
-    final game = SpaceGame(
-      storageService: storage,
-      audioService: audio,
-      settingsService: settings,
-    );
+    final game = SpaceGame(storageService: storage, audioService: audio);
     game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
     game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());

--- a/test/settings_overlay_test.dart
+++ b/test/settings_overlay_test.dart
@@ -10,7 +10,7 @@ import 'package:space_game/ui/settings_overlay.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('slider and toggle modify settings', (tester) async {
+  testWidgets('slider modifies settings', (tester) async {
     SharedPreferences.setMockInitialValues({});
     final view = tester.view;
     view.physicalSize = const Size(800, 1200);
@@ -29,11 +29,5 @@ void main() {
     await tester.drag(slider, const Offset(50, 0));
     await tester.pump();
     expect(game.settingsService.hudButtonScale.value, isNot(initial));
-
-    final toggle = find.byType(Switch);
-    expect(game.settingsService.muteOnPause.value, isTrue);
-    await tester.tap(toggle, warnIfMissed: false);
-    await tester.pump();
-    expect(game.settingsService.muteOnPause.value, isFalse);
   });
 }

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -63,10 +63,8 @@ void main() {
     final storage = await StorageService.create();
     var settings = SettingsService(storage: storage);
     settings.hudButtonScale.value = 1.2;
-    settings.muteOnPause.value = false;
     await Future.delayed(Duration.zero);
     settings = SettingsService(storage: storage);
     expect(settings.hudButtonScale.value, 1.2);
-    expect(settings.muteOnPause.value, isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- Remove `mute on pause` toggle and persisted setting
- Always lower master volume when the game is paused
- Update docs and tests for reduced-volume behavior

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68baaf4e32488330ad4a6de6719c464b