### PR TITLE
feat: add settings reset and service docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -157,7 +157,7 @@ tree spanning weapons and ship systems.
 - An upgrades overlay opens with the `U` key or HUD button and pauses gameplay
   while letting players buy basic upgrades that persist between sessions.
 - A settings overlay provides sliders for HUD, text, joystick, targeting,
-  Tractor Aura and mining ranges.
+  Tractor Aura and mining ranges and includes a reset button.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -181,7 +181,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   persist between sessions, opened with a HUD button or the `U` key and
   pausing gameplay
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
-  and mining ranges
+  and mining ranges, plus a reset button
 - Game works offline after the first load thanks to the service worker
 - Simple parallax starfield background
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -39,7 +39,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it
 - [ ] Settings overlay sliders adjust HUD button, minimap, text, joystick sizes
-      and gameplay ranges (default 0.75 for buttons and text)
+      and gameplay ranges (default 0.75 for buttons and text) and reset button
+      restores defaults
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ dedicated server or NAT traversal.
 - HUD button or `B` key toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Upgrades overlay lets you buy simple upgrades with minerals that persist
   between sessions, accessible via a HUD button or the `U` key
-- Settings overlay adjusts HUD, text and joystick scale
+- Settings overlay adjusts HUD, minimap, text and joystick scales and gameplay
+  ranges, and includes a reset button
 - Menu allows choosing between multiple ship sprites and remembers the selection
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over

--- a/TASKS.md
+++ b/TASKS.md
@@ -77,7 +77,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       persist across sessions.
 - [x] HUD button or `B` key toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with sliders for HUD, text, joystick, targeting,
-      Tractor Aura and mining ranges.
+      Tractor Aura and mining ranges, plus reset button.
 
 - [x] Persist purchased upgrades across sessions using `StorageService`.
 

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -8,7 +8,8 @@ Optional helpers for cross-cutting concerns.
   `shared_preferences`.
 - `score_service.dart` tracks score, minerals and health values.
 - `overlay_service.dart` shows and hides overlays on the `GameWidget`.
-- `settings_service.dart` holds UI scale values and gameplay ranges.
+- `settings_service.dart` holds UI scale values and gameplay ranges and can
+  reset them to defaults.
 - `targeting_service.dart` assists auto-aim queries.
 - `upgrade_service.dart` manages purchasing upgrades with minerals,
   persists bought upgrades via `StorageService`, and derives gameplay modifiers

--- a/lib/services/overlay_service.md
+++ b/lib/services/overlay_service.md
@@ -1,0 +1,11 @@
+# OverlayService
+
+Manages showing and hiding Flutter overlays on the `GameWidget`.
+
+## Responsibilities
+
+- Swap between menu, HUD, pause, game over, upgrades and settings overlays.
+- Show or hide help and pause overlays without affecting others.
+- Keep overlay identifiers centralised.
+
+See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/services/score_service.md
+++ b/lib/services/score_service.md
@@ -1,0 +1,11 @@
+# ScoreService
+
+Tracks score, minerals, health and high score persistence.
+
+## Responsibilities
+
+- Expose `ValueNotifier`s for score, high score, minerals and health.
+- Update totals when the player scores, mines or takes damage.
+- Persist and reset the local high score via `StorageService`.
+
+See [../../PLAN.md](../../PLAN.md) for core loop and polish goals.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -94,6 +94,17 @@ class SettingsService {
     miningRange.value = storage.getDouble(_miningRangeKey, miningRange.value);
   }
 
+  /// Restores all values to their defaults.
+  void reset() {
+    hudButtonScale.value = defaultHudButtonScale;
+    textScale.value = defaultTextScale;
+    joystickScale.value = defaultJoystickScale;
+    minimapScale.value = defaultMinimapScale;
+    targetingRange.value = Constants.playerAutoAimRange;
+    tractorRange.value = Constants.playerTractorAuraRadius;
+    miningRange.value = Constants.playerMiningRange;
+  }
+
   static const _hudScaleKey = 'hudButtonScale';
   static const _textScaleKey = 'textScale';
   static const _joystickScaleKey = 'joystickScale';

