### PR TITLE
Anchor fire button correctly when scaling

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -179,23 +179,7 @@ class SpaceGame extends FlameGame
     miningLaser = laser;
     await add(laser);
 
-    final upButton = CircleComponent(
-      radius: 30 * settingsService.joystickScale.value,
-      paint: Paint()..color = colorScheme.primary.withValues(alpha: 0.4),
-    );
-    final downButton = CircleComponent(
-      radius: 30 * settingsService.joystickScale.value,
-      paint: Paint()..color = colorScheme.primary,
-    );
-    fireButton = HudButtonComponent(
-      button: upButton,
-      buttonDown: downButton,
-      anchor: Anchor.bottomRight,
-      margin: const EdgeInsets.only(right: 40, bottom: 40),
-      onPressed: player.startShooting,
-      onReleased: player.stopShooting,
-      onCancelled: player.stopShooting,
-    );
+    fireButton = _buildFireButton(settingsService.joystickScale.value);
     await add(fireButton);
 
     enemySpawner = EnemySpawner();
@@ -382,6 +366,25 @@ class SpaceGame extends FlameGame
     )..anchor = Anchor.bottomLeft;
   }
 
+  HudButtonComponent _buildFireButton(double scale) {
+    final scheme = colorScheme;
+    return HudButtonComponent(
+      button: CircleComponent(
+        radius: 30 * scale,
+        paint: Paint()..color = scheme.primary.withValues(alpha: 0.4),
+      ),
+      buttonDown: CircleComponent(
+        radius: 30 * scale,
+        paint: Paint()..color = scheme.primary,
+      ),
+      anchor: Anchor.bottomRight,
+      margin: const EdgeInsets.only(right: 40, bottom: 40),
+      onPressed: player.startShooting,
+      onReleased: player.stopShooting,
+      onCancelled: player.stopShooting,
+    )..size = Vector2.all(60 * scale);
+  }
+
   void _updateJoystickScale() {
     final scale = settingsService.joystickScale.value;
     // Rebuild the joystick to ensure the knob stays centred and scaling
@@ -391,9 +394,12 @@ class SpaceGame extends FlameGame
     add(joystick);
     joystick.onGameResize(size);
 
-    // Scale the fire button to match the joystick.
+    // Scale the fire button to match the joystick and stay anchored
+    // to the bottom-right corner.
     (fireButton.button as CircleComponent).radius = 30 * scale;
     (fireButton.buttonDown as CircleComponent).radius = 30 * scale;
+    fireButton.size = Vector2.all(60 * scale);
+    fireButton.anchor = Anchor.bottomRight;
     fireButton.onGameResize(size);
   }
 

--- a/test/joystick_fire_button_scale_test.dart
+++ b/test/joystick_fire_button_scale_test.dart
@@ -17,8 +17,7 @@ import 'package:space_game/ui/upgrades_overlay.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('joystick scale updates fire button and keeps bottom-left anchor',
-      () async {
+  test('joystick scale updates fire button and keeps anchors', () async {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
@@ -44,5 +43,6 @@ void main() {
     expect(fire.radius, 30 * 1.2);
     expect(game.joystick.position.x, 40);
     expect(game.joystick.position.y, game.size.y - 40);
+    expect(game.fireButton.anchor, Anchor.bottomRight);
   });
 }


### PR DESCRIPTION
## Summary
- keep fire button anchored when joystick scale changes by resizing and re-anchoring the button
- test fire button and joystick scale updates

## Testing
- `scripts/flutterw test`
- `scripts/flutterw test test/joystick_fire_button_scale_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68bd80062b708330a4afef6800e5f7a4