### PR TITLE
Enforce dark theme and remove theme toggle

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -112,8 +112,8 @@ tree spanning weapons and ship systems.
   high score and settings.
 - `score_service.dart` tracks score, minerals and health values.
 - `overlay_service.dart` shows and hides the Flutter overlays.
-- `settings_service.dart` holds tweakable UI and text scale values, gameplay
-  range multipliers and theme mode.
+- `settings_service.dart` holds tweakable UI and text scale values and gameplay
+  range multipliers.
 - `targeting_service.dart` assists auto-aim queries.
 - `upgrade_service.dart` manages purchasing upgrades with minerals and exposes
   a `ValueListenable` for bought upgrade ids.
@@ -152,7 +152,7 @@ tree spanning weapons and ship systems.
 - An upgrades overlay (placeholder) opens with the `U` key or HUD button and
   pauses gameplay until dismissed.
 - A settings overlay provides sliders for HUD, text, joystick, targeting,
-  Tractor Aura and mining ranges plus a dark theme selector.
+  Tractor Aura and mining ranges.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -175,7 +175,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Upgrades overlay placeholder opened with a HUD button or the `U` key and
   pausing gameplay for future ship upgrades
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
-  and mining ranges, plus a dark theme selector
+  and mining ranges
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dedicated server or NAT traversal.
 - Code and asset base kept tiny and easy to maintain
 - Ship quickly and iterate in small increments
 - Responsive scaling for phones, tablets and desktop
-- Centralised colour theming with light and dark palettes
+- Centralised colour theming with a dark palette
 - Solo-friendly workflow with minimal tooling
 - Fun, casual tone with cartoony visuals
 - Modular game logic built with Flame (pinned for stability)
@@ -47,7 +47,7 @@ dedicated server or NAT traversal.
 - Toggable top-left minimap shows nearby asteroids, enemies and pickups
 - HUD button toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Placeholder upgrades overlay accessible via a HUD button or the `U` key
-- Settings overlay adjusts HUD, text and joystick scale and offers light or dark themes
+- Settings overlay adjusts HUD, text and joystick scale
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
   screens, plus an `M` key shortcut

--- a/TASKS.md
+++ b/TASKS.md
@@ -74,7 +74,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
 - [x] HUD button toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text, joystick, targeting,
