### PR TITLE
feat: add Q shortcut for returning to menu

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -64,6 +64,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Keyboard shortcut `P` pauses or resumes the game.
 - [x] Keyboard shortcuts: `Enter` starts or restarts from the menu or game over;
       `R` restarts during play, pause or game over.
+- [x] Keyboard shortcut `Q` returns to the menu from pause or game over.
 - [x] Help overlay lists controls and can be toggled with a button or the `H` key;
       `Esc` also closes it.
 - [x] HUD displays current score, minerals and health.

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -6,6 +6,9 @@ import 'game_state.dart';
 import 'key_dispatcher.dart';
 
 /// Registers global keyboard shortcuts and wires them to actions.
+///
+/// Supported keys: `Esc`, `P`, `M`, `Enter`, `R`, `H`, `U`, `F1`, `N` and
+/// `Q`.
 class ShortcutManager {
   ShortcutManager({
     required KeyDispatcher keyDispatcher,
@@ -18,6 +21,7 @@ class ShortcutManager {
     required void Function() toggleUpgrades,
     required void Function() toggleDebug,
     required void Function() toggleMinimap,
+    required void Function() returnToMenu,
   }) {
     keyDispatcher.register(LogicalKeyboardKey.escape, onDown: () {
       if (stateMachine.state == GameState.playing) {
@@ -74,5 +78,12 @@ class ShortcutManager {
       LogicalKeyboardKey.keyN,
       onDown: toggleMinimap,
     );
+
+    keyDispatcher.register(LogicalKeyboardKey.keyQ, onDown: () {
+      if (stateMachine.state == GameState.paused ||
+          stateMachine.state == GameState.gameOver) {
+        returnToMenu();
+      }
+    });
   }
 }

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -232,6 +232,7 @@ class SpaceGame extends FlameGame
       toggleUpgrades: toggleUpgrades,
       toggleDebug: toggleDebug,
       toggleMinimap: toggleMinimap,
+      returnToMenu: returnToMenu,
     );
     stateMachine.returnToMenu();
 

--- a/test/assets_load_test.dart
+++ b/test/assets_load_test.dart
@@ -1,7 +1,5 @@
-import 'package:audioplayers/audioplayers.dart';
 import 'package:flame/flame.dart';
 import 'package:flame_audio/flame_audio.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/assets.dart';
 

--- a/test/minimap_markers_test.dart
+++ b/test/minimap_markers_test.dart
@@ -41,7 +41,7 @@ Future<int> _getPixel(ui.Image image, int x, int y) async {
   final g = data.getUint8(offset + 1);
   final b = data.getUint8(offset + 2);
   final a = data.getUint8(offset + 3);
-  return Color.fromARGB(a, r, g, b).value;
+  return Color.fromARGB(a, r, g, b).toARGB32();
 }
 
 void main() {
@@ -78,11 +78,11 @@ void main() {
         .painter!;
     var image = await _paintToImage(painter, 100);
     var pixel = await _getPixel(image, 55, 50);
-    expect(pixel, equals(Colors.redAccent.value));
+    expect(pixel, equals(Colors.redAccent.toARGB32()));
 
     enemy.position = Vector2(2000, 0);
     image = await _paintToImage(painter, 100);
     pixel = await _getPixel(image, 55, 50);
-    expect(pixel, isNot(equals(Colors.redAccent.value)));
+    expect(pixel, isNot(equals(Colors.redAccent.toARGB32())));
   }, skip: true);
 }

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -98,6 +98,7 @@ class _Harness {
       toggleUpgrades: () => upgradesCalled = true,
       toggleDebug: () => debugCalled = true,
       toggleMinimap: () => minimapCalled = true,
+      returnToMenu: () => menuCalled = true,
     );
   }
 
@@ -111,6 +112,7 @@ class _Harness {
   bool upgradesCalled = false;
   bool debugCalled = false;
   bool minimapCalled = false;
+  bool menuCalled = false;
 
   void press(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) {
     dispatcher.onKeyEvent(
@@ -211,6 +213,17 @@ void main() {
       final h = _Harness();
       h.press(LogicalKeyboardKey.keyN, PhysicalKeyboardKey.keyN);
       expect(h.minimapCalled, isTrue);
+    });
+
+    test('Q returns to menu from pause or game over', () {
+      final h = _Harness()..stateMachine.state = GameState.paused;
+      h.press(LogicalKeyboardKey.keyQ, PhysicalKeyboardKey.keyQ);
+      expect(h.menuCalled, isTrue);
+
+      h.menuCalled = false;
+      h.stateMachine.state = GameState.gameOver;
+      h.press(LogicalKeyboardKey.keyQ, PhysicalKeyboardKey.keyQ);
+      expect(h.menuCalled, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add `Q` keyboard shortcut to exit to the menu from pause or game over
- wire SpaceGame to provide `returnToMenu` to the shortcut manager
- document the new shortcut in TASKS

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli TASKS.md`


------
https://chatgpt.com/codex/tasks/task_e_68bbb3a209cc8330ac271bdb0e38d8e3