### PR TITLE
Remove theming references and document static palette

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,7 +60,7 @@ tree spanning weapons and ship systems.
 - It wraps `SpaceGame` in a `GameWidget`, ensures the PWA manifest loads and
 - preloads assets through `Assets.load()` before play.
 - It initialises `StorageService`, `AudioService` and `SettingsService`, applies
-  light or dark `ColorScheme`s, and attaches global text scaling via
+  a static dark `ColorScheme`, and attaches global text scaling via
   `GameText.attachTextScale`.
 - An app lifecycle observer pauses the engine and audio when the window loses
   focus.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dedicated server or NAT traversal.
 - Code and asset base kept tiny and easy to maintain
 - Ship quickly and iterate in small increments
 - Responsive scaling for phones, tablets and desktop
-- Centralised colour theming with a dark palette
+- Static dark colour palette
 - Solo-friendly workflow with minimal tooling
 - Fun, casual tone with cartoony visuals
 - Modular game logic built with Flame (pinned for stability)

--- a/lib/theme/game_theme.dart
+++ b/lib/theme/game_theme.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-/// Theme extension holding game-specific colour roles.
+/// Defines custom colours used throughout the game.
 @immutable
 class GameColors extends ThemeExtension<GameColors> {
   const GameColors({required this.playerLaser, required this.enemyLaser});
@@ -28,7 +28,7 @@ class GameColors extends ThemeExtension<GameColors> {
     );
   }
 
-  /// Dark theme values.
+  /// Default colour values.
   static const GameColors dark = GameColors(
     playerLaser: Color(0xffffffff),
     enemyLaser: Color(0xffff8888),

--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 
 /// Displays text using a consistent style across game overlays.
 ///
-/// Text is rendered without decoration and uses the theme's primary colour by
+/// Text is rendered without decoration and uses the game's primary colour by
 /// default, but can be customised via [style], [maxLines] and [textAlign].
 class GameText extends StatelessWidget {
   const GameText(

--- a/web/README.md
+++ b/web/README.md
@@ -2,8 +2,7 @@
 
 PWA configuration and static web files.
 
-- `manifest.json` defines PWA metadata like `start_url`, `display` and theme
-  colours.
+- `manifest.json` defines PWA metadata like `start_url`, `display` and colour values.
 - `icons/` holds 192x192 and 512x512 app icons.
 - `index.html` bootstraps the Flutter app and registers `sw.js`.
 - `sw.js` precaches assets listed in `assets_manifest.json` and provides a


### PR DESCRIPTION
## Summary
- note static dark color palette in docs
- reword game comments to avoid theming terminology
- clarify PWA README and design docs about fixed scheme

## Testing
- `./scripts/dartw analyze` (warnings: unused/deprecated imports)
- `./scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bbb7bf14608330a122c27980eb1f25