### PR TITLE
docs: document event bus and pool manager

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -78,6 +78,10 @@ tree spanning weapons and ship systems.
 - It owns small system classes for input, physics/collisions, entity spawners
   and scoring. Hooks for resource mining, inventory, networking and save/load
   will slot in later milestones.
+- A lightweight `GameEventBus` broadcasts component spawn and remove events so
+  systems can react without direct references.
+- `PoolManager` reuses bullets, enemies, minerals and asteroids and keeps a
+  spatial grid of asteroids for efficient proximity queries.
 - Flutter overlays handle menus and the HUD so UI stays outside the game loop.
 - A shared `GameText` widget standardises overlay text styling and listens for
   global text scale changes.
@@ -91,6 +95,8 @@ tree spanning weapons and ship systems.
 
 - Player, enemy, asteroid and bullet components live under `lib/components/`.
 - Components mix in `HasGameReference<SpaceGame>` when they need game context.
+- The `SpawnRemoveEmitter` mixin fires events to the `GameEventBus` whenever a
+  component is added or removed, enabling pooling and targeting helpers.
 - Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and
   `HasCollisionDetection`.
 - An `EnemySpawner` system releases groups of enemies at timed intervals.

--- a/PLAN.md
+++ b/PLAN.md
@@ -149,6 +149,11 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple
   object pools to reduce garbage collection overhead
+- A lightweight `GameEventBus` emits component spawn and remove events so
+  systems like the targeting service and pool manager can react without
+  direct references
+- `PoolManager` owns these pools and keeps a spatial grid of asteroids for
+  efficient proximity queries
 - Movement and animations should be time‑based using `dt` to stay consistent
   across frame rates
 - Rely on Flame's `update`/`render` lifecycle; avoid custom game loops

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -12,6 +12,10 @@ Core game class and shared systems.
   - Input uses Flame's `JoystickComponent`, `ButtonComponent` and a
     custom `KeyDispatcher` (via `KeyboardHandler`) that supports helpers like
     `isAnyPressed` for grouped key queries.
+- Broadcasts component spawn and remove events through a lightweight
+  `GameEventBus` so systems can react without tight coupling.
+- `PoolManager` reuses bullets, enemies, minerals and asteroids while keeping
+  a spatial grid of rocks for quick proximity queries.
 - Hooks exist for resource mining, inventory, networking and save/load in later
   milestones.
 - Keep this layer lean and delegate work to components or services.
@@ -27,9 +31,11 @@ Core game class and shared systems.
 - Schedule the update tick and other timers.
 - Route input from joystick, fire button or keyboard to the player component.
 
-## Planned Files
+## Key Files
 
 - [space_game.dart](space_game.md) – main game class.
 - [game_state.dart](game_state.md) – enum describing the game's phases.
+- [event_bus.dart](event_bus.md) – typed hub for spawn/remove events.
+- [pool_manager.dart](pool_manager.md) – central object pools and spatial grid.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/game/event_bus.md
+++ b/lib/game/event_bus.md
@@ -1,0 +1,10 @@
+# event_bus.dart
+
+Lightweight synchronous event hub used by core game systems.
+
+- `GameEventBus` exposes `emit` and typed `on<T>()` helpers for broadcasting
+  events.
+- Components mix in `SpawnRemoveEmitter` so `ComponentSpawnEvent` and
+  `ComponentRemoveEvent` fire when they are added or removed.
+- `SpaceGame` creates a single bus instance and passes it to services like
+  `TargetingService` and `PoolManager` for decoupled communication.

--- a/lib/game/pool_manager.md
+++ b/lib/game/pool_manager.md
@@ -1,0 +1,11 @@
+# pool_manager.dart
+
+Central registry for reusable component pools and spatial queries.
+
+- Maintains pools for bullets, enemies, minerals and asteroids to minimise
+  allocations.
+- Listens to `ComponentRemoveEvent` on the `GameEventBus` to return objects to
+  their pools and invoke any cleanup hooks.
+- Tracks active asteroids in a small `SpatialGrid` so nearby rocks can be
+  queried efficiently.
+- Applies debug mode to all pooled objects when the game's debug flag changes.


### PR DESCRIPTION
## Summary
- Document the GameEventBus used for spawn/remove notifications
- Add PoolManager notes and reference the central spatial grid
- Update game docs and roadmap to include these systems

## Testing
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx -y markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bd6713b1b88330ac878c9523829fb4