### PR TITLE
docs: clarify deterministic starfield plan

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,7 +185,13 @@ tree spanning weapons and ship systems.
   `OffscreenCleanup` mixin. Asteroid and enemy spawners place new objects ahead
   of the player's current heading using this same radius so action stays in
   front of the ship.
-- A deterministic world-space starfield generates stars per chunk using Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex noise modulates density to create clusters and voids, and a cached `CustomPainter` renders small circle stars that stay static as the player moves.
+- A deterministic world-space starfield generates stars per chunk using
+  Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex
+  noise modulates density to create clusters and voids. Stars follow a weighted
+  size/brightness distribution with optional subtle colour jitter. A cached
+  `CustomPainter` translates by `-playerPosition`, draws faint-to-bright circles
+  and can cache layers with `PictureRecorder` if needed so the field stays
+  static as the player moves.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -144,7 +144,11 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
     and the deterministic world-space starfield spans chunks to avoid blank space
 - Use `HasCollisionDetection` for collisions with simple `CircleHitbox`/`RectangleHitbox`
   shapes and a timer-based spawner
-- Top‑down view with a deterministic world-space starfield generated per chunk using Poisson-disk sampling seeded by chunk coordinates and modulated by Simplex noise, rendered with a cached `CustomPainter`
+- Top‑down view with a deterministic world-space starfield generated per chunk
+  via Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex
+  noise modulates density for clusters, and a cached `CustomPainter` draws
+  faint-to-bright circle stars based on a weighted size/brightness distribution
+  with subtle colour jitter.
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple
   object pools to reduce garbage collection overhead
@@ -187,7 +191,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
   and mining ranges, plus a reset button
 - Game works offline after the first load thanks to the service worker
-- Deterministic world-space starfield with Poisson-disk sampling and Simplex-noise clusters
+- Deterministic world-space starfield seeded by chunk coordinates using
+  Poisson-disk sampling. Density varies with Simplex noise; stars use a
+  weighted size/brightness spread and optional colour jitter and are drawn by a
+  cached `CustomPainter` so the player moves over a static field.
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
   `P` to resume; `Q` returns to the menu from pause or game over
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ dedicated server or NAT traversal.
   help overlay that `Esc` also closes, `U` opens an upgrades overlay that `Esc`
   also closes)
 - Game works offline after the first load
-- Deterministic world-space starfield with Poisson-disk sampling and Simplex noise clustering
+- Deterministic world-space starfield seeded by chunk coordinates using
+  Poisson-disk sampling. Simplex noise modulates density for clusters, and
+  stars use a weighted size/brightness spread with subtle colour jitter,
+  rendered via a cached `CustomPainter` so the player moves over a static field
+  with consistent spacing.
 
 ## 🔮 Future Plans
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -99,4 +99,4 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       far behind.
 - [x] Tile the parallax starfield so it scrolls seamlessly.
 - [x] Add a minimap or other navigation aid for exploring the larger world.
-- [ ] Update the background system to replace the player-following parallax starfield with a deterministic world-space starfield. Generate stars per chunk using Poisson-disk sampling seeded by chunk coordinates. Modulate density with Simplex noise for subtle clusters. Render stars as pinpoint circles of varying size and brightness with a cached CustomPainter so the player moves over a static field.
+- [ ] Update the background system to replace the player-following parallax starfield with a deterministic world-space starfield. Generate stars per chunk using Poisson-disk sampling seeded by chunk coordinates. Modulate density with Simplex noise for subtle clusters. Render stars as pinpoint circles of varying size/brightness with CustomPainter, cached per chunk. The player moves over this static starfield, ensuring consistent, realistic spacing and density patterns.

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -3,8 +3,16 @@
 
 Deterministic world-space starfield drawn with `CustomPainter`.
 
-- Stars are generated per world-space chunk using Poisson-disk sampling seeded by chunk coordinates.
-- Low-frequency Simplex noise modulates spawn density to create clusters and voids.
-- Star radius and brightness follow a weighted distribution; subtle colour jitter adds variation.
-- Generated stars are cached per chunk and rendered as tiny circles so the player moves over a static field.
-- Added to `SpaceGame` with a negative priority so it always renders beneath gameplay components.
+- Stars are generated per chunk using Poisson-disk sampling seeded by the
+  `(chunkX, chunkY)` coordinates so results are reproducible.
+- A weighted radius/brightness distribution (≈80% tiny, 19% small, 1% medium)
+  gives variation; an optional subtle blue/yellow colour jitter adds depth.
+- Low-frequency Simplex noise modulates spawn probability for soft clusters and
+  voids.
+- Star data is cached per chunk. When rendering, the painter translates by
+  `-playerPosition` and draws circles via `canvas.drawCircle`, iterating from
+  faint to bright for gentle blending.
+- If rendering cost spikes, cache layers with `PictureRecorder` or
+  `Canvas.saveLayer`.
+- Added to `SpaceGame` with a negative priority so it always renders beneath
+  gameplay components.

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -5,8 +5,9 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 ## Responsibilities
 
 - Preload assets via the central registry before entering gameplay.
-- Configure the parallax background, set up a fixed-resolution camera that
-  follows the player via `camera.follow`, and register component spawners.
+- Initialise the deterministic world-space starfield, set up a fixed-resolution
+  camera that follows the player via `camera.follow`, and register component
+  spawners.
 - Spawn the player and register enemy or asteroid generators.
 - Provide small bullet, asteroid, enemy and mineral pickup pools to limit allocations.
 - Maintain `GameState` values (`menu`, `playing`, `paused`, `gameOver`)

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -19,7 +19,13 @@ See [PLAN.md](PLAN.md) for overall project goals and
 
 ## Design Notes
 
-- Background stars are generated per world-space chunk using Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex noise modulates density for clusters and voids, and a cached `CustomPainter` draws small circle stars that stay static as the player moves.
+- Background stars are generated per world-space chunk using Poisson-disk
+  sampling seeded by chunk coordinates. Low-frequency Simplex noise modulates
+  density for clusters and voids. Stars follow a weighted radius/brightness
+  distribution with subtle colour jitter and are cached per chunk. A
+  `CustomPainter` translates by `-playerPosition` and draws faint-to-bright
+  circles, optionally caching layers with `PictureRecorder` if performance dips
+  so the field stays static as the player moves.
 - Centralise audio assets in `assets.dart` and play them through a small
   audio service.
 - Persist the high score with `shared_preferences` using a lightweight storage


### PR DESCRIPTION
## Summary
- flesh out deterministic starfield background plan and design notes
- update plan, milestone polish, and README with Poisson-disk/Simplex details
- add codex-ready backlog item for world-space starfield

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bd7e80b4788330bb994f101b612aa6