### PR TITLE
docs: detail deterministic starfield

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -191,10 +191,14 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
   and mining ranges, plus a reset button
 - Game works offline after the first load thanks to the service worker
-- Deterministic world-space starfield seeded by chunk coordinates using
-  Poisson-disk sampling. Density varies with Simplex noise; stars use a
-  weighted size/brightness spread and optional colour jitter and are drawn by a
-  cached `CustomPainter` so the player moves over a static field.
+- Deterministic world-space starfield replaces the parallax background:
+  - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.
+  - Simplex noise modulates density for subtle clusters.
+  - Weighted size/brightness spread (≈80% tiny, 19% small, 1% medium) with optional
+    colour jitter adds variety.
+  - Cache star data per chunk and draw via a `CustomPainter`, translating by
+    `-playerPosition` so the player flies over a static backdrop. Draw faint stars
+    first for smoother blending.
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
   `P` to resume; `Q` returns to the menu from pause or game over
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,14 @@ dedicated server or NAT traversal.
   help overlay that `Esc` also closes, `U` opens an upgrades overlay that `Esc`
   also closes)
 - Game works offline after the first load
-- Deterministic world-space starfield seeded by chunk coordinates using
-  Poisson-disk sampling. Simplex noise modulates density for clusters, and
-  stars use a weighted size/brightness spread with subtle colour jitter,
-  rendered via a cached `CustomPainter` so the player moves over a static field
-  with consistent spacing.
+- Deterministic world-space starfield replaces the parallax background:
+  - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.
+  - Simplex noise modulates density for subtle clusters.
+  - Weighted radius/brightness spread (≈80% tiny, 19% small, 1% medium) with optional
+    colour jitter adds variation.
+  - Cache star data per chunk and draw via a `CustomPainter`, translating by
+    `-playerPosition` so the player flies over a static field. Draw faint stars
+    first for smoother blending.
 
 ## 🔮 Future Plans
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -99,4 +99,16 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       far behind.
 - [x] Tile the parallax starfield so it scrolls seamlessly.
 - [x] Add a minimap or other navigation aid for exploring the larger world.
-- [ ] Update the background system to replace the player-following parallax starfield with a deterministic world-space starfield. Generate stars per chunk using Poisson-disk sampling seeded by chunk coordinates. Modulate density with Simplex noise for subtle clusters. Render stars as pinpoint circles of varying size/brightness with CustomPainter, cached per chunk. The player moves over this static starfield, ensuring consistent, realistic spacing and density patterns.
+- [ ] Replace the player-following parallax starfield with a deterministic
+      world-space starfield:
+      - [ ] Generate stars per chunk using Poisson-disk sampling seeded by chunk
+            coordinates.
+      - [ ] Modulate spawn density with low-frequency Simplex noise to create
+            clusters.
+      - [ ] Assign weighted radius/brightness (≈80% tiny, 19% small, 1% medium)
+            and optional colour jitter.
+      - [ ] Render stars as pinpoint circles via a cached `CustomPainter`,
+            translating by `-playerPosition` so the player moves over a static
+            backdrop.
+      - [ ] Remove the old parallax starfield once the deterministic version is
+            in place.


### PR DESCRIPTION
## Summary
- expand deterministic starfield sections with seeded Poisson-disk sampling, Simplex density modulation, cached CustomPainter rendering and translation by `-playerPosition`
- break starfield backlog item into actionable subtasks

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bd8030c57c83308f3c55bd9358df3e