--- a/lib/services/settings_service.md
+++ b/lib/services/settings_service.md
@@ -1,0 +1,12 @@
+# SettingsService
+
+Stores tweakable UI scales and gameplay ranges with persistence.
+
+## Responsibilities
+
+- Hold `ValueNotifier`s for HUD, minimap, text and joystick scales.
+- Track targeting, Tractor Aura and mining ranges.
+- Persist changes via `StorageService` and reload on startup.
+- Provide `reset()` to restore default values for all settings.
+
+See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/lib/services/targeting_service.md
+++ b/lib/services/targeting_service.md
@@ -1,0 +1,10 @@
+# TargetingService
+
+Tracks key targets like the player for auto-aim queries.
+
+## Responsibilities
+
+- Listen for spawn and remove events to track the player component.
+- Expose the current player position for systems needing targeting.
+
+See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -27,7 +27,7 @@ Flutter overlays and HUD widgets.
 - [UpgradesOverlay](upgrades_overlay.md) – lists purchasable ship upgrades;
   opened with `U` and pauses gameplay.
 - [SettingsOverlay](settings_overlay.md) – adjust HUD, minimap, text, joystick
-  scale and gameplay ranges; opened via HUD button.
+  scale and gameplay ranges, with a reset button; opened via HUD button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -93,6 +93,14 @@ class SettingsOverlay extends StatelessWidget {
                   ),
                   SizedBox(height: spacing),
                   ElevatedButton(
+                    onPressed: settings.reset,
+                    child: const GameText(
+                      'Reset',
+                      maxLines: 1,
+                    ),
+                  ),
+                  SizedBox(height: spacing),
+                  ElevatedButton(
                     onPressed: game.toggleSettings,
                     child: const GameText(
                       'Close',

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -8,5 +8,6 @@ Overlay providing runtime UI scaling and range controls.
 - Bordered layout limits width on large screens for clarity.
 - Opens from the HUD; closing returns to the game.
 - Overlay remains transparent so adjustments can be viewed immediately.
+- Reset button restores default values for all sliders.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -14,6 +14,8 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Simple HUD and menus layered with Flutter overlays.
 - [x] Menu allows choosing between multiple ship sprites and persists the selection.
 - [x] Option to mute or dim audio when the game is paused.
+- [x] Settings overlay with sliders for HUD, minimap, text, joystick, targeting,
+      Tractor Aura and mining ranges, plus reset button.
 
 ## Design Notes
 

--- a/test/settings_overlay_test.dart
+++ b/test/settings_overlay_test.dart
@@ -6,6 +6,7 @@ import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
 import 'package:space_game/ui/settings_overlay.dart';
+import 'package:space_game/services/settings_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -29,5 +30,26 @@ void main() {
     await tester.drag(slider, const Offset(50, 0));
     await tester.pump();
     expect(game.settingsService.hudButtonScale.value, isNot(initial));
+  });
+
+  testWidgets('reset button restores defaults', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final view = tester.view;
+    view.physicalSize = const Size(800, 1200);
+    view.devicePixelRatio = 1;
+    addTearDown(view.resetPhysicalSize);
+    addTearDown(view.resetDevicePixelRatio);
+
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.settingsService.hudButtonScale.value = 1.2;
+
+    await tester.pumpWidget(MaterialApp(home: SettingsOverlay(game: game)));
+    await tester.tap(find.text('Reset'));
+    await tester.pump();
+
+    expect(game.settingsService.hudButtonScale.value,
+        SettingsService.defaultHudButtonScale);
   });
 }

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -64,6 +64,28 @@ void main() {
     expect(settings.miningRange.value, 180);
   });
 
+  test('reset restores default values', () {
+    final settings = SettingsService();
+    settings.hudButtonScale.value = 1.2;
+    settings.minimapScale.value = 1.3;
+    settings.textScale.value = 1.8;
+    settings.joystickScale.value = 1.4;
+    settings.targetingRange.value = 400;
+    settings.tractorRange.value = 300;
+    settings.miningRange.value = 200;
+
+    settings.reset();
+
+    expect(
+        settings.hudButtonScale.value, SettingsService.defaultHudButtonScale);
+    expect(settings.minimapScale.value, SettingsService.defaultMinimapScale);
+    expect(settings.textScale.value, SettingsService.defaultTextScale);
+    expect(settings.joystickScale.value, SettingsService.defaultJoystickScale);
+    expect(settings.targetingRange.value, Constants.playerAutoAimRange);
+    expect(settings.tractorRange.value, Constants.playerTractorAuraRadius);
+    expect(settings.miningRange.value, Constants.playerMiningRange);
+  });
+
   test('values persist across sessions', () async {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();


### PR DESCRIPTION
## Summary
- add SettingsService.reset and reset button in SettingsOverlay
- document overlay, score, settings and targeting services
- update design docs and tasks for settings reset option

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bcfa2b1d64833083004af21b03a52b