### PR TITLE
feat: follow player with camera

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -172,7 +172,7 @@ class SpaceGame extends FlameGame
     );
     await add(player);
     _playerInitialized = true;
-    camera.viewfinder.position = player.position;
+    camera.follow(player, snap: true);
     final laser = MiningLaserComponent(player: player);
     miningLaser = laser;
     await add(laser);
@@ -416,9 +416,6 @@ class SpaceGame extends FlameGame
             stateMachine.state == GameState.upgrades);
     final effectiveDt = shouldFreeze ? 0.0 : dt;
     super.update(effectiveDt);
-    if (_playerInitialized) {
-      camera.viewfinder.position = player.position;
-    }
   }
 
   @override

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -6,7 +6,7 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 
 - Preload assets via the central registry before entering gameplay.
 - Configure the parallax background, set up a fixed-resolution camera that
-  follows the player, and register component spawners.
+  follows the player via `camera.follow`, and register component spawners.
 - Spawn the player and register enemy or asteroid generators.
 - Provide small bullet, asteroid, enemy and mineral pickup pools to limit allocations.
 - Maintain `GameState` values (`menu`, `playing`, `paused`, `gameOver`)


### PR DESCRIPTION
## Summary
- use Flame camera.follow to track the player
- document camera follow responsibility

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `scripts/markdownlint.sh lib/game/space_game.md`


------
https://chatgpt.com/codex/tasks/task_e_68bbb3a209cc8330ac271bdb0e38d8e3