### PR TITLE
refactor: centralize overlay transitions

### DIFF
--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -1,12 +1,12 @@
 import 'package:flame/game.dart';
 
 import '../ui/game_over_overlay.dart';
+import '../ui/help_overlay.dart';
 import '../ui/hud_overlay.dart';
 import '../ui/menu_overlay.dart';
 import '../ui/pause_overlay.dart';
-import '../ui/help_overlay.dart';
-import '../ui/upgrades_overlay.dart';
 import '../ui/settings_overlay.dart';
+import '../ui/upgrades_overlay.dart';
 
 /// Handles showing and hiding Flutter overlays.
 class OverlayService {
@@ -14,7 +14,7 @@ class OverlayService {
 
   final Game game;
 
-  void _showOnly(String id, Set<String> remove) {
+  void _showOnly(String id, Iterable<String> remove) {
     final overlays = game.overlays;
     for (final overlay in remove) {
       overlays.remove(overlay);
@@ -22,49 +22,52 @@ class OverlayService {
     overlays.add(id);
   }
 
-  static const _menuRemove = <String>{
-    HudOverlay.id,
-    PauseOverlay.id,
-    GameOverOverlay.id,
-    SettingsOverlay.id,
+  static const _exclusiveOverlays = <String, Set<String>>{
+    MenuOverlay.id: {
+      HudOverlay.id,
+      PauseOverlay.id,
+      GameOverOverlay.id,
+      SettingsOverlay.id,
+    },
+    HudOverlay.id: {
+      MenuOverlay.id,
+      PauseOverlay.id,
+      GameOverOverlay.id,
+      SettingsOverlay.id,
+    },
+    GameOverOverlay.id: {
+      HudOverlay.id,
+      PauseOverlay.id,
+      SettingsOverlay.id,
+    },
+    UpgradesOverlay.id: {
+      HudOverlay.id,
+      SettingsOverlay.id,
+    },
   };
 
-  static const _hudRemove = <String>{
-    MenuOverlay.id,
-    PauseOverlay.id,
-    GameOverOverlay.id,
-    SettingsOverlay.id,
-  };
+  void _showExclusive(String id, {Set<String>? remove}) =>
+      _showOnly(id, remove ?? _exclusiveOverlays[id] ?? const <String>{});
 
-  static const _gameOverRemove = <String>{
-    HudOverlay.id,
-    PauseOverlay.id,
-    SettingsOverlay.id,
-  };
+  void showMenu() => _showExclusive(MenuOverlay.id);
 
-  void showMenu() => _showOnly(MenuOverlay.id, _menuRemove);
-
-  void showHud() => _showOnly(HudOverlay.id, _hudRemove);
+  void showHud() => _showExclusive(HudOverlay.id);
 
   /// Shows the pause overlay without affecting other active overlays.
   void showPause() => game.overlays.add(PauseOverlay.id);
 
-  void showGameOver() => _showOnly(GameOverOverlay.id, _gameOverRemove);
+  void showGameOver() => _showExclusive(GameOverOverlay.id);
 
   void showHelp() => game.overlays.add(HelpOverlay.id);
 
   void hideHelp() => game.overlays.remove(HelpOverlay.id);
 
-  static const _upgradesRemove = <String>{HudOverlay.id, SettingsOverlay.id};
+  void showUpgrades() => _showExclusive(UpgradesOverlay.id);
 
-  static const _hideUpgradesRemove = <String>{
-    UpgradesOverlay.id,
-    SettingsOverlay.id,
-  };
-
-  void showUpgrades() => _showOnly(UpgradesOverlay.id, _upgradesRemove);
-
-  void hideUpgrades() => _showOnly(HudOverlay.id, _hideUpgradesRemove);
+  void hideUpgrades() => _showExclusive(
+        HudOverlay.id,
+        remove: {UpgradesOverlay.id, SettingsOverlay.id},
+      );
 
   void showSettings() => game.overlays.add(SettingsOverlay.id);
 


### PR DESCRIPTION
## Summary
- deduplicate overlay removal rules into a single map
- expose `_showExclusive` helper for consistent overlay transitions

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68be8812f6908330b8ecea6d4bb433e5