### PR TITLE
feat: add size-limited object pool

### DIFF
--- a/lib/util/object_pool.dart
+++ b/lib/util/object_pool.dart
@@ -1,8 +1,14 @@
 /// Generic object pool to minimise allocations by reusing instances.
 class ObjectPool<T> {
-  ObjectPool(this._create);
+  /// Creates a new pool that builds objects using [create].
+  ///
+  /// If [maxSize] is provided, the pool will keep at most that many
+  /// instances when [release] is called. Additional releases are discarded
+  /// to avoid unbounded memory growth.
+  ObjectPool(T Function() create, {this.maxSize}) : _create = create;
 
   final T Function() _create;
+  final int? maxSize;
   final List<T> _items = [];
 
   /// Returns the cached items currently in the pool.
@@ -15,7 +21,11 @@ class ObjectPool<T> {
   }
 
   /// Returns [obj] to the pool for future reuse.
-  void release(T obj) => _items.add(obj);
+  void release(T obj) {
+    if (maxSize == null || _items.length < maxSize!) {
+      _items.add(obj);
+    }
+  }
 
   /// Clears all cached instances.
   void clear() => _items.clear();

--- a/test/object_pool_max_size_test.dart
+++ b/test/object_pool_max_size_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/util/object_pool.dart';
+
+void main() {
+  test('pool respects maxSize when releasing', () {
+    final pool = ObjectPool<int>(() => 0, maxSize: 1);
+    pool.release(1);
+    pool.release(2); // Should be discarded.
+
+    expect(pool.items.length, 1);
+    // Ensure the stored instance is the first one released.
+    expect(pool.acquire(), 1);
+  });
+}


### PR DESCRIPTION
## Summary
- allow object pools to cap cached instances
- test max size behavior

## Testing
- `scripts/dartw analyze lib/util/object_pool.dart test/object_pool_max_size_test.dart`
- `scripts/flutterw test test/object_pool_max_size_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_68be8812f6908330b8ecea6d4bb433e5