### PR TITLE
Clamp persisted player sprite index

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flame/components.dart';
@@ -50,14 +51,21 @@ class SpaceGame extends FlameGame
     GameColors? gameColors,
     SettingsService? settingsService,
     FocusNode? focusNode,
-  })  : selectedPlayerIndex =
-            ValueNotifier<int>(storageService.getPlayerSpriteIndex()),
+  })  : selectedPlayerIndex = ValueNotifier<int>(
+          storageService
+              .getPlayerSpriteIndex()
+              .clamp(0, Assets.players.length - 1),
+        ),
         colorScheme =
             colorScheme ?? ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         gameColors = gameColors ?? GameColors.dark,
         settingsService = settingsService ?? SettingsService(),
         focusNode = focusNode ?? FocusNode(),
         scoreService = ScoreService(storageService: storageService) {
+    final storedIndex = storageService.getPlayerSpriteIndex();
+    if (storedIndex != selectedPlayerIndex.value) {
+      unawaited(storageService.setPlayerSpriteIndex(selectedPlayerIndex.value));
+    }
     this.settingsService.attachStorage(storageService);
     debugMode = kDebugMode;
     pools = createPoolManager();


### PR DESCRIPTION
## Summary
- guard against invalid stored player index by clamping to available sprites
- persist corrected index if needed

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc655745483308af6c7f7dfa4a8dd