### PR TITLE
Organize HUD settings into scaling and range sections

### DIFF
--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -4,7 +4,8 @@ import '../game/space_game.dart';
 import 'game_text.dart';
 import 'overlay_widgets.dart';
 
-/// Overlay providing runtime UI scaling and range sliders.
+/// Overlay providing runtime UI scaling and range sliders, grouped into
+/// sections for clarity.
 class SettingsOverlay extends StatelessWidget {
   const SettingsOverlay({super.key, required this.game});
 
@@ -43,6 +44,12 @@ class SettingsOverlay extends StatelessWidget {
                     maxLines: 1,
                   ),
                   SizedBox(height: spacing),
+                  GameText(
+                    'HUD Scaling',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    maxLines: 1,
+                  ),
+                  SizedBox(height: spacing),
                   _buildSlider(
                     context,
                     'HUD Buttons',
@@ -67,6 +74,12 @@ class SettingsOverlay extends StatelessWidget {
                     settings.joystickScale,
                     spacing,
                   ),
+                  GameText(
+                    'Range Scaling',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    maxLines: 1,
+                  ),
+                  SizedBox(height: spacing),
                   _buildSlider(
                     context,
                     'Targeting Range',

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -5,6 +5,7 @@ Overlay providing runtime UI scaling and range controls.
 ## Features
 
 - Sliders adjust HUD button, minimap, text, joystick scales and gameplay ranges.
+- Sections separate HUD scaling from range scaling for easier navigation.
 - Bordered layout limits width on large screens for clarity.
 - Opens from the HUD; closing returns to the game.
 - Overlay remains transparent so adjustments can be viewed immediately.


### PR DESCRIPTION
## Summary
- Group HUD-related sliders under new "HUD Scaling" and "Range Scaling" headings for clarity.
- Document the grouped sections in the settings overlay guide.

## Testing
- `scripts/dartw format lib/ui/settings_overlay.dart`
- `scripts/markdownlint.sh lib/ui/settings_overlay.md`
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7f65647c833096a6152a0493321a