### PR TITLE
chore: remove unnecessary test import

### DIFF
--- a/test/player_collision_test.dart
+++ b/test/player_collision_test.dart
@@ -1,5 +1,4 @@
 import 'package:flame/collisions.dart';
-import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame/flame.dart';
 import 'package:flame_audio/flame_audio.dart';


### PR DESCRIPTION
## Summary
- remove redundant Flame components import from player collision test

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6a8d71f88330bb747b41a7a222c2