-      Tractor Aura and mining ranges, plus a dark theme selector.
+      Tractor Aura and mining ranges.
 
 ## Next Steps
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -52,7 +52,7 @@ class SpaceGame extends FlameGame
     FocusNode? focusNode,
   })  : colorScheme = colorScheme ??
             ValueNotifier(ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
-        gameColors = gameColors ?? ValueNotifier(GameColors.light),
+        gameColors = gameColors ?? ValueNotifier(GameColors.dark),
         settingsService = settingsService ?? SettingsService(),
         focusNode = focusNode ?? FocusNode(),
         scoreService = ScoreService(storageService: storageService) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,45 +26,12 @@ Future<void> main() async {
   final settings = SettingsService();
   final focusNode = FocusNode();
 
-  final lightScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
   final darkScheme = ColorScheme.fromSeed(
     seedColor: Colors.deepPurple,
     brightness: Brightness.dark,
   );
-  final initialBrightness =
-      WidgetsBinding.instance.platformDispatcher.platformBrightness;
-  final colorScheme = ValueNotifier<ColorScheme>(
-    initialBrightness == Brightness.dark ? darkScheme : lightScheme,
-  );
-  final gameColors = ValueNotifier<GameColors>(
-    initialBrightness == Brightness.dark ? GameColors.dark : GameColors.light,
-  );
-
-  void applyTheme() {
-    final brightness = settings.themeMode.value == ThemeMode.system
-        ? WidgetsBinding.instance.platformDispatcher.platformBrightness
-        : (settings.themeMode.value == ThemeMode.dark
-            ? Brightness.dark
-            : Brightness.light);
-    if (brightness == Brightness.dark) {
-      colorScheme.value = darkScheme;
-      gameColors.value = GameColors.dark;
-    } else {
-      colorScheme.value = lightScheme;
-      gameColors.value = GameColors.light;
-    }
-  }
-
-  settings.themeMode.addListener(applyTheme);
-  final dispatcher = WidgetsBinding.instance.platformDispatcher;
-  final defaultBrightnessHandler = dispatcher.onPlatformBrightnessChanged;
-  dispatcher.onPlatformBrightnessChanged = () {
-    defaultBrightnessHandler?.call();
-    if (settings.themeMode.value == ThemeMode.system) {
-      applyTheme();
-    }
-  };
-  applyTheme();
+  final colorScheme = ValueNotifier<ColorScheme>(darkScheme);
+  final gameColors = ValueNotifier<GameColors>(GameColors.dark);
 
   final game = SpaceGame(
     storageService: storage,
@@ -82,41 +49,30 @@ Future<void> main() async {
   GameText.attachTextScale(settings.textScale);
 
   runApp(
-    ValueListenableBuilder<ThemeMode>(
-      valueListenable: settings.themeMode,
-      builder: (context, mode, _) => MaterialApp(
-        theme: ThemeData(
-          colorScheme: lightScheme,
-          useMaterial3: true,
-          extensions: const [GameColors.light],
-        ),
-        darkTheme: ThemeData(
-          colorScheme: darkScheme,
-          useMaterial3: true,
-          extensions: const [GameColors.dark],
-        ),
-        themeMode: mode,
-        home: GameWidget<SpaceGame>(
-          game: game,
-          focusNode: focusNode,
-          // Automatically request keyboard focus so web players can use WASD
-          // without tapping the canvas first.
-          autofocus: true,
-          overlayBuilderMap: {
-            MenuOverlay.id: (context, SpaceGame game) =>
-                MenuOverlay(game: game),
-            HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
-            PauseOverlay.id: (context, SpaceGame game) => const PauseOverlay(),
-            GameOverOverlay.id: (context, SpaceGame game) =>
-                GameOverOverlay(game: game),
-            HelpOverlay.id: (context, SpaceGame game) =>
-                HelpOverlay(game: game),
-            UpgradesOverlay.id: (context, SpaceGame game) =>
-                UpgradesOverlay(game: game),
-            SettingsOverlay.id: (context, SpaceGame game) =>
-                SettingsOverlay(game: game),
-          },
-        ),
+    MaterialApp(
+      theme: ThemeData(
+        colorScheme: darkScheme,
+        useMaterial3: true,
+        extensions: const [GameColors.dark],
+      ),
+      home: GameWidget<SpaceGame>(
+        game: game,
+        focusNode: focusNode,
+        // Automatically request keyboard focus so web players can use WASD
+        // without tapping the canvas first.
+        autofocus: true,
+        overlayBuilderMap: {
+          MenuOverlay.id: (context, SpaceGame game) => MenuOverlay(game: game),
+          HudOverlay.id: (context, SpaceGame game) => HudOverlay(game: game),
+          PauseOverlay.id: (context, SpaceGame game) => const PauseOverlay(),
+          GameOverOverlay.id: (context, SpaceGame game) =>
+              GameOverOverlay(game: game),
+          HelpOverlay.id: (context, SpaceGame game) => HelpOverlay(game: game),
+          UpgradesOverlay.id: (context, SpaceGame game) =>
+              UpgradesOverlay(game: game),
+          SettingsOverlay.id: (context, SpaceGame game) =>
+              SettingsOverlay(game: game),
+        },
       ),
     ),
   );

--- a/lib/main.md
+++ b/lib/main.md
@@ -7,7 +7,7 @@ Entry point launching the Flutter app and `SpaceGame`.
 - Bootstraps the Flutter app using the FVM-pinned SDK.
 - Preloads assets via `Assets.load()` before gameplay.
 - Creates core services (`StorageService`, `AudioService`, `SettingsService`).
-- Configures light and dark `ColorScheme`s based on the selected theme.
+- Configures a dark `ColorScheme` for the app.
 - Attaches global text scaling via `GameText.attachTextScale`.
 - Wraps `SpaceGame` in a `GameWidget` so overlays can render Flutter UI and
   registers overlay builders for menus, HUD and dialogs.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -8,7 +8,7 @@ Optional helpers for cross-cutting concerns.
   `shared_preferences`.
 - `score_service.dart` tracks score, minerals and health values.
 - `overlay_service.dart` shows and hides overlays on the `GameWidget`.
-- `settings_service.dart` holds UI scale values, theme mode and gameplay ranges.
+- `settings_service.dart` holds UI scale values and gameplay ranges.
 - `targeting_service.dart` assists auto-aim queries.
 - `upgrade_service.dart` manages purchasing upgrades with minerals and
   derives gameplay modifiers like fire rate and mining speed.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 import '../constants.dart';
 import 'storage_service.dart';
@@ -19,9 +19,6 @@ class SettingsService {
         minimapScale = ValueNotifier<double>(
             storage?.getDouble(_minimapScaleKey, defaultMinimapScale) ??
                 defaultMinimapScale),
-        themeMode = ValueNotifier<ThemeMode>(ThemeMode.values[
-            storage?.getInt(_themeModeKey, ThemeMode.system.index) ??
-                ThemeMode.system.index]),
         targetingRange = ValueNotifier<double>(storage?.getDouble(
                 _targetingRangeKey, Constants.playerAutoAimRange) ??
             Constants.playerAutoAimRange),
@@ -39,8 +36,6 @@ class SettingsService {
         () => _storage?.setDouble(_joystickScaleKey, joystickScale.value));
     minimapScale.addListener(
         () => _storage?.setDouble(_minimapScaleKey, minimapScale.value));
-    themeMode.addListener(
-        () => _storage?.setInt(_themeModeKey, themeMode.value.index));
     targetingRange.addListener(
         () => _storage?.setDouble(_targetingRangeKey, targetingRange.value));
     tractorRange.addListener(
@@ -65,9 +60,6 @@ class SettingsService {
 
   /// Multiplier applied to the minimap size.
   final ValueNotifier<double> minimapScale;
-
-  /// Currently selected theme mode.
-  final ValueNotifier<ThemeMode> themeMode;
 
   /// Distance used to auto-aim enemies when stationary.
   final ValueNotifier<double> targetingRange;
@@ -95,8 +87,6 @@ class SettingsService {
         storage.getDouble(_joystickScaleKey, joystickScale.value);
     minimapScale.value =
         storage.getDouble(_minimapScaleKey, minimapScale.value);
-    themeMode.value =
-        ThemeMode.values[storage.getInt(_themeModeKey, themeMode.value.index)];
     targetingRange.value =
         storage.getDouble(_targetingRangeKey, targetingRange.value);
     tractorRange.value =
@@ -108,7 +98,6 @@ class SettingsService {
   static const _textScaleKey = 'textScale';
   static const _joystickScaleKey = 'joystickScale';
   static const _minimapScaleKey = 'minimapScale';
-  static const _themeModeKey = 'themeMode';
   static const _targetingRangeKey = 'targetingRange';
   static const _tractorRangeKey = 'tractorRange';
   static const _miningRangeKey = 'miningRange';

--- a/lib/theme/game_theme.dart
+++ b/lib/theme/game_theme.dart
@@ -28,12 +28,6 @@ class GameColors extends ThemeExtension<GameColors> {
     );
   }
 
-  /// Light theme values.
-  static const GameColors light = GameColors(
-    playerLaser: Color(0xffffffff),
-    enemyLaser: Color(0xffff6666),
-  );
-
   /// Dark theme values.
   static const GameColors dark = GameColors(
     playerLaser: Color(0xffffffff),

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -27,7 +27,7 @@ Flutter overlays and HUD widgets.
 - [UpgradesOverlay](upgrades_overlay.md) – lists purchasable ship upgrades;
   opened with `U` and pauses gameplay.
 - [SettingsOverlay](settings_overlay.md) – adjust HUD, minimap, text, joystick
-  scale and gameplay ranges, and toggle the dark theme; opened via HUD button.
+  scale and gameplay ranges; opened via HUD button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -91,34 +91,6 @@ class SettingsOverlay extends StatelessWidget {
                     min: 50,
                     max: 600,
                   ),
-                  ValueListenableBuilder<ThemeMode>(
-                    valueListenable: settings.themeMode,
-                    builder: (context, mode, _) => ListTile(
-                      title: const GameText('Theme', maxLines: 1),
-                      trailing: DropdownButton<ThemeMode>(
-                        value: mode,
-                        onChanged: (newMode) {
-                          if (newMode != null) {
-                            settings.themeMode.value = newMode;
-                          }
-                        },
-                        items: const [
-                          DropdownMenuItem(
-                            value: ThemeMode.system,
-                            child: GameText('System', maxLines: 1),
-                          ),
-                          DropdownMenuItem(
-                            value: ThemeMode.light,
-                            child: GameText('Light', maxLines: 1),
-                          ),
-                          DropdownMenuItem(
-                            value: ThemeMode.dark,
-                            child: GameText('Dark', maxLines: 1),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
                   SizedBox(height: spacing),
                   ElevatedButton(
                     onPressed: game.toggleSettings,

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -1,11 +1,10 @@
 # SettingsOverlay
 
-Overlay providing runtime UI scaling and range controls plus a dark theme toggle.
+Overlay providing runtime UI scaling and range controls.
 
 ## Features
 
 - Sliders adjust HUD button, minimap, text, joystick scales and gameplay ranges.
-- Switch toggles between light and dark themes.
 - Bordered layout limits width on large screens for clarity.
 - Opens from the HUD; closing returns to the game.
 - Overlay remains transparent so adjustments can be viewed immediately.


### PR DESCRIPTION
## Summary
- remove theme mode persistence and listeners from settings
- default the app and game colors to the existing dark theme
- drop the theme selection UI and update docs for single theme

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bba81812c48330a07382c225ee4321