### PR TITLE
Fix Escape behavior when Help overlay visible

### DIFF
--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -23,8 +23,13 @@ class ShortcutManager {
     required void Function() toggleMinimap,
     required void Function() toggleRangeRings,
     required void Function() returnToMenu,
+    required bool Function() isHelpVisible,
   }) {
     keyDispatcher.register(LogicalKeyboardKey.escape, onDown: () {
+      if (isHelpVisible()) {
+        toggleHelp();
+        return;
+      }
       if (stateMachine.state == GameState.playing) {
         pauseGame();
       } else if (stateMachine.state == GameState.paused) {

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -228,6 +228,7 @@ class SpaceGame extends FlameGame
       toggleMinimap: toggleMinimap,
       toggleRangeRings: toggleRangeRings,
       returnToMenu: returnToMenu,
+      isHelpVisible: () => overlays.isActive(HelpOverlay.id),
     );
     stateMachine.returnToMenu();
 

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -100,6 +100,7 @@ class _Harness {
       toggleMinimap: () => minimapCalled = true,
       toggleRangeRings: () => rangeRingsCalled = true,
       returnToMenu: () => menuCalled = true,
+      isHelpVisible: () => helpVisible,
     );
   }
 
@@ -115,6 +116,7 @@ class _Harness {
   bool minimapCalled = false;
   bool rangeRingsCalled = false;
   bool menuCalled = false;
+  bool helpVisible = false;
 
   void press(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) {
     dispatcher.onKeyEvent(
@@ -142,6 +144,15 @@ void main() {
       h.stateMachine.state = GameState.paused;
       h.press(LogicalKeyboardKey.escape, PhysicalKeyboardKey.escape);
       expect(h.resumeCalled, isTrue);
+      expect(h.pauseCalled, isFalse);
+    });
+
+    test('escape hides help when visible', () {
+      final h = _Harness()..stateMachine.state = GameState.playing;
+      h.helpVisible = true;
+
+      h.press(LogicalKeyboardKey.escape, PhysicalKeyboardKey.escape);
+      expect(h.helpCalled, isTrue);
       expect(h.pauseCalled, isFalse);
     });
 


### PR DESCRIPTION
## Summary
- Close the Help overlay with Esc without pausing
- Hook SpaceGame into new Escape behavior
- Test Esc handling for the Help overlay

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8102cef483309bfb8d2b6acc56b6