### PR TITLE
Optimize SolidBody collision math

### DIFF
--- a/lib/util/collision_utils.dart
+++ b/lib/util/collision_utils.dart
@@ -22,31 +22,31 @@ mixin SolidBody on PositionComponent, CollisionCallbacks {
     }
     final diff = position - other.position;
     var distance = diff.length;
+    late final Vector2 direction;
     if (distance == 0) {
       // Components are exactly on top of each other; nudge in a random direction.
       final angle = _rand.nextDouble() * math.pi * 2;
-      diff
-        ..x = math.cos(angle)
-        ..y = math.sin(angle);
+      direction = Vector2(math.cos(angle), math.sin(angle));
       distance = 0.0001;
+    } else {
+      direction = diff / distance;
     }
     final minDistance = (size.x + other.size.x) / 2;
     final overlap = minDistance - distance;
     if (overlap > 0) {
-      final direction = diff.normalized();
-      final selfSize = size.length;
-      final otherSize = other.size.length;
-      if (selfSize < otherSize) {
+      final selfSize2 = size.length2;
+      final otherSize2 = other.size.length2;
+      if (selfSize2 < otherSize2) {
         // Current component is smaller; move it out of the way entirely.
-        position.add(direction * overlap);
-      } else if (selfSize > otherSize) {
+        position += direction * overlap;
+      } else if (selfSize2 > otherSize2) {
         // Other component is smaller; move it out of the way.
-        other.position.sub(direction * overlap);
+        other.position -= direction * overlap;
       } else {
         // Components are roughly the same size; split the push.
         final push = direction * (overlap / 2);
-        position.add(push);
-        other.position.sub(push);
+        position += push;
+        other.position -= push;
       }
     }
   }


### PR DESCRIPTION
## Summary
- reuse distance to derive collision direction
- compare squared component sizes to avoid extra sqrt

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8a3c576483308dab165684990f84