### PR TITLE
Treat preview deploy failures as non-blocking

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,6 +12,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
+    continue-on-error: true
     environment:
       name: preview
       url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/


### PR DESCRIPTION
## Summary
- mark preview deploy job `continue-on-error` so cancelled or failing previews don't block PRs

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8c5663508330a769a95d9035aedf