### PR TITLE
feat: add keyboard shortcut for range rings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,7 +164,8 @@ tree spanning weapons and ship systems.
 - On-screen joystick and fire button mirror keyboard controls (WASD + Space).
 - Input handling stays isolated from rendering for easier testing.
 - `N` toggles a minimap overlay for navigation.
-- HUD button toggles range rings showing targeting, Tractor Aura and mining radii.
+- `B` or a HUD button toggles range rings showing targeting, Tractor Aura and
+  mining radii.
 - `H` toggles a help overlay for quick reference, and `Esc` closes it when
   visible.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -165,7 +165,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Player score, minerals and health shown in the HUD with simple
   start/game‑over screens
 - Toggable top-left minimap shows nearby asteroids, enemies and pickups
-- HUD button toggles coloured range rings showing targeting, Tractor Aura and mining radii
+- HUD button or `B` key toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Local high score stored on device (e.g., shared preferences)
 - Menu offers a reset button to clear the high score
 - Menu allows choosing between multiple ship sprites and remembers the selection
@@ -175,7 +175,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `N` toggles the
   minimap, `F1` toggles debug overlays, `Enter` starts or restarts from the
   menu or game over, `R` restarts at any time, `H` shows a help overlay that
-  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes)
+  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes, `B`
+  toggles range rings)
 - Upgrades overlay placeholder opened with a HUD button or the `U` key and
   pausing gameplay for future ship upgrades
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -10,7 +10,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Bullets travel in the direction the ship is facing
 - [ ] Bullets spawn from the front of the player's ship
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
-- [ ] Target button toggles range rings display
+- [ ] Target button or `B` key toggles range rings display
 - [ ] Minimap icon or `N` key toggles minimap visibility
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dedicated server or NAT traversal.
 - Player score, health and minerals displayed in the HUD; health drops on
   collision and minerals increase when collecting pickups from mined asteroids
 - Toggable top-left minimap shows nearby asteroids, enemies and pickups
-- HUD button toggles coloured range rings showing targeting, Tractor Aura and mining radii
+- HUD button or `B` key toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Placeholder upgrades overlay accessible via a HUD button or the `U` key
 - Settings overlay adjusts HUD, text and joystick scale
 - Menu allows choosing between multiple ship sprites and remembers the selection
@@ -55,10 +55,11 @@ dedicated server or NAT traversal.
 - Pause or resume via keyboard or HUD button with a `PAUSED` indicator and a
   hint to press `Esc` or `P` to resume, leaving the interface visible
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
-  shoot, `Escape` or `P` to pause or resume, `M` to mute, `N` toggles the
-  minimap, `F1` toggles debug overlays, `Enter` starts or restarts from the
-  menu or game over, `R` restarts at any time, `H` shows a help overlay that
-  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes)
+  shoot, `Escape` or `P` to pause or resume, `M` to mute, `B` toggles range
+  rings, `N` toggles the minimap, `F1` toggles debug overlays, `Enter` starts
+  or restarts from the menu or game over, `R` restarts at any time, `H` shows a
+  help overlay that `Esc` also closes, `U` opens an upgrades overlay that `Esc`
+  also closes)
 - Game works offline after the first load
 - Parallax starfield background
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -74,7 +74,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Menu includes button to reset the high score.
 - [x] Menu allows choosing between multiple ship sprites and persists the selection.
 - [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
-- [x] HUD button toggles range rings for targeting, Tractor Aura and mining.
+- [x] HUD button or `B` key toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text, joystick, targeting,
       Tractor Aura and mining ranges.
 

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -48,8 +48,8 @@ class PlayerComponent extends SpriteComponent
 
   String _spritePath;
 
-  /// Whether to render range rings around the player.
-  bool showAutoAimRadius = false;
+  /// Whether to render targeting, tractor and mining range rings.
+  bool showRangeRings = false;
 
   /// Angle the ship should currently rotate towards.
   double targetAngle = 0;
@@ -108,8 +108,8 @@ class PlayerComponent extends SpriteComponent
   }
 
   /// Toggles visibility of the player's range rings.
-  void toggleAutoAimRadius() {
-    showAutoAimRadius = !showAutoAimRadius;
+  void toggleRangeRings() {
+    showRangeRings = !showRangeRings;
   }
 
   /// Triggers a short red flash that fades out to indicate damage taken.
@@ -199,7 +199,7 @@ class PlayerComponent extends SpriteComponent
   @override
   void render(Canvas canvas) {
     super.render(canvas);
-    if (showAutoAimRadius) {
+    if (showRangeRings) {
       final center = Offset(size.x / 2, size.y / 2);
       canvas.drawCircle(
         center,

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -7,7 +7,7 @@ import 'key_dispatcher.dart';
 
 /// Registers global keyboard shortcuts and wires them to actions.
 ///
-/// Supported keys: `Esc`, `P`, `M`, `Enter`, `R`, `H`, `U`, `F1`, `N` and
+/// Supported keys: `Esc`, `P`, `M`, `Enter`, `R`, `H`, `U`, `F1`, `N`, `B` and
 /// `Q`.
 class ShortcutManager {
   ShortcutManager({
@@ -21,6 +21,7 @@ class ShortcutManager {
     required void Function() toggleUpgrades,
     required void Function() toggleDebug,
     required void Function() toggleMinimap,
+    required void Function() toggleRangeRings,
     required void Function() returnToMenu,
   }) {
     keyDispatcher.register(LogicalKeyboardKey.escape, onDown: () {
@@ -77,6 +78,11 @@ class ShortcutManager {
     keyDispatcher.register(
       LogicalKeyboardKey.keyN,
       onDown: toggleMinimap,
+    );
+
+    keyDispatcher.register(
+      LogicalKeyboardKey.keyB,
+      onDown: toggleRangeRings,
     );
 
     keyDispatcher.register(LogicalKeyboardKey.keyQ, onDown: () {

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -215,6 +215,7 @@ class SpaceGame extends FlameGame
       toggleUpgrades: toggleUpgrades,
       toggleDebug: toggleDebug,
       toggleMinimap: toggleMinimap,
+      toggleRangeRings: toggleRangeRings,
       returnToMenu: returnToMenu,
     );
     stateMachine.returnToMenu();
@@ -342,8 +343,8 @@ class SpaceGame extends FlameGame
   }
 
   /// Toggles rendering of the player's range rings.
-  void toggleAutoAimRadius() {
-    player.toggleAutoAimRadius();
+  void toggleRangeRings() {
+    player.toggleRangeRings();
   }
 
   /// Shows or hides the runtime settings overlay.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -31,7 +31,7 @@ Flutter overlays and HUD widgets.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,
-  `U` opens upgrades, `N` toggles the minimap, and `Esc` also closes overlays
-  when visible.
+  `U` opens upgrades, `N` toggles the minimap, `B` toggles range rings, and
+  `Esc` also closes overlays when visible.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -34,7 +34,7 @@ class HelpOverlay extends StatelessWidget {
               'Mute: M\n'
               'Toggle Minimap: N or HUD button\n'
               'Toggle Debug: F1\n'
-              'Auto-aim Radius: Target Button\n'
+              'Toggle Range Rings: B or HUD button\n'
               'Upgrades: U or HUD button\n'
               'Settings: HUD button\n'
               'Pause/Resume: Esc or P\n'

--- a/lib/ui/help_overlay.md
+++ b/lib/ui/help_overlay.md
@@ -8,6 +8,6 @@ Lists available touch and keyboard controls.
 - Activated via the `H` key or help buttons on other overlays.
 - Pauses gameplay when opened during a run and resumes when closed.
 - Dismiss with the on-screen close button or by pressing `H` again or `Esc`.
-- Lists the `N` key for toggling the minimap.
+- Lists the `N` key for toggling the minimap and `B` for range rings.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -81,14 +81,14 @@ class HudOverlay extends StatelessWidget {
                     child: Wrap(
                       alignment: WrapAlignment.end,
                       children: [
-                        // Shows or hides targeting, tractor and mining range rings.
+                        // Shows or hides targeting, tractor and mining range rings (also via "B").
                         IconButton(
                           iconSize: iconSize,
                           icon: Icon(
                             Icons.gps_fixed,
                             color: Theme.of(context).colorScheme.onSurface,
                           ),
-                          onPressed: game.toggleAutoAimRadius,
+                          onPressed: game.toggleRangeRings,
                         ),
                         MinimapButton(game: game, iconSize: iconSize),
                         UpgradeButton(game: game, iconSize: iconSize),

--- a/lib/ui/hud_overlay.md
+++ b/lib/ui/hud_overlay.md
@@ -16,6 +16,7 @@ Heads-up display shown during play.
 - `Escape` or `P` keys also pause or resume.
 - Press `R` to restart the current run without using on-screen buttons.
 - Press `N` to toggle the minimap without tapping the icon.
+- Press `B` to toggle range rings without tapping the icon.
 - Visible in the `playing` and `paused` states.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/test/player_range_rings_toggle_test.dart
+++ b/test/player_range_rings_toggle_test.dart
@@ -54,10 +54,10 @@ void main() {
     final game = _TestGame(storage: storage, audio: audio);
     await game.onLoad();
 
-    expect(game.player.showAutoAimRadius, isFalse);
-    game.toggleAutoAimRadius();
-    expect(game.player.showAutoAimRadius, isTrue);
-    game.toggleAutoAimRadius();
-    expect(game.player.showAutoAimRadius, isFalse);
+    expect(game.player.showRangeRings, isFalse);
+    game.toggleRangeRings();
+    expect(game.player.showRangeRings, isTrue);
+    game.toggleRangeRings();
+    expect(game.player.showRangeRings, isFalse);
   });
 }

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -98,6 +98,7 @@ class _Harness {
       toggleUpgrades: () => upgradesCalled = true,
       toggleDebug: () => debugCalled = true,
       toggleMinimap: () => minimapCalled = true,
+      toggleRangeRings: () => rangeRingsCalled = true,
       returnToMenu: () => menuCalled = true,
     );
   }
@@ -112,6 +113,7 @@ class _Harness {
   bool upgradesCalled = false;
   bool debugCalled = false;
   bool minimapCalled = false;
+  bool rangeRingsCalled = false;
   bool menuCalled = false;
 
   void press(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) {
@@ -213,6 +215,12 @@ void main() {
       final h = _Harness();
       h.press(LogicalKeyboardKey.keyN, PhysicalKeyboardKey.keyN);
       expect(h.minimapCalled, isTrue);
+    });
+
+    test('B toggles range rings', () {
+      final h = _Harness();
+      h.press(LogicalKeyboardKey.keyB, PhysicalKeyboardKey.keyB);
+      expect(h.rangeRingsCalled, isTrue);
     });
 
     test('Q returns to menu from pause or game over', () {


### PR DESCRIPTION
## Summary
- add `B` key shortcut to toggle targeting, tractor and mining range rings
- rename auto-aim radius helpers to range ring terminology
- document new shortcut across help text, README, plan and checklist

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bbc03829608330acf63c0a836fb2e7