### PR TITLE
Refactor overlay removal logic

### DIFF
--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -14,7 +14,7 @@ class OverlayService {
 
   final Game game;
 
-  void _showOnly(String id, Iterable<String> remove) {
+  void _showOnly(String id, Set<String> remove) {
     final overlays = game.overlays;
     for (final overlay in remove) {
       overlays.remove(overlay);
@@ -22,38 +22,49 @@ class OverlayService {
     overlays.add(id);
   }
 
-  void showMenu() => _showOnly(MenuOverlay.id, [
-        HudOverlay.id,
-        PauseOverlay.id,
-        GameOverOverlay.id,
-        SettingsOverlay.id,
-      ]);
+  static const _menuRemove = <String>{
+    HudOverlay.id,
+    PauseOverlay.id,
+    GameOverOverlay.id,
+    SettingsOverlay.id,
+  };
 
-  void showHud() => _showOnly(HudOverlay.id, [
-        MenuOverlay.id,
-        PauseOverlay.id,
-        GameOverOverlay.id,
-        SettingsOverlay.id,
-      ]);
+  static const _hudRemove = <String>{
+    MenuOverlay.id,
+    PauseOverlay.id,
+    GameOverOverlay.id,
+    SettingsOverlay.id,
+  };
+
+  static const _gameOverRemove = <String>{
+    HudOverlay.id,
+    PauseOverlay.id,
+    SettingsOverlay.id,
+  };
+
+  void showMenu() => _showOnly(MenuOverlay.id, _menuRemove);
+
+  void showHud() => _showOnly(HudOverlay.id, _hudRemove);
 
   /// Shows the pause overlay without affecting other active overlays.
   void showPause() => game.overlays.add(PauseOverlay.id);
 
-  void showGameOver() => _showOnly(GameOverOverlay.id, [
-        HudOverlay.id,
-        PauseOverlay.id,
-        SettingsOverlay.id,
-      ]);
+  void showGameOver() => _showOnly(GameOverOverlay.id, _gameOverRemove);
 
   void showHelp() => game.overlays.add(HelpOverlay.id);
 
   void hideHelp() => game.overlays.remove(HelpOverlay.id);
 
-  void showUpgrades() =>
-      _showOnly(UpgradesOverlay.id, [HudOverlay.id, SettingsOverlay.id]);
+  static const _upgradesRemove = <String>{HudOverlay.id, SettingsOverlay.id};
 
-  void hideUpgrades() =>
-      _showOnly(HudOverlay.id, [UpgradesOverlay.id, SettingsOverlay.id]);
+  static const _hideUpgradesRemove = <String>{
+    UpgradesOverlay.id,
+    SettingsOverlay.id,
+  };
+
+  void showUpgrades() => _showOnly(UpgradesOverlay.id, _upgradesRemove);
+
+  void hideUpgrades() => _showOnly(HudOverlay.id, _hideUpgradesRemove);
 
   void showSettings() => game.overlays.add(SettingsOverlay.id);
 


### PR DESCRIPTION
## Summary
- centralize overlay removal sets to simplify OverlayService logic

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8c1930808330bc3ea9fc782d7af5