### PR TITLE
docs: document theme and util directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ lib/
   components/           # Game entities/components
   ui/                   # Flutter widgets for menus/HUD
   services/             # Storage, networking, audio
+  theme/                # Game-specific color theme extension
+  util/                 # Reusable helpers (object pools, spatial grid)
 web/                    # PWA manifest, service worker
 .github/workflows/      # CI/CD configs
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,9 +6,11 @@ live in [lib/README.md](lib/README.md), [assets/README.md](assets/README.md),
 [web/README.md](web/README.md) and [test/README.md](test/README.md).
 Design notes for the central helper files are in
 [lib/main.md](lib/main.md), [lib/assets.md](lib/assets.md),
-[lib/constants.md](lib/constants.md) and [lib/log.md](lib/log.md).
+[lib/constants.md](lib/constants.md), [lib/log.md](lib/log.md) and
+[lib/theme/game_theme.dart](lib/theme/game_theme.dart).
 Modules such as `space_game`, components, overlays and services have dedicated
-docs in their respective subfolders.
+docs in their respective subfolders, and shared utilities live under
+[lib/util](lib/util).
 Milestone goals are detailed in [milestone-setup.md](milestone-setup.md),
 [milestone-core-loop.md](milestone-core-loop.md) and
 [milestone-polish.md](milestone-polish.md), with the day-to-day backlog in
@@ -60,8 +62,8 @@ tree spanning weapons and ship systems.
 - It wraps `SpaceGame` in a `GameWidget`, ensures the PWA manifest loads and
 - preloads assets through `Assets.load()` before play.
 - It initialises `StorageService`, `AudioService` and `SettingsService`, applies
-  a static dark `ColorScheme`, and attaches global text scaling via
-  `GameText.attachTextScale`.
+  a static dark `ColorScheme` with extra hues from the `GameColors` theme
+  extension, and attaches global text scaling via `GameText.attachTextScale`.
 - An app lifecycle observer pauses the engine and audio when the window loses
   focus.
 - Run all development commands through FVM (`fvm flutter`, `fvm dart`) to keep

--- a/PLAN.md
+++ b/PLAN.md
@@ -99,6 +99,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   - `log.dart` – tiny `log()` helper wrapping `debugPrint`
   - `ui/game_text.dart` – text widget applying global scaling for consistent style
   - `services/` – storage, audio, settings and other helpers added only when needed
+  - `theme/` – `GameColors` extension with game-specific colour values
+  - `util/` – shared helpers like object pools and spatial queries
 - `assets/` – images, audio and fonts
 - `web/` – PWA manifest, icons and service worker
 - `test/` – placeholder for future automated tests

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ lib/                    # Game source code
   constants.dart        # Tunable values for balancing
   log.dart              # Tiny log() wrapper around debugPrint
   services/             # Optional helpers (see lib/services/README.md)
+  theme/                # Game-specific color extensions
+  util/                 # Shared helpers (object pools, spatial grid)
 web/                    # PWA configuration (see web/README.md)
 test/                   # Automated tests for services and game logic (see test/README.md)
 assets_manifest.json    # List of bundled asset files for caching (see assets_manifest.md)

--- a/lib/README.md
+++ b/lib/README.md
@@ -27,5 +27,7 @@ the pinned SDK.
 - [ui/](ui/) – Flutter widgets for menus and HUD displayed using Flame overlays.
 - [services/](services/) – optional helpers for audio, storage
   (`shared_preferences`) and other utilities added as needed.
+- [theme/](theme/) – `GameColors` extension and theming helpers.
+- [util/](util/) – shared utilities like object pools and spatial queries.
 
 See [../PLAN.md](../PLAN.md) for the broader roadmap.


### PR DESCRIPTION
## Summary
- note new `theme/` and `util/` folders in project structure docs
- mention `GameColors` theme extension and shared utilities in design docs

## Testing
- `dart format lib`
- `dart analyze`
- `npx --yes markdownlint-cli '**/*.md'`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68bbbe33b0c083309e344cea7a627902