### PR TITLE
feat: add minimap scale setting

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -37,8 +37,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it
-- [ ] Settings overlay sliders adjust HUD button, text, joystick sizes and
-      gameplay ranges (default 0.75 for buttons and text)
+- [ ] Settings overlay sliders adjust HUD button, minimap, text, joystick sizes
+      and gameplay ranges (default 0.75 for buttons, minimap and text)
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -10,6 +10,9 @@ class SettingsService {
         hudButtonScale = ValueNotifier<double>(
             storage?.getDouble(_hudScaleKey, defaultHudButtonScale) ??
                 defaultHudButtonScale),
+        minimapScale = ValueNotifier<double>(
+            storage?.getDouble(_minimapScaleKey, defaultMinimapScale) ??
+                defaultMinimapScale),
         textScale = ValueNotifier<double>(
             storage?.getDouble(_textScaleKey, defaultTextScale) ??
                 defaultTextScale),
@@ -32,6 +35,8 @@ class SettingsService {
                 Constants.playerMiningRange) {
     hudButtonScale.addListener(
         () => _storage?.setDouble(_hudScaleKey, hudButtonScale.value));
+    minimapScale.addListener(
+        () => _storage?.setDouble(_minimapScaleKey, minimapScale.value));
     textScale
         .addListener(() => _storage?.setDouble(_textScaleKey, textScale.value));
     joystickScale.addListener(
@@ -51,9 +56,13 @@ class SettingsService {
   static const double defaultHudButtonScale = 0.75;
   static const double defaultTextScale = 1.5;
   static const double defaultJoystickScale = 1;
+  static const double defaultMinimapScale = 0.75;
 
   /// Multiplier applied to HUD buttons and icons.
   final ValueNotifier<double> hudButtonScale;
+
+  /// Multiplier applied to the minimap widget.
+  final ValueNotifier<double> minimapScale;
 
   /// Multiplier applied to in-game text sizes.
   final ValueNotifier<double> textScale;
@@ -88,6 +97,8 @@ class SettingsService {
     _storage = storage;
     hudButtonScale.value =
         storage.getDouble(_hudScaleKey, hudButtonScale.value);
+    minimapScale.value =
+        storage.getDouble(_minimapScaleKey, minimapScale.value);
     textScale.value = storage.getDouble(_textScaleKey, textScale.value);
     joystickScale.value =
         storage.getDouble(_joystickScaleKey, joystickScale.value);
@@ -104,6 +115,7 @@ class SettingsService {
   static const _hudScaleKey = 'hudButtonScale';
   static const _textScaleKey = 'textScale';
   static const _joystickScaleKey = 'joystickScale';
+  static const _minimapScaleKey = 'minimapScale';
   static const _themeModeKey = 'themeMode';
   static const _muteOnPauseKey = 'muteOnPause';
   static const _targetingRangeKey = 'targetingRange';

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -26,8 +26,9 @@ Flutter overlays and HUD widgets.
   pauses gameplay when opened mid-run; `Esc` also closes it.
 - [UpgradesOverlay](upgrades_overlay.md) – lists purchasable ship upgrades;
   opened with `U` and pauses gameplay.
-- [SettingsOverlay](settings_overlay.md) – adjust HUD, text, joystick scale and
-  gameplay ranges, and toggle the dark theme; opened via HUD button.
+- [SettingsOverlay](settings_overlay.md) – adjust HUD, minimap, text,
+  joystick scale and gameplay ranges, and toggle the dark theme; opened via HUD
+  button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -39,9 +39,13 @@ class HudOverlay extends StatelessWidget {
                         if (!show) {
                           return const SizedBox.shrink();
                         }
-                        return Padding(
-                          padding: const EdgeInsets.only(top: 8, left: 8),
-                          child: MiniMapDisplay(game: game, size: 80 * scale),
+                        return ValueListenableBuilder<double>(
+                          valueListenable: game.settingsService.minimapScale,
+                          builder: (context, miniScale, _) => Padding(
+                            padding: const EdgeInsets.only(top: 8, left: 8),
+                            child: MiniMapDisplay(
+                                game: game, size: 80 * miniScale),
+                          ),
                         );
                       },
                     ),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -10,6 +10,7 @@ Heads-up display shown during play.
   bound to `SpaceGame` and `AudioService`.
 - Toggles a top-left minimap for navigation.
 - Icon sizes scale with screen size for better usability on different devices.
+- Minimap size scales via the SettingsOverlay.
 - `U` opens the upgrades overlay; `Esc` closes it.
 - `H` opens the help overlay showing controls; `Esc` closes it.
 - `M` key also toggles audio mute.

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -46,6 +46,12 @@ class SettingsOverlay extends StatelessWidget {
             ),
             _buildSlider(
               context,
+              'Minimap',
+              settings.minimapScale,
+              spacing,
+            ),
+            _buildSlider(
+              context,
               'Targeting Range',
               settings.targetingRange,
               spacing,

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -4,7 +4,7 @@ Overlay providing runtime UI scaling and range controls plus a dark theme toggle
 
 ## Features
 
-- Sliders adjust HUD button, text, joystick scales and gameplay ranges.
+- Sliders adjust HUD button, minimap, text, joystick scales and gameplay ranges.
 - Switch toggles between light and dark themes.
 - Opens from the HUD; closing returns to the game.
 - Overlay remains transparent so adjustments can be viewed immediately.

--- a/test/settings_overlay_test.dart
+++ b/test/settings_overlay_test.dart
@@ -30,6 +30,12 @@ void main() {
     await tester.pump();
     expect(game.settingsService.hudButtonScale.value, isNot(initial));
 
+    final minimapSlider = find.byType(Slider).at(3);
+    final minimapInitial = game.settingsService.minimapScale.value;
+    await tester.drag(minimapSlider, const Offset(50, 0));
+    await tester.pump();
+    expect(game.settingsService.minimapScale.value, isNot(minimapInitial));
+
     final toggle = find.byType(Switch);
     expect(game.settingsService.muteOnPause.value, isTrue);
     await tester.tap(toggle, warnIfMissed: false);

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -12,6 +12,7 @@ void main() {
 
     expect(
         settings.hudButtonScale.value, SettingsService.defaultHudButtonScale);
+    expect(settings.minimapScale.value, SettingsService.defaultMinimapScale);
     expect(settings.textScale.value, SettingsService.defaultTextScale);
     expect(settings.joystickScale.value, SettingsService.defaultJoystickScale);
     expect(settings.targetingRange.value, Constants.playerAutoAimRange);
@@ -23,6 +24,7 @@ void main() {
     final settings = SettingsService();
 
     var hudNotified = false;
+    var minimapNotified = false;
     var textNotified = false;
     var joystickNotified = false;
     var targetingNotified = false;
@@ -30,6 +32,7 @@ void main() {
     var miningNotified = false;
 
     settings.hudButtonScale.addListener(() => hudNotified = true);
+    settings.minimapScale.addListener(() => minimapNotified = true);
     settings.textScale.addListener(() => textNotified = true);
     settings.joystickScale.addListener(() => joystickNotified = true);
     settings.targetingRange.addListener(() => targetingNotified = true);
@@ -37,6 +40,7 @@ void main() {
     settings.miningRange.addListener(() => miningNotified = true);
 
     settings.hudButtonScale.value = 1.2;
+    settings.minimapScale.value = 1.1;
     settings.textScale.value = 1.3;
     settings.joystickScale.value = 1.1;
     settings.targetingRange.value = 350;
@@ -44,6 +48,7 @@ void main() {
     settings.miningRange.value = 180;
 
     expect(hudNotified, isTrue);
+    expect(minimapNotified, isTrue);
     expect(textNotified, isTrue);
     expect(joystickNotified, isTrue);
     expect(targetingNotified, isTrue);
@@ -51,6 +56,7 @@ void main() {
     expect(miningNotified, isTrue);
 
     expect(settings.hudButtonScale.value, 1.2);
+    expect(settings.minimapScale.value, 1.1);
     expect(settings.textScale.value, 1.3);
     expect(settings.joystickScale.value, 1.1);
     expect(settings.targetingRange.value, 350);
@@ -63,24 +69,31 @@ void main() {
     final storage = await StorageService.create();
     var settings = SettingsService(storage: storage);
     settings.hudButtonScale.value = 1.2;
+    settings.minimapScale.value = 1.1;
     settings.muteOnPause.value = false;
     await Future.delayed(Duration.zero);
     settings = SettingsService(storage: storage);
     expect(settings.hudButtonScale.value, 1.2);
+    expect(settings.minimapScale.value, 1.1);
     expect(settings.muteOnPause.value, isFalse);
   });
 
   test('attachStorage injects storage into existing instance', () async {
-    SharedPreferences.setMockInitialValues({'hudButtonScale': 0.9});
+    SharedPreferences.setMockInitialValues(
+        {'hudButtonScale': 0.9, 'minimapScale': 0.8});
     final storage = await StorageService.create();
     final settings = SettingsService();
     expect(
         settings.hudButtonScale.value, SettingsService.defaultHudButtonScale);
+    expect(settings.minimapScale.value, SettingsService.defaultMinimapScale);
     settings.attachStorage(storage);
     expect(settings.hudButtonScale.value, 0.9);
+    expect(settings.minimapScale.value, 0.8);
     settings.hudButtonScale.value = 1.4;
+    settings.minimapScale.value = 1.3;
     await Future.delayed(Duration.zero);
     final reloaded = SettingsService(storage: storage);
     expect(reloaded.hudButtonScale.value, 1.4);
+    expect(reloaded.minimapScale.value, 1.3);
   });
 }

--- a/test/space_game_settings_injection_test.dart
+++ b/test/space_game_settings_injection_test.dart
@@ -10,7 +10,8 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('SpaceGame attaches storage to provided SettingsService', () async {
-    SharedPreferences.setMockInitialValues({'hudButtonScale': 0.8});
+    SharedPreferences.setMockInitialValues(
+        {'hudButtonScale': 0.8, 'minimapScale': 0.9});
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     final settings = SettingsService();
@@ -23,10 +24,13 @@ void main() {
 
     expect(game.settingsService, same(settings));
     expect(settings.hudButtonScale.value, 0.8);
+    expect(settings.minimapScale.value, 0.9);
 
     settings.hudButtonScale.value = 1.3;
+    settings.minimapScale.value = 1.2;
     await Future.delayed(Duration.zero);
     final reloaded = SettingsService(storage: storage);
     expect(reloaded.hudButtonScale.value, 1.3);
+    expect(reloaded.minimapScale.value, 1.2);
   });
 }


### PR DESCRIPTION
## Summary
- allow players to adjust minimap size via new slider in settings overlay
- persist minimap scale in SettingsService
- document minimap scaling and update tests

## Testing
- `./scripts/dartw format`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bab19a70e48330a7f11a166584b4b2