### PR TITLE
feat: add minimap scale slider

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -37,8 +37,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it
-- [ ] Settings overlay sliders adjust HUD button, text, joystick sizes and
-      gameplay ranges (default 0.75 for buttons and text)
+- [ ] Settings overlay sliders adjust HUD button, minimap, text, joystick sizes
+      and gameplay ranges (default 0.75 for buttons and text)
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -16,6 +16,9 @@ class SettingsService {
         joystickScale = ValueNotifier<double>(
             storage?.getDouble(_joystickScaleKey, defaultJoystickScale) ??
                 defaultJoystickScale),
+        minimapScale = ValueNotifier<double>(
+            storage?.getDouble(_minimapScaleKey, defaultMinimapScale) ??
+                defaultMinimapScale),
         themeMode = ValueNotifier<ThemeMode>(ThemeMode.values[
             storage?.getInt(_themeModeKey, ThemeMode.system.index) ??
                 ThemeMode.system.index]),
@@ -34,6 +37,8 @@ class SettingsService {
         .addListener(() => _storage?.setDouble(_textScaleKey, textScale.value));
     joystickScale.addListener(
         () => _storage?.setDouble(_joystickScaleKey, joystickScale.value));
+    minimapScale.addListener(
+        () => _storage?.setDouble(_minimapScaleKey, minimapScale.value));
     themeMode.addListener(
         () => _storage?.setInt(_themeModeKey, themeMode.value.index));
     targetingRange.addListener(
@@ -47,6 +52,7 @@ class SettingsService {
   static const double defaultHudButtonScale = 0.75;
   static const double defaultTextScale = 1.5;
   static const double defaultJoystickScale = 1;
+  static const double defaultMinimapScale = 1;
 
   /// Multiplier applied to HUD buttons and icons.
   final ValueNotifier<double> hudButtonScale;
@@ -56,6 +62,9 @@ class SettingsService {
 
   /// Multiplier applied to on-screen joystick elements.
   final ValueNotifier<double> joystickScale;
+
+  /// Multiplier applied to the minimap size.
+  final ValueNotifier<double> minimapScale;
 
   /// Currently selected theme mode.
   final ValueNotifier<ThemeMode> themeMode;
@@ -84,6 +93,8 @@ class SettingsService {
     textScale.value = storage.getDouble(_textScaleKey, textScale.value);
     joystickScale.value =
         storage.getDouble(_joystickScaleKey, joystickScale.value);
+    minimapScale.value =
+        storage.getDouble(_minimapScaleKey, minimapScale.value);
     themeMode.value =
         ThemeMode.values[storage.getInt(_themeModeKey, themeMode.value.index)];
     targetingRange.value =
@@ -96,6 +107,7 @@ class SettingsService {
   static const _hudScaleKey = 'hudButtonScale';
   static const _textScaleKey = 'textScale';
   static const _joystickScaleKey = 'joystickScale';
+  static const _minimapScaleKey = 'minimapScale';
   static const _themeModeKey = 'themeMode';
   static const _targetingRangeKey = 'targetingRange';
   static const _tractorRangeKey = 'tractorRange';

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -26,8 +26,8 @@ Flutter overlays and HUD widgets.
   pauses gameplay when opened mid-run; `Esc` also closes it.
 - [UpgradesOverlay](upgrades_overlay.md) – lists purchasable ship upgrades;
   opened with `U` and pauses gameplay.
-- [SettingsOverlay](settings_overlay.md) – adjust HUD, text, joystick scale and
-  gameplay ranges, and toggle the dark theme; opened via HUD button.
+- [SettingsOverlay](settings_overlay.md) – adjust HUD, minimap, text, joystick
+  scale and gameplay ranges, and toggle the dark theme; opened via HUD button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -41,7 +41,14 @@ class HudOverlay extends StatelessWidget {
                         }
                         return Padding(
                           padding: const EdgeInsets.only(top: 8, left: 8),
-                          child: MiniMapDisplay(game: game, size: 80 * scale),
+                          child: ValueListenableBuilder<double>(
+                            valueListenable: game.settingsService.minimapScale,
+                            builder: (context, minimapScale, _) =>
+                                MiniMapDisplay(
+                              game: game,
+                              size: 80 * scale * minimapScale,
+                            ),
+                          ),
                         );
                       },
                     ),

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -51,6 +51,12 @@ class SettingsOverlay extends StatelessWidget {
                   ),
                   _buildSlider(
                     context,
+                    'Minimap',
+                    settings.minimapScale,
+                    spacing,
+                  ),
+                  _buildSlider(
+                    context,
                     'Text',
                     settings.textScale,
                     spacing,

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -4,7 +4,7 @@ Overlay providing runtime UI scaling and range controls plus a dark theme toggle
 
 ## Features
 
-- Sliders adjust HUD button, text, joystick scales and gameplay ranges.
+- Sliders adjust HUD button, minimap, text, joystick scales and gameplay ranges.
 - Switch toggles between light and dark themes.
 - Bordered layout limits width on large screens for clarity.
 - Opens from the HUD; closing returns to the game.

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -12,6 +12,7 @@ void main() {
 
     expect(
         settings.hudButtonScale.value, SettingsService.defaultHudButtonScale);
+    expect(settings.minimapScale.value, SettingsService.defaultMinimapScale);
     expect(settings.textScale.value, SettingsService.defaultTextScale);
     expect(settings.joystickScale.value, SettingsService.defaultJoystickScale);
     expect(settings.targetingRange.value, Constants.playerAutoAimRange);
@@ -23,6 +24,7 @@ void main() {
     final settings = SettingsService();
 
     var hudNotified = false;
+    var minimapNotified = false;
     var textNotified = false;
     var joystickNotified = false;
     var targetingNotified = false;
@@ -30,6 +32,7 @@ void main() {
     var miningNotified = false;
 
     settings.hudButtonScale.addListener(() => hudNotified = true);
+    settings.minimapScale.addListener(() => minimapNotified = true);
     settings.textScale.addListener(() => textNotified = true);
     settings.joystickScale.addListener(() => joystickNotified = true);
     settings.targetingRange.addListener(() => targetingNotified = true);
@@ -37,6 +40,7 @@ void main() {
     settings.miningRange.addListener(() => miningNotified = true);
 
     settings.hudButtonScale.value = 1.2;
+    settings.minimapScale.value = 1.4;
     settings.textScale.value = 1.3;
     settings.joystickScale.value = 1.1;
     settings.targetingRange.value = 350;
@@ -44,6 +48,7 @@ void main() {
     settings.miningRange.value = 180;
 
     expect(hudNotified, isTrue);
+    expect(minimapNotified, isTrue);
     expect(textNotified, isTrue);
     expect(joystickNotified, isTrue);
     expect(targetingNotified, isTrue);
@@ -51,6 +56,7 @@ void main() {
     expect(miningNotified, isTrue);
 
     expect(settings.hudButtonScale.value, 1.2);
+    expect(settings.minimapScale.value, 1.4);
     expect(settings.textScale.value, 1.3);
     expect(settings.joystickScale.value, 1.1);
     expect(settings.targetingRange.value, 350);
@@ -63,9 +69,11 @@ void main() {
     final storage = await StorageService.create();
     var settings = SettingsService(storage: storage);
     settings.hudButtonScale.value = 1.2;
+    settings.minimapScale.value = 1.3;
     await Future.delayed(Duration.zero);
     settings = SettingsService(storage: storage);
     expect(settings.hudButtonScale.value, 1.2);
+    expect(settings.minimapScale.value, 1.3);
   });
 
   test('attachStorage injects storage into existing instance', () async {
@@ -77,8 +85,10 @@ void main() {
     settings.attachStorage(storage);
     expect(settings.hudButtonScale.value, 0.9);
     settings.hudButtonScale.value = 1.4;
+    settings.minimapScale.value = 1.2;
     await Future.delayed(Duration.zero);
     final reloaded = SettingsService(storage: storage);
     expect(reloaded.hudButtonScale.value, 1.4);
+    expect(reloaded.minimapScale.value, 1.2);
   });
 }


### PR DESCRIPTION
## Summary
- add minimap scale setting with persistence
- allow resizing minimap via Settings overlay slider
- document minimap scaling in UI guide and playtest checklist

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bba55d48c88330880c4a4810901127