### PR TITLE
docs: plan deterministic starfield background

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,7 +185,7 @@ tree spanning weapons and ship systems.
   `OffscreenCleanup` mixin. Asteroid and enemy spawners place new objects ahead
   of the player's current heading using this same radius so action stays in
   front of the ship.
-- A parallax starfield is tiled procedurally to appear endless.
+- A deterministic world-space starfield generates stars per chunk using Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex noise modulates density to create clusters and voids, and a cached `CustomPainter` renders small circle stars that stay static as the player moves.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -141,11 +141,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Keep Flutter UI widgets separate from game state updates
 - If saving is needed later, add IDs and JSON‑serializable state
   - Camera follows the player via `CameraComponent` with no world bounds,
-    and the parallax starfield tiles infinitely to avoid blank space
+    and the deterministic world-space starfield spans chunks to avoid blank space
 - Use `HasCollisionDetection` for collisions with simple `CircleHitbox`/`RectangleHitbox`
   shapes and a timer-based spawner
-- Top‑down view with a simple parallax starfield background using Flame's
-  `ParallaxComponent`
+- Top‑down view with a deterministic world-space starfield generated per chunk using Poisson-disk sampling seeded by chunk coordinates and modulated by Simplex noise, rendered with a cached `CustomPainter`
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple
   object pools to reduce garbage collection overhead
@@ -188,7 +187,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
   and mining ranges, plus a reset button
 - Game works offline after the first load thanks to the service worker
-- Simple parallax starfield background
+- Deterministic world-space starfield with Poisson-disk sampling and Simplex-noise clusters
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
   `P` to resume; `Q` returns to the menu from pause or game over
 
@@ -196,7 +195,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 
 - **Setup** – basic project scaffolding runs in the browser with placeholder assets
 - **Core Loop** – player moves and shoots, one enemy type, basic scoring
-- **Polish** – starfield background, sound effects, and local high score
+- **Polish** – deterministic world-space starfield, sound effects, and local high score
 
 Detailed tasks for each milestone live in
 [milestone-setup.md](milestone-setup.md),
@@ -260,7 +259,7 @@ the world beyond the viewport and have the camera track the ship.
 - Attach a `CameraComponent` that follows the player without clamping.
 - Continuously spawn asteroids, enemies and pickups ahead of the ship and
   despawn any far behind to keep the scene light.
-- Tile the parallax starfield or otherwise prevent gaps as the camera moves.
+- Generate and cache stars per world-space chunk so no gaps appear as the camera moves.
 - A small togglable minimap in the top-left aids navigation through the endless world.
 
 ## 🔮 Future Ideas

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -27,7 +27,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Selected ship persists between sessions
 - [ ] Enter starts or restarts from the menu or game over; `R` restarts at any time
 - [ ] Escape or `P` key pauses or resumes the game
-- [ ] Parallax starfield renders behind gameplay
+- [ ] Deterministic world-space starfield renders consistently behind gameplay
 - [ ] Sound effects play and can be muted from menu, HUD or game over overlay,
       or via the `M` key
 - [ ] Laser shot sound plays when firing

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dedicated server or NAT traversal.
   help overlay that `Esc` also closes, `U` opens an upgrades overlay that `Esc`
   also closes)
 - Game works offline after the first load
-- Parallax starfield background
+- Deterministic world-space starfield with Poisson-disk sampling and Simplex noise clustering
 
 ## 🔮 Future Plans
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -99,3 +99,4 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       far behind.
 - [x] Tile the parallax starfield so it scrolls seamlessly.
 - [x] Add a minimap or other navigation aid for exploring the larger world.
+- [ ] Update the background system to replace the player-following parallax starfield with a deterministic world-space starfield. Generate stars per chunk using Poisson-disk sampling seeded by chunk coordinates. Modulate density with Simplex noise for subtle clusters. Render stars as pinpoint circles of varying size and brightness with a cached CustomPainter so the player moves over a static field.

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -33,8 +33,7 @@ Gameplay entities and reusable pieces.
   damaged that increases the player's mineral total when picked up.
 - Each mineral independently homes toward the player when within the Tractor
   Aura, removing the need for a separate component.
-- [Starfield](starfield.md) – parallax background built with Flame's
-  `ParallaxComponent`.
+- [Starfield](starfield.md) – deterministic world-space background drawn with a cached `CustomPainter`.
 - [ExplosionComponent](explosion.md) – short animation and sound played when
   a ship is destroyed.
 

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -1,12 +1,10 @@
+
 # Starfield
 
-Background starfield using Flame's `ParallaxComponent`.
+Deterministic world-space starfield drawn with `CustomPainter`.
 
-- Generates three random star layers with speeds from `constants.dart` for
-  parallax depth.
-- Stars are rendered once into images and the parallax system manages scroll
-  and wrapping.
-- Recenters on the camera each frame to keep the starfield visible as the
-  player moves.
-- Added to `SpaceGame` with a negative priority so it always renders beneath
-  gameplay components.
+- Stars are generated per world-space chunk using Poisson-disk sampling seeded by chunk coordinates.
+- Low-frequency Simplex noise modulates spawn density to create clusters and voids.
+- Star radius and brightness follow a weighted distribution; subtle colour jitter adds variation.
+- Generated stars are cached per chunk and rendered as tiny circles so the player moves over a static field.
+- Added to `SpaceGame` with a negative priority so it always renders beneath gameplay components.

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -23,7 +23,7 @@ Core game class and shared systems.
 ## Responsibilities
 
 - Load assets via a central registry before starting play.
-- Configure the world, including the parallax starfield background and
+- Configure the world, including the deterministic world-space starfield and
   camera.
 - Spawn the player and register component spawners.
 - Maintain `GameState` values (`menu`, `playing`, `upgrades`, `paused`,

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -6,7 +6,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 ## Tasks
 
-- [x] Parallax starfield background renders behind gameplay.
+- [x] Deterministic world-space starfield background renders behind gameplay.
 - [x] Implement `audio_service.dart` wrapping `flame_audio` with a
       mute toggle.
 - [x] Implement `storage_service.dart` using `shared_preferences`
@@ -19,7 +19,7 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 ## Design Notes
 
-- A parallax starfield uses Flame's `ParallaxComponent` for the background.
+- Background stars are generated per world-space chunk using Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex noise modulates density for clusters and voids, and a cached `CustomPainter` draws small circle stars that stay static as the player moves.
 - Centralise audio assets in `assets.dart` and play them through a small
   audio service.
 - Persist the high score with `shared_preferences` using a lightweight storage


### PR DESCRIPTION
## Summary
- document deterministic world-space starfield replacing old parallax version
- outline Poisson-disk sampling, Simplex-noise density, and CustomPainter rendering
- add planning task for world-space starfield and update playtest checklist

## Testing
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bd6a53be208330967c0164a2c15388