### PR TITLE
Fix joypad scaling and sync fire button size

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -169,11 +169,11 @@ class SpaceGame extends FlameGame
     await add(laser);
 
     final upButton = CircleComponent(
-      radius: 30 * settingsService.hudButtonScale.value,
+      radius: 30 * settingsService.joystickScale.value,
       paint: Paint()..color = colorScheme.primary.withValues(alpha: 0.4),
     );
     final downButton = CircleComponent(
-      radius: 30 * settingsService.hudButtonScale.value,
+      radius: 30 * settingsService.joystickScale.value,
       paint: Paint()..color = colorScheme.primary,
     );
     fireButton = HudButtonComponent(
@@ -221,7 +221,6 @@ class SpaceGame extends FlameGame
     stateMachine.returnToMenu();
 
     settingsService.joystickScale.addListener(_updateJoystickScale);
-    settingsService.hudButtonScale.addListener(_updateHudButtonScale);
     _isLoaded = true;
   }
 
@@ -369,19 +368,22 @@ class SpaceGame extends FlameGame
         paint: Paint()..color = scheme.primary.withValues(alpha: 0.4),
       ),
       margin: const EdgeInsets.only(left: 40, bottom: 40),
-    );
+    )..anchor = Anchor.bottomLeft;
   }
 
   void _updateJoystickScale() {
     final scale = settingsService.joystickScale.value;
-    (joystick.knob as CircleComponent).radius = 20 * scale;
-    (joystick.background as CircleComponent).radius = 50 * scale;
-  }
+    // Rebuild the joystick to ensure the knob stays centred and scaling
+    // expands from the bottom-left corner.
+    joystick.removeFromParent();
+    joystick = _buildJoystick();
+    add(joystick);
+    joystick.onGameResize(size);
 
-  void _updateHudButtonScale() {
-    final scale = settingsService.hudButtonScale.value;
+    // Scale the fire button to match the joystick.
     (fireButton.button as CircleComponent).radius = 30 * scale;
     (fireButton.buttonDown as CircleComponent).radius = 30 * scale;
+    fireButton.onGameResize(size);
   }
 
   /// Ensures the camera stays centred on the player.

--- a/test/joystick_fire_button_scale_test.dart
+++ b/test/joystick_fire_button_scale_test.dart
@@ -1,0 +1,48 @@
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/material.dart';
+
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/game_over_overlay.dart';
+import 'package:space_game/ui/help_overlay.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+import 'package:space_game/ui/settings_overlay.dart';
+import 'package:space_game/ui/upgrades_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('joystick scale updates fire button and keeps bottom-left anchor',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays
+      ..addEntry(MenuOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(HudOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(PauseOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(GameOverOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(SettingsOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(HelpOverlay.id, (_, __) => const SizedBox())
+      ..addEntry(UpgradesOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2(800, 600));
+    await game.ready();
+
+    game.settingsService.joystickScale.value = 1.2;
+    await Future<void>.delayed(Duration.zero);
+
+    final bg = game.joystick.background as CircleComponent;
+    final fire = game.fireButton.button as CircleComponent;
+    expect(bg.radius, 50 * 1.2);
+    expect(fire.radius, 30 * 1.2);
+    expect(game.joystick.position.x, 40);
+    expect(game.joystick.position.y, game.size.y - 40);
+  });
+}


### PR DESCRIPTION
## Summary
- Anchor joystick to bottom-left and rebuild on scale to keep knob centered
- Scale fire button using joystick setting
- Test joystick and fire button scaling

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc75b1cb4833090b9b48c50b92969