### PR TITLE
Refactor overlay handling and key dispatcher

### DIFF
--- a/lib/game/key_dispatcher.dart
+++ b/lib/game/key_dispatcher.dart
@@ -35,14 +35,8 @@ class KeyDispatcher extends Component with KeyboardHandler {
   bool isPressed(LogicalKeyboardKey key) => _pressed.contains(key);
 
   /// Returns whether any of [keys] are currently pressed.
-  bool isAnyPressed(Iterable<LogicalKeyboardKey> keys) {
-    for (final key in keys) {
-      if (_pressed.contains(key)) {
-        return true;
-      }
-    }
-    return false;
-  }
+  bool isAnyPressed(Iterable<LogicalKeyboardKey> keys) =>
+      keys.any(_pressed.contains);
 
   @override
   bool onKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {

--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -14,52 +14,46 @@ class OverlayService {
 
   final Game game;
 
-  void showMenu() {
-    game.overlays
-      ..remove(HudOverlay.id)
-      ..remove(PauseOverlay.id)
-      ..remove(GameOverOverlay.id)
-      ..remove(SettingsOverlay.id)
-      ..add(MenuOverlay.id);
+  void _showOnly(String id, Iterable<String> remove) {
+    final overlays = game.overlays;
+    for (final overlay in remove) {
+      overlays.remove(overlay);
+    }
+    overlays.add(id);
   }
 
-  void showHud() {
-    game.overlays
-      ..remove(MenuOverlay.id)
-      ..remove(PauseOverlay.id)
-      ..remove(GameOverOverlay.id)
-      ..remove(SettingsOverlay.id)
-      ..add(HudOverlay.id);
-  }
+  void showMenu() => _showOnly(MenuOverlay.id, [
+        HudOverlay.id,
+        PauseOverlay.id,
+        GameOverOverlay.id,
+        SettingsOverlay.id,
+      ]);
+
+  void showHud() => _showOnly(HudOverlay.id, [
+        MenuOverlay.id,
+        PauseOverlay.id,
+        GameOverOverlay.id,
+        SettingsOverlay.id,
+      ]);
 
   /// Shows the pause overlay without affecting other active overlays.
   void showPause() => game.overlays.add(PauseOverlay.id);
 
-  void showGameOver() {
-    game.overlays
-      ..remove(HudOverlay.id)
-      ..remove(PauseOverlay.id)
-      ..remove(SettingsOverlay.id)
-      ..add(GameOverOverlay.id);
-  }
+  void showGameOver() => _showOnly(GameOverOverlay.id, [
+        HudOverlay.id,
+        PauseOverlay.id,
+        SettingsOverlay.id,
+      ]);
 
   void showHelp() => game.overlays.add(HelpOverlay.id);
 
   void hideHelp() => game.overlays.remove(HelpOverlay.id);
 
-  void showUpgrades() {
-    game.overlays
-      ..remove(HudOverlay.id)
-      ..remove(SettingsOverlay.id)
-      ..add(UpgradesOverlay.id);
-  }
+  void showUpgrades() =>
+      _showOnly(UpgradesOverlay.id, [HudOverlay.id, SettingsOverlay.id]);
 
-  void hideUpgrades() {
-    game.overlays
-      ..remove(UpgradesOverlay.id)
-      ..remove(SettingsOverlay.id)
-      ..add(HudOverlay.id);
-  }
+  void hideUpgrades() =>
+      _showOnly(HudOverlay.id, [UpgradesOverlay.id, SettingsOverlay.id]);
 
   void showSettings() => game.overlays.add(SettingsOverlay.id);
 


### PR DESCRIPTION
## Summary
- simplify keyboard key checks by leveraging `Iterable.any`
- centralize overlay transitions with a helper to show one and hide others

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8a3c576483308dab165684990f84