### PR TITLE
Make tractor range slider apply in-game

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -73,6 +73,7 @@ class SpaceGame extends FlameGame
     upgradeService = UpgradeService(
       scoreService: scoreService,
       storageService: storageService,
+      settingsService: this.settingsService,
     );
   }
 

--- a/lib/services/upgrade_service.dart
+++ b/lib/services/upgrade_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../constants.dart';
 import 'score_service.dart';
+import 'settings_service.dart';
 import 'storage_service.dart';
 
 /// Simple upgrade data.
@@ -15,13 +16,18 @@ class Upgrade {
 
 /// Handles purchasing upgrades with minerals.
 class UpgradeService {
-  UpgradeService({required this.scoreService, required this.storageService}) {
+  UpgradeService({
+    required this.scoreService,
+    required this.storageService,
+    required this.settingsService,
+  }) {
     final saved = storageService.getStringList(_purchasedUpgradesKey, []);
     _purchased.value = saved.toSet();
   }
 
   final ScoreService scoreService;
   final StorageService storageService;
+  final SettingsService settingsService;
 
   static const _purchasedUpgradesKey = 'purchasedUpgrades';
 
@@ -61,7 +67,7 @@ class UpgradeService {
 
   /// Current auto-aim targeting range factoring in purchased upgrades.
   double get targetingRange {
-    var range = Constants.playerAutoAimRange;
+    var range = settingsService.targetingRange.value;
     if (isPurchased('targetingRange1')) {
       range *= Constants.targetingRangeUpgradeFactor;
     }
@@ -70,7 +76,7 @@ class UpgradeService {
 
   /// Current Tractor Aura radius factoring in purchased upgrades.
   double get tractorRange {
-    var range = Constants.playerTractorAuraRadius;
+    var range = settingsService.tractorRange.value;
     if (isPurchased('tractorRange1')) {
       range *= Constants.tractorRangeUpgradeFactor;
     }

--- a/test/upgrade_effects_test.dart
+++ b/test/upgrade_effects_test.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/services/score_service.dart';
 import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/settings_service.dart';
 import 'package:space_game/services/upgrade_service.dart';
 
 void main() {
@@ -13,9 +14,11 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
       storageService: storage,
+      settingsService: settings,
     );
     final upgrade = service.upgrades.firstWhere((u) => u.id == 'fireRate1');
     expect(service.bulletCooldown, Constants.bulletCooldown);
@@ -28,9 +31,11 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
       storageService: storage,
+      settingsService: settings,
     );
     final upgrade = service.upgrades.firstWhere((u) => u.id == 'miningSpeed1');
     expect(service.miningPulseInterval, Constants.miningPulseInterval);
@@ -44,9 +49,11 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
       storageService: storage,
+      settingsService: settings,
     );
     final upgrade =
         service.upgrades.firstWhere((u) => u.id == 'targetingRange1');
@@ -60,9 +67,11 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
       storageService: storage,
+      settingsService: settings,
     );
     final upgrade = service.upgrades.firstWhere((u) => u.id == 'tractorRange1');
     expect(service.tractorRange, Constants.playerTractorAuraRadius);

--- a/test/upgrade_service_test.dart
+++ b/test/upgrade_service_test.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:space_game/services/score_service.dart';
 import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/settings_service.dart';
 import 'package:space_game/services/upgrade_service.dart';
 
 void main() {
@@ -12,9 +13,11 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
       storageService: storage,
+      settingsService: settings,
     );
     score.addMinerals(20);
     final upgrade = service.upgrades.first;
@@ -28,9 +31,11 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
       storageService: storage,
+      settingsService: settings,
     );
     final upgrade = service.upgrades.first;
     final success = service.buy(upgrade);
@@ -42,9 +47,11 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
       storageService: storage,
+      settingsService: settings,
     );
     final upgrade = service.upgrades.first;
     score.addMinerals(upgrade.cost);
@@ -54,6 +61,7 @@ void main() {
     final service2 = UpgradeService(
       scoreService: score2,
       storageService: storage,
+      settingsService: settings,
     );
     expect(service2.isPurchased(upgrade.id), isTrue);
   });


### PR DESCRIPTION
## Summary
- tie upgrade service ranges to SettingsService so Tractor Range slider updates runtime
- pass SettingsService into UpgradeService
- adjust upgrade tests to include SettingsService

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7fc1bf3c8330bc39ce783f98a576