### PR TITLE
Test upgrade ranges and audio persistence

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -24,6 +24,10 @@ class Constants {
   /// Maximum distance to auto-aim enemies when stationary, in pixels.
   static const double playerAutoAimRange = 300;
 
+  /// Multiplier applied to [playerAutoAimRange] when the targeting range
+  /// upgrade is purchased.
+  static const double targetingRangeUpgradeFactor = 1.5;
+
   /// Maximum distance to auto-mine asteroids, in pixels.
   static const double playerMiningRange = playerAutoAimRange;
 
@@ -51,6 +55,10 @@ class Constants {
 
   /// Radius of the player's Tractor Aura in pixels.
   static const double playerTractorAuraRadius = 150;
+
+  /// Multiplier applied to [playerTractorAuraRadius] when the Tractor Aura
+  /// range upgrade is purchased.
+  static const double tractorRangeUpgradeFactor = 1.5;
 
   /// Speed pickups move toward the player within the Tractor Aura.
   static const double tractorAuraPullSpeed = 200;

--- a/lib/services/audio_service.md
+++ b/lib/services/audio_service.md
@@ -6,8 +6,9 @@ Lightweight wrapper around `flame_audio`.
 
 - Preload sound effect clips during game startup.
 - Play one-shot effects for actions like shooting or explosions.
-- Expose a mute toggle persisted via `StorageService`.
-- Provide simple methods like `playShoot()` or `playExplosion()`.
+- Expose a mute toggle and master volume persisted via `StorageService`.
+- Provide simple methods like `playShoot()`, `playExplosion()` and
+  `stopAll()` to halt loops.
 - Reuse the shoot sound via a web-only `AudioPool` to avoid network
   fetches on rapid fire.
 

--- a/lib/services/upgrade_service.dart
+++ b/lib/services/upgrade_service.dart
@@ -28,6 +28,8 @@ class UpgradeService {
   final List<Upgrade> upgrades = [
     Upgrade(id: 'fireRate1', name: 'Faster Cannon', cost: 10),
     Upgrade(id: 'miningSpeed1', name: 'Efficient Mining', cost: 15),
+    Upgrade(id: 'targetingRange1', name: 'Targeting Computer', cost: 20),
+    Upgrade(id: 'tractorRange1', name: 'Tractor Booster', cost: 25),
   ];
 
   final ValueNotifier<Set<String>> _purchased =
@@ -55,6 +57,24 @@ class UpgradeService {
       interval *= Constants.miningPulseIntervalUpgradeFactor;
     }
     return interval;
+  }
+
+  /// Current auto-aim targeting range factoring in purchased upgrades.
+  double get targetingRange {
+    var range = Constants.playerAutoAimRange;
+    if (isPurchased('targetingRange1')) {
+      range *= Constants.targetingRangeUpgradeFactor;
+    }
+    return range;
+  }
+
+  /// Current Tractor Aura radius factoring in purchased upgrades.
+  double get tractorRange {
+    var range = Constants.playerTractorAuraRadius;
+    if (isPurchased('tractorRange1')) {
+      range *= Constants.tractorRangeUpgradeFactor;
+    }
+    return range;
   }
 
   /// Attempts to buy [upgrade], returning `true` on success.

--- a/lib/services/upgrade_service.md
+++ b/lib/services/upgrade_service.md
@@ -9,7 +9,7 @@ Manages purchasing upgrades using collected minerals.
 - Persist purchased upgrades via `StorageService` so they survive app restarts.
 - Deduct mineral costs via `ScoreService` when buying.
 - Provide a `ValueListenable` of purchased upgrade ids for UI widgets.
-- Provide derived values like bullet cooldown and mining pulse interval based
-  on purchased upgrades.
+- Provide derived values like bullet cooldown, mining pulse interval, targeting
+  range and Tractor Aura radius based on purchased upgrades.
 
 See [../../PLAN.md](../../PLAN.md) for progression goals.

--- a/test/audio_service_test.dart
+++ b/test/audio_service_test.dart
@@ -57,6 +57,33 @@ void main() {
     await service.startMiningLaser();
     expect(service.miningLoop, isNull);
   });
+
+  test('master volume persists across sessions', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    var service = await AudioService.create(storage);
+    service.setMasterVolume(0.3);
+
+    service = await AudioService.create(storage);
+    expect(service.masterVolume, closeTo(0.3, 1e-9));
+  });
+
+  test('stopAll halts active loops', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final player = _FakeAudioPlayer();
+    final service = await AudioService.create(
+      storage,
+      loop: (_, {double volume = 1}) async => player,
+    );
+
+    await service.startMiningLaser();
+    expect(service.miningLoop, isNotNull);
+
+    service.stopAll();
+    expect(player.stopped, isTrue);
+    expect(service.miningLoop, isNull);
+  });
 }
 
 class _FakeAudioPlayer implements AudioPlayer {

--- a/test/upgrade_effects_test.dart
+++ b/test/upgrade_effects_test.dart
@@ -39,4 +39,36 @@ void main() {
     expect(
         service.miningPulseInterval, lessThan(Constants.miningPulseInterval));
   });
+
+  test('Targeting Computer increases auto-aim range', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+    );
+    final upgrade =
+        service.upgrades.firstWhere((u) => u.id == 'targetingRange1');
+    expect(service.targetingRange, Constants.playerAutoAimRange);
+    score.addMinerals(upgrade.cost);
+    service.buy(upgrade);
+    expect(service.targetingRange, greaterThan(Constants.playerAutoAimRange));
+  });
+
+  test('Tractor Booster extends Tractor Aura radius', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+    );
+    final upgrade = service.upgrades.firstWhere((u) => u.id == 'tractorRange1');
+    expect(service.tractorRange, Constants.playerTractorAuraRadius);
+    score.addMinerals(upgrade.cost);
+    service.buy(upgrade);
+    expect(
+        service.tractorRange, greaterThan(Constants.playerTractorAuraRadius));
+  });
 }


### PR DESCRIPTION
## Summary
- add targeting and tractor range upgrades with service accessors
- persist AudioService master volume and test stopAll behavior
- expand upgrade and audio tests for new coverage

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd672053d8833086966fd5f4b6be92