### PR TITLE
feat: persist player ship selection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,6 +140,8 @@ tree spanning weapons and ship systems.
 - Play centres on searching for asteroids to mine while surviving periodic enemy
   waves.
 - The game starts in a menu overlay that also exposes a mute toggle.
+- Players can choose between multiple ship sprites from the menu, and the
+  selection persists via `StorageService`.
 - `SpaceGame` transitions to `playing` when the user taps start.
 - Players can pause the game from the HUD or with the Escape or `P` key,
   showing a centered `PAUSED` label with a hint to press `Esc` or `P` to

--- a/PLAN.md
+++ b/PLAN.md
@@ -166,6 +166,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - HUD button toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Local high score stored on device (e.g., shared preferences)
 - Menu offers a reset button to clear the high score
+- Menu allows choosing between multiple ship sprites and remembers the selection
 - Basic sound effects using `flame_audio` with mute toggle (button or `M` key)
   available on menu, HUD and game over overlays
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -24,6 +24,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Game states transition: menu → playing → upgrades → paused → game over
       → restart or menu
 - [ ] Player can choose a ship from the menu before starting
+- [ ] Selected ship persists between sessions
 - [ ] Enter starts or restarts from the menu or game over; `R` restarts at any time
 - [ ] Escape or `P` key pauses or resumes the game
 - [ ] Parallax starfield renders behind gameplay

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ dedicated server or NAT traversal.
 - HUD button toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Placeholder upgrades overlay accessible via a HUD button or the `U` key
 - Settings overlay adjusts HUD, text and joystick scale
+- Menu allows choosing between multiple ship sprites and remembers the selection
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
   screens, plus an `M` key shortcut

--- a/TASKS.md
+++ b/TASKS.md
@@ -72,6 +72,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Keyboard shortcut `F1` toggles debug overlays.
 - [x] Audio volume lowers when the game is paused.
 - [x] Menu includes button to reset the high score.
+- [x] Menu allows choosing between multiple ship sprites and persists the selection.
 - [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
 - [x] HUD button toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text, joystick, targeting,

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -50,7 +50,9 @@ class SpaceGame extends FlameGame
     GameColors? gameColors,
     SettingsService? settingsService,
     FocusNode? focusNode,
-  })  : colorScheme =
+  })  : selectedPlayerIndex =
+            ValueNotifier<int>(storageService.getPlayerSpriteIndex()),
+        colorScheme =
             colorScheme ?? ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         gameColors = gameColors ?? GameColors.dark,
         settingsService = settingsService ?? SettingsService(),
@@ -121,12 +123,14 @@ class SpaceGame extends FlameGame
   late final UpgradeService upgradeService;
 
   /// Selected player sprite index for menu selection.
-  final ValueNotifier<int> selectedPlayerIndex = ValueNotifier<int>(0);
+  final ValueNotifier<int> selectedPlayerIndex;
 
   String get selectedPlayerSprite => Assets.players[selectedPlayerIndex.value];
 
   void selectPlayer(int index) {
-    selectedPlayerIndex.value = index.clamp(0, Assets.players.length - 1);
+    final clamped = index.clamp(0, Assets.players.length - 1);
+    selectedPlayerIndex.value = clamped;
+    storageService.setPlayerSpriteIndex(clamped);
   }
 
   void toggleMinimap() {

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -19,7 +19,8 @@ Main FlameGame subclass managing world setup, state transitions and the update l
   closes it).
 - Expose helpers to pause, resume or return to the menu.
 - Drive the update cycle while delegating work to components and services.
-- Persist and load the high score through `StorageService`.
+- Persist and load the high score and selected player sprite index through
+  `StorageService`.
 - Exposes `ValueNotifier<int>`s for the current score, minerals, health and
   persisted high score so Flutter overlays can render values without touching
   the game loop.

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -2,8 +2,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// Simple wrapper around [SharedPreferences] for persisting small bits of data.
 ///
-/// Currently only stores and retrieves the local high score but can expand to
-/// handle additional settings in the future.
+/// Stores the local high score, mute flag and selected player sprite index.
+/// Additional getters/setters expose primitive types for future expansion.
 class StorageService {
   StorageService(this._prefs);
 
@@ -17,6 +17,7 @@ class StorageService {
 
   static const _highScoreKey = 'highScore';
   static const _mutedKey = 'muted';
+  static const _playerSpriteKey = 'playerSpriteIndex';
 
   /// Returns the stored high score or `0` if none exists.
   int getHighScore() => _prefs.getInt(_highScoreKey) ?? 0;
@@ -37,6 +38,14 @@ class StorageService {
   /// Persists the mute flag.
   Future<void> setMuted(bool value) async {
     await _prefs.setBool(_mutedKey, value);
+  }
+
+  /// Returns the selected player sprite index or `0` if unset.
+  int getPlayerSpriteIndex() => _prefs.getInt(_playerSpriteKey) ?? 0;
+
+  /// Persists the selected player sprite index.
+  Future<void> setPlayerSpriteIndex(int value) async {
+    await _prefs.setInt(_playerSpriteKey, value);
   }
 
   /// Retrieves a double value for [key] or returns [defaultValue] if unset.

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -6,6 +6,7 @@ Handles local persistence using `shared_preferences`.
 
 - Save and load the local high score.
 - Store settings such as the mute flag.
+- Persist the selected player sprite index.
 - Provide simple async getters and setters.
 - Future expansion can add save/load for other data.
 

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -12,6 +12,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Implement `storage_service.dart` using `shared_preferences`
       to persist the local high score.
 - [x] Simple HUD and menus layered with Flutter overlays.
+- [x] Menu allows choosing between multiple ship sprites and persists the selection.
 - [x] Option to mute or dim audio when the game is paused.
 
 ## Design Notes

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -22,5 +22,13 @@ void main() {
       await storage.resetHighScore();
       expect(storage.getHighScore(), 0);
     });
+
+    test('persists selected player sprite index', () async {
+      SharedPreferences.setMockInitialValues({});
+      final storage = await StorageService.create();
+      expect(storage.getPlayerSpriteIndex(), 0);
+      await storage.setPlayerSpriteIndex(1);
+      expect(storage.getPlayerSpriteIndex(), 1);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- persist selected player ship using StorageService and load it at startup
- document ship selection across design and task docs
- test StorageService and update playtest checklist

## Testing
- `./scripts/dartw analyze`
- `npx --yes markdownlint-cli '**/*.md'`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bbbe33b0c083309e344cea7a627902