### PR TITLE
refactor: remove dynamic color scheme

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -14,6 +14,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Code and asset base kept tiny and easy to maintain
 - Ship quickly and iterate in small increments
 - Responsive scaling so the same build works on phones, tablets and desktop
+- Static dark colour palette; no runtime theme switching
 - Solo-friendly workflow with minimal tooling
 - Core loop focused on mining asteroids for minerals while fending off enemy
   groups

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -21,20 +21,13 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
   final PlayerComponent player;
   AsteroidComponent? _target;
   final Paint _paint = Paint();
-  late void Function() _colorListener;
   final Timer _pulseTimer = Timer(Constants.miningPulseInterval, repeat: true);
   bool _playingSound = false;
 
   @override
   void onMount() {
     super.onMount();
-    void updateColor() {
-      _paint.color = game.gameColors.value.playerLaser.withValues(alpha: 0.4);
-    }
-
-    updateColor();
-    _colorListener = updateColor;
-    game.gameColors.addListener(_colorListener);
+    _paint.color = game.gameColors.playerLaser.withValues(alpha: 0.4);
   }
 
   @override
@@ -126,7 +119,6 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
       game.audioService.stopMiningLaser();
       _playingSound = false;
     }
-    game.gameColors.removeListener(_colorListener);
     super.onRemove();
   }
 }

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -46,13 +46,13 @@ class SpaceGame extends FlameGame
   SpaceGame({
     required this.storageService,
     required this.audioService,
-    ValueNotifier<ColorScheme>? colorScheme,
-    ValueNotifier<GameColors>? gameColors,
+    ColorScheme? colorScheme,
+    GameColors? gameColors,
     SettingsService? settingsService,
     FocusNode? focusNode,
-  })  : colorScheme = colorScheme ??
-            ValueNotifier(ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
-        gameColors = gameColors ?? ValueNotifier(GameColors.dark),
+  })  : colorScheme =
+            colorScheme ?? ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        gameColors = gameColors ?? GameColors.dark,
         settingsService = settingsService ?? SettingsService(),
         focusNode = focusNode ?? FocusNode(),
         scoreService = ScoreService(storageService: storageService) {
@@ -73,10 +73,10 @@ class SpaceGame extends FlameGame
   final SettingsService settingsService;
 
   /// Active colour scheme shared with Flutter widgets.
-  final ValueNotifier<ColorScheme> colorScheme;
+  final ColorScheme colorScheme;
 
   /// Game-specific colours from [GameColors] extension.
-  final ValueNotifier<GameColors> gameColors;
+  final GameColors gameColors;
 
   /// Focus node used to capture keyboard input.
   final FocusNode focusNode;
@@ -114,9 +114,6 @@ class SpaceGame extends FlameGame
   bool _isLoaded = false;
   bool get isLoaded => _isLoaded;
 
-  late void Function() _updateFireButtonColors;
-  late void Function() _updateJoystickColors;
-
   ValueNotifier<int> get score => scoreService.score;
   ValueNotifier<int> get highScore => scoreService.highScore;
   ValueNotifier<int> get minerals => scoreService.minerals;
@@ -151,16 +148,6 @@ class SpaceGame extends FlameGame
 
     joystick = _buildJoystick();
     await add(joystick);
-    void updateJoystickColors() {
-      (joystick.knob as CircleComponent).paint.color =
-          colorScheme.value.primary;
-      (joystick.background as CircleComponent).paint.color =
-          colorScheme.value.primary.withValues(alpha: 0.4);
-    }
-
-    updateJoystickColors();
-    _updateJoystickColors = updateJoystickColors;
-    colorScheme.addListener(_updateJoystickColors);
 
     _starfield = await StarfieldComponent();
     await add(_starfield!);
@@ -179,11 +166,11 @@ class SpaceGame extends FlameGame
 
     final upButton = CircleComponent(
       radius: 30 * settingsService.hudButtonScale.value,
-      paint: Paint(),
+      paint: Paint()..color = colorScheme.primary.withValues(alpha: 0.4),
     );
     final downButton = CircleComponent(
       radius: 30 * settingsService.hudButtonScale.value,
-      paint: Paint(),
+      paint: Paint()..color = colorScheme.primary,
     );
     fireButton = HudButtonComponent(
       button: upButton,
@@ -195,14 +182,6 @@ class SpaceGame extends FlameGame
       onCancelled: player.stopShooting,
     );
     await add(fireButton);
-    void updateFireButtonColors() {
-      upButton.paint.color = colorScheme.value.primary.withValues(alpha: 0.4);
-      downButton.paint.color = colorScheme.value.primary;
-    }
-
-    updateFireButtonColors();
-    _updateFireButtonColors = updateFireButtonColors;
-    colorScheme.addListener(_updateFireButtonColors);
 
     enemySpawner = EnemySpawner();
     asteroidSpawner = AsteroidSpawner();
@@ -239,14 +218,6 @@ class SpaceGame extends FlameGame
     settingsService.joystickScale.addListener(_updateJoystickScale);
     settingsService.hudButtonScale.addListener(_updateHudButtonScale);
     _isLoaded = true;
-  }
-
-  @override
-  void onRemove() {
-    colorScheme
-      ..removeListener(_updateFireButtonColors)
-      ..removeListener(_updateJoystickColors);
-    super.onRemove();
   }
 
   @protected
@@ -382,7 +353,7 @@ class SpaceGame extends FlameGame
 
   JoystickComponent _buildJoystick() {
     final scale = settingsService.joystickScale.value;
-    final scheme = colorScheme.value;
+    final scheme = colorScheme;
     return JoystickComponent(
       knob: CircleComponent(
         radius: 20 * scale,
@@ -400,7 +371,6 @@ class SpaceGame extends FlameGame
     final scale = settingsService.joystickScale.value;
     (joystick.knob as CircleComponent).radius = 20 * scale;
     (joystick.background as CircleComponent).radius = 50 * scale;
-    _updateJoystickColors();
   }
 
   void _updateHudButtonScale() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,12 +26,11 @@ Future<void> main() async {
   final settings = SettingsService();
   final focusNode = FocusNode();
 
-  final darkScheme = ColorScheme.fromSeed(
+  final colorScheme = ColorScheme.fromSeed(
     seedColor: Colors.deepPurple,
     brightness: Brightness.dark,
   );
-  final colorScheme = ValueNotifier<ColorScheme>(darkScheme);
-  final gameColors = ValueNotifier<GameColors>(GameColors.dark);
+  const gameColors = GameColors.dark;
 
   final game = SpaceGame(
     storageService: storage,
@@ -51,7 +50,7 @@ Future<void> main() async {
   runApp(
     MaterialApp(
       theme: ThemeData(
-        colorScheme: darkScheme,
+        colorScheme: colorScheme,
         useMaterial3: true,
         extensions: const [GameColors.dark],
       ),

--- a/lib/ui/minimap_display.dart
+++ b/lib/ui/minimap_display.dart
@@ -57,11 +57,11 @@ class _MiniMapPainter extends CustomPainter {
     final radius = size.width / 2;
     final center = Offset(radius, radius);
     final borderPaint = Paint()
-      ..color = game.colorScheme.value.primary
+      ..color = game.colorScheme.primary
       ..style = PaintingStyle.stroke;
     canvas.drawCircle(center, radius, borderPaint);
 
-    final playerPaint = Paint()..color = game.colorScheme.value.primary;
+    final playerPaint = Paint()..color = game.colorScheme.primary;
     canvas.drawCircle(center, 3, playerPaint);
 
     final enemyPaint = Paint()..color = Colors.redAccent;


### PR DESCRIPTION
## Summary
- remove ValueNotifier-based color scheme and game colors
- update code and docs for static dark palette

## Testing
- `./scripts/dartw format lib/main.dart lib/game/space_game.dart lib/ui/minimap_display.dart lib/components/mining_laser.dart`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bbbabda3388330b5cced038a942a52