### PR TITLE
Rebind camera to active player on respawn

### DIFF
--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -58,7 +58,9 @@ class LifecycleManager {
       game.player.setSprite(game.selectedPlayerSprite);
       game.player.reset();
     }
-    game.camera.viewfinder.position = game.player.position;
+    // Rebind the camera to the active player each run so it doesn't
+    // follow a removed instance after respawns.
+    game.camera.follow(game.player, snap: true);
     game.enemySpawner
       ..stop()
       ..start();


### PR DESCRIPTION
## Summary
- Rebind the camera to the active player whenever a new player instance is created so respawns remain tracked

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bbbe52fde88330a2cd8102a1361390