### PR TITLE
feat: persist purchased upgrades

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,8 +117,9 @@ tree spanning weapons and ship systems.
 - `settings_service.dart` holds tweakable UI and text scale values and gameplay
   range multipliers.
 - `targeting_service.dart` assists auto-aim queries.
-- `upgrade_service.dart` manages purchasing upgrades with minerals and exposes
-  a `ValueListenable` for bought upgrade ids.
+- `upgrade_service.dart` manages purchasing upgrades with minerals, persists
+  them via `StorageService` and exposes a `ValueListenable` for bought upgrade
+  ids.
 - Add services only when needed to keep the project lightweight.
 
 ## State and Data
@@ -153,8 +154,8 @@ tree spanning weapons and ship systems.
 - On player death, a game over overlay appears with restart, menu and mute buttons.
 - A help overlay lists controls and can be toggled with the `H` key, pausing the
   game when opened mid-run. `Esc` also closes it without triggering pause.
-- An upgrades overlay (placeholder) opens with the `U` key or HUD button and
-  pauses gameplay until dismissed.
+- An upgrades overlay opens with the `U` key or HUD button and pauses gameplay
+  while letting players buy basic upgrades that persist between sessions.
 - A settings overlay provides sliders for HUD, text, joystick, targeting,
   Tractor Aura and mining ranges.
 - A `GameState` enum tracks the current phase.

--- a/PLAN.md
+++ b/PLAN.md
@@ -177,8 +177,9 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   menu or game over, `R` restarts at any time, `H` shows a help overlay that
   `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes, `B`
   toggles range rings)
-- Upgrades overlay placeholder opened with a HUD button or the `U` key and
-  pausing gameplay for future ship upgrades
+- Upgrades overlay lets players spend minerals on simple upgrades that
+  persist between sessions, opened with a HUD button or the `U` key and
+  pausing gameplay
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
   and mining ranges
 - Game works offline after the first load thanks to the service worker

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ dedicated server or NAT traversal.
   collision and minerals increase when collecting pickups from mined asteroids
 - Toggable top-left minimap shows nearby asteroids, enemies and pickups
 - HUD button or `B` key toggles coloured range rings showing targeting, Tractor Aura and mining radii
-- Placeholder upgrades overlay accessible via a HUD button or the `U` key
+- Upgrades overlay lets you buy simple upgrades with minerals that persist
+  between sessions, accessible via a HUD button or the `U` key
 - Settings overlay adjusts HUD, text and joystick scale
 - Menu allows choosing between multiple ship sprites and remembers the selection
 - Local high score stored on device using `shared_preferences`

--- a/TASKS.md
+++ b/TASKS.md
@@ -73,10 +73,13 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Audio volume lowers when the game is paused.
 - [x] Menu includes button to reset the high score.
 - [x] Menu allows choosing between multiple ship sprites and persists the selection.
-- [x] Upgrades overlay placeholder accessible via HUD button or the `U` key.
+- [x] Upgrades overlay accessible via HUD button or the `U` key where purchases
+      persist across sessions.
 - [x] HUD button or `B` key toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text, joystick, targeting,
       Tractor Aura and mining ranges.
+
+- [x] Persist purchased upgrades across sessions using `StorageService`.
 
 ## Next Steps
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -62,7 +62,10 @@ class SpaceGame extends FlameGame
     debugMode = kDebugMode;
     pools = createPoolManager();
     targetingService = TargetingService(eventBus);
-    upgradeService = UpgradeService(scoreService: scoreService);
+    upgradeService = UpgradeService(
+      scoreService: scoreService,
+      storageService: storageService,
+    );
   }
 
   /// Handles persistence for the high score.

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -10,8 +10,9 @@ Optional helpers for cross-cutting concerns.
 - `overlay_service.dart` shows and hides overlays on the `GameWidget`.
 - `settings_service.dart` holds UI scale values and gameplay ranges.
 - `targeting_service.dart` assists auto-aim queries.
-- `upgrade_service.dart` manages purchasing upgrades with minerals and
-  derives gameplay modifiers like fire rate and mining speed.
+- `upgrade_service.dart` manages purchasing upgrades with minerals,
+  persists bought upgrades via `StorageService`, and derives gameplay modifiers
+  like fire rate and mining speed.
 - Keep services lightweight; add them only when a milestone needs them.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -74,4 +74,13 @@ class StorageService {
   Future<void> setInt(String key, int value) async {
     await _prefs.setInt(key, value);
   }
+
+  /// Retrieves a list of strings for [key] or returns [defaultValue] if unset.
+  List<String> getStringList(String key, List<String> defaultValue) =>
+      _prefs.getStringList(key) ?? defaultValue;
+
+  /// Persists a list of strings [value] for [key].
+  Future<void> setStringList(String key, List<String> value) async {
+    await _prefs.setStringList(key, value);
+  }
 }

--- a/lib/services/upgrade_service.dart
+++ b/lib/services/upgrade_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../constants.dart';
 import 'score_service.dart';
+import 'storage_service.dart';
 
 /// Simple upgrade data.
 class Upgrade {
@@ -14,9 +15,15 @@ class Upgrade {
 
 /// Handles purchasing upgrades with minerals.
 class UpgradeService {
-  UpgradeService({required this.scoreService});
+  UpgradeService({required this.scoreService, required this.storageService}) {
+    final saved = storageService.getStringList(_purchasedUpgradesKey, []);
+    _purchased.value = saved.toSet();
+  }
 
   final ScoreService scoreService;
+  final StorageService storageService;
+
+  static const _purchasedUpgradesKey = 'purchasedUpgrades';
 
   final List<Upgrade> upgrades = [
     Upgrade(id: 'fireRate1', name: 'Faster Cannon', cost: 10),
@@ -58,6 +65,10 @@ class UpgradeService {
     scoreService.addMinerals(-upgrade.cost);
     final newSet = Set<String>.from(_purchased.value)..add(upgrade.id);
     _purchased.value = newSet;
+    storageService.setStringList(
+      _purchasedUpgradesKey,
+      _purchased.value.toList(),
+    );
     return true;
   }
 }

--- a/lib/services/upgrade_service.md
+++ b/lib/services/upgrade_service.md
@@ -6,6 +6,7 @@ Manages purchasing upgrades using collected minerals.
 
 - Expose a list of available upgrades with ids, names and costs.
 - Track which upgrades have been purchased.
+- Persist purchased upgrades via `StorageService` so they survive app restarts.
 - Deduct mineral costs via `ScoreService` when buying.
 - Provide a `ValueListenable` of purchased upgrade ids for UI widgets.
 - Provide derived values like bullet cooldown and mining pulse interval based

--- a/test/upgrade_effects_test.dart
+++ b/test/upgrade_effects_test.dart
@@ -13,7 +13,10 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
-    final service = UpgradeService(scoreService: score);
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+    );
     final upgrade = service.upgrades.firstWhere((u) => u.id == 'fireRate1');
     expect(service.bulletCooldown, Constants.bulletCooldown);
     score.addMinerals(upgrade.cost);
@@ -25,7 +28,10 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
-    final service = UpgradeService(scoreService: score);
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+    );
     final upgrade = service.upgrades.firstWhere((u) => u.id == 'miningSpeed1');
     expect(service.miningPulseInterval, Constants.miningPulseInterval);
     score.addMinerals(upgrade.cost);

--- a/test/upgrade_service_test.dart
+++ b/test/upgrade_service_test.dart
@@ -12,7 +12,10 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
-    final service = UpgradeService(scoreService: score);
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+    );
     score.addMinerals(20);
     final upgrade = service.upgrades.first;
     final success = service.buy(upgrade);
@@ -25,10 +28,33 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
-    final service = UpgradeService(scoreService: score);
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+    );
     final upgrade = service.upgrades.first;
     final success = service.buy(upgrade);
     expect(success, isFalse);
     expect(score.minerals.value, 0);
+  });
+
+  test('purchased upgrades persist to storage', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+    );
+    final upgrade = service.upgrades.first;
+    score.addMinerals(upgrade.cost);
+    service.buy(upgrade);
+
+    final score2 = ScoreService(storageService: storage);
+    final service2 = UpgradeService(
+      scoreService: score2,
+      storageService: storage,
+    );
+    expect(service2.isPurchased(upgrade.id), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- persist purchased upgrades via StorageService
- expose string list helpers on StorageService
- document upgrade persistence and update tasks

## Testing
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bbc63a3a2c8330a75046c5d07c8b4c