### PR TITLE
feat: add deterministic starfield

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,10 +188,11 @@ tree spanning weapons and ship systems.
 - A deterministic world-space starfield generates stars per chunk using
   Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex
   noise modulates density to create clusters and voids. Stars follow a weighted
-  size/brightness distribution with optional subtle colour jitter. A cached
-  `CustomPainter` translates by `-playerPosition`, draws faint-to-bright circles
-  and can cache layers with `PictureRecorder` if needed so the field stays
-  static as the player moves.
+  size/brightness distribution with optional subtle colour jitter. Each chunk
+  pre-renders to a cached `Picture` translated by `-playerPosition`, dropping
+  tiles outside a small margin around the camera so memory stays bounded. The
+  player flies over a static backdrop while circles draw faint-to-bright. A
+  `debugDrawTiles` switch outlines tile boundaries for troubleshooting.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -146,9 +146,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   shapes and a timer-based spawner
 - Top‑down view with a deterministic world-space starfield generated per chunk
   via Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex
-  noise modulates density for clusters, and a cached `CustomPainter` draws
-  faint-to-bright circle stars based on a weighted size/brightness distribution
-  with subtle colour jitter.
+  noise modulates density for clusters, and each chunk pre-renders to a cached
+  `Picture` that sorts stars by radius so faint ones draw first for smoother
+  blending. A weighted size/brightness distribution with subtle colour jitter
+  adds variety.
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple
   object pools to reduce garbage collection overhead
@@ -196,9 +197,11 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   - Simplex noise modulates density for subtle clusters.
   - Weighted size/brightness spread (≈80% tiny, 19% small, 1% medium) with optional
     colour jitter adds variety.
-  - Cache star data per chunk and draw via a `CustomPainter`, translating by
-    `-playerPosition` so the player flies over a static backdrop. Draw faint stars
-    first for smoother blending.
+  - Each chunk pre-renders to a cached `Picture`, dropping tiles outside a small
+    margin around the camera, then draws with a translation of `-playerPosition`
+    so the player flies over a static backdrop. Stars sort by radius so faint
+    ones render first for smoother blending. A `debugDrawTiles` option outlines
+    tile boundaries to aid development.
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
   `P` to resume; `Q` returns to the menu from pause or game over
 

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -27,7 +27,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Selected ship persists between sessions
 - [ ] Enter starts or restarts from the menu or game over; `R` restarts at any time
 - [ ] Escape or `P` key pauses or resumes the game
-- [ ] Deterministic world-space starfield renders consistently behind gameplay
+- [ ] Deterministic world-space starfield renders consistently and prunes
+      distant tiles to avoid memory leaks
 - [ ] Sound effects play and can be muted from menu, HUD or game over overlay,
       or via the `M` key
 - [ ] Laser shot sound plays when firing

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ dedicated server or NAT traversal.
   - Simplex noise modulates density for subtle clusters.
   - Weighted radius/brightness spread (≈80% tiny, 19% small, 1% medium) with optional
     colour jitter adds variation.
-  - Cache star data per chunk and draw via a `CustomPainter`, translating by
-    `-playerPosition` so the player flies over a static field. Draw faint stars
-    first for smoother blending.
+  - Each chunk pre-renders to a cached `Picture`, dropping tiles outside a small
+    margin around the camera, then draws with a translation of `-playerPosition`
+    so the player flies over a static field. Draw faint stars first for smoother
+    blending. A `debugDrawTiles` flag can outline tiles during development.
 
 ## 🔮 Future Plans
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -99,16 +99,21 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       far behind.
 - [x] Tile the parallax starfield so it scrolls seamlessly.
 - [x] Add a minimap or other navigation aid for exploring the larger world.
-- [ ] Replace the player-following parallax starfield with a deterministic
+- [x] Replace the player-following parallax starfield with a deterministic
       world-space starfield:
-      - [ ] Generate stars per chunk using Poisson-disk sampling seeded by chunk
+      - [x] Generate stars per chunk using Poisson-disk sampling seeded by chunk
             coordinates.
-      - [ ] Modulate spawn density with low-frequency Simplex noise to create
+      - [x] Modulate spawn density with low-frequency Simplex noise to create
             clusters.
-      - [ ] Assign weighted radius/brightness (≈80% tiny, 19% small, 1% medium)
+      - [x] Assign weighted radius/brightness (≈80% tiny, 19% small, 1% medium)
             and optional colour jitter.
-      - [ ] Render stars as pinpoint circles via a cached `CustomPainter`,
-            translating by `-playerPosition` so the player moves over a static
+        - [x] Pre-render stars per chunk into a cached `Picture`, drawing with
+            a translation of `-playerPosition` so the player moves over a static
             backdrop.
-      - [ ] Remove the old parallax starfield once the deterministic version is
+      - [x] Sort stars by radius so faint ones render first for smoother
+            blending.
+      - [x] Prune cached starfield tiles outside a small margin so memory
+            remains bounded.
+      - [x] Remove the old parallax starfield once the deterministic version is
             in place.
+      - [x] Expose an optional `debugDrawTiles` flag to outline starfield tiles.

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -33,7 +33,8 @@ Gameplay entities and reusable pieces.
   damaged that increases the player's mineral total when picked up.
 - Each mineral independently homes toward the player when within the Tractor
   Aura, removing the need for a separate component.
-- [Starfield](starfield.md) – deterministic world-space background drawn with a cached `CustomPainter`.
+- [Starfield](starfield.md) – deterministic world-space background that caches
+  star tiles and prunes those far from the camera.
 - [ExplosionComponent](explosion.md) – short animation and sound played when
   a ship is destroyed.
 

--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -1,81 +1,234 @@
-import 'dart:math';
+import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
-import 'package:flame/parallax.dart';
-import 'package:flutter/painting.dart' show ImageRepeat;
+import 'package:flutter/foundation.dart';
 
 import '../constants.dart';
+import '../util/open_simplex_noise.dart';
 
-/// Persistent parallax starfield that caches its layers after the first build.
-class StarfieldComponent extends ParallaxComponent<FlameGame> {
-  StarfieldComponent() : super(priority: -1);
+/// Deterministic world-space starfield rendered behind gameplay.
+class StarfieldComponent extends Component with HasGameReference<FlameGame> {
+  StarfieldComponent({int seed = 0, this.debugDrawTiles = false})
+      : _seed = seed,
+        super(priority: -1);
 
-  static Parallax? _cachedParallax;
+  final int _seed;
+  late final OpenSimplexNoise _noise = OpenSimplexNoise(_seed);
+  final Map<math.Point<int>, Picture> _cache = {};
+
+  /// Whether to draw debug outlines around generated tiles.
+  final bool debugDrawTiles;
+
+  static final Paint _outlinePaint = Paint()
+    ..color = const Color(0x40FFFFFF)
+    ..style = PaintingStyle.stroke;
+
+  /// Exposes the current cache size for tests.
+  @visibleForTesting
+  int get debugCacheSize => _cache.length;
 
   @override
-  Future<void> onLoad() async {
-    parallax = _cachedParallax ??=
-        await _buildParallax(Vector2.all(Constants.starfieldTileSize));
-  }
+  void render(Canvas canvas) {
+    final cameraPos = game.camera.viewfinder.position;
+    final viewSize = game.size;
+    final left = cameraPos.x - viewSize.x / 2;
+    final top = cameraPos.y - viewSize.y / 2;
+    final right = left + viewSize.x;
+    final bottom = top + viewSize.y;
 
-  @override
-  void onGameResize(Vector2 size) {
-    super.onGameResize(size);
-    this.size = size;
-  }
+    final startX = (left / Constants.starfieldTileSize).floor();
+    final endX = (right / Constants.starfieldTileSize).floor();
+    final startY = (top / Constants.starfieldTileSize).floor();
+    final endY = (bottom / Constants.starfieldTileSize).floor();
 
-  @override
-  void update(double dt) {
-    super.update(dt);
-    position = game.camera.viewfinder.position - size / 2;
-  }
-
-  // Keep the starfield centred on the camera so it always covers the viewport.
-  // Parallax layers still provide depth, but without this recentering the
-  // background would vanish once the player moves away from the origin.
-
-  static Future<Parallax> _buildParallax(Vector2 size) async {
-    final random = Random();
-    final paint = Paint();
-
-    Future<ParallaxImage> buildLayer() async {
-      final recorder = PictureRecorder();
-      final canvas = Canvas(recorder);
-      for (var i = 0; i < Constants.starsPerLayer; i++) {
-        final brightness = 128 + random.nextInt(128);
-        paint.color = Color.fromARGB(255, brightness, brightness, brightness);
-        final position = Offset(
-          random.nextDouble() * size.x,
-          random.nextDouble() * size.y,
-        );
-        final radius = random.nextDouble() * Constants.starMaxSize + 1;
-        canvas.drawCircle(position, radius, paint);
+    canvas.save();
+    canvas.translate(-left, -top);
+    for (var tx = startX; tx <= endX; tx++) {
+      for (var ty = startY; ty <= endY; ty++) {
+        final key = math.Point(tx, ty);
+        final picture =
+            _cache.putIfAbsent(key, () => _generateTilePicture(tx, ty));
+        final offsetX = tx * Constants.starfieldTileSize;
+        final offsetY = ty * Constants.starfieldTileSize;
+        canvas.save();
+        canvas.translate(offsetX, offsetY);
+        canvas.drawPicture(picture);
+        if (debugDrawTiles) {
+          canvas.drawRect(
+            Rect.fromLTWH(
+              0,
+              0,
+              Constants.starfieldTileSize,
+              Constants.starfieldTileSize,
+            ),
+            _outlinePaint,
+          );
+        }
+        canvas.restore();
       }
-      final picture = recorder.endRecording();
-      final image = await picture.toImage(size.x.toInt(), size.y.toInt());
-      return ParallaxImage(image, repeat: ImageRepeat.repeat);
+    }
+    canvas.restore();
+
+    _cache.removeWhere((key, picture) {
+      final keep = key.x >= startX - Constants.starfieldCacheMargin &&
+          key.x <= endX + Constants.starfieldCacheMargin &&
+          key.y >= startY - Constants.starfieldCacheMargin &&
+          key.y <= endY + Constants.starfieldCacheMargin;
+      if (!keep) {
+        picture.dispose();
+      }
+      return !keep;
+    });
+  }
+
+  @override
+  void onRemove() {
+    for (final pic in _cache.values) {
+      pic.dispose();
+    }
+    _cache.clear();
+    super.onRemove();
+  }
+
+  Picture _generateTilePicture(int tx, int ty) {
+    final recorder = PictureRecorder();
+    final tileCanvas = Canvas(recorder);
+    for (final star in _tileStars(tx, ty)) {
+      tileCanvas.drawCircle(star.position, star.radius, star.paint);
+    }
+    return recorder.endRecording();
+  }
+
+  List<_Star> _tileStars(int tx, int ty) {
+    final rnd = math.Random(_seed ^ tx ^ (ty << 16));
+    final noise = _noise.noise2D(
+        tx * Constants.starNoiseScale, ty * Constants.starNoiseScale);
+    final density = (noise + 1) / 2; // 0..1
+    final minDist = _lerp(
+      Constants.starMinDistanceMin,
+      Constants.starMinDistanceMax,
+      (1 - density).toDouble(),
+    );
+    final samples = _poisson(Constants.starfieldTileSize, minDist, rnd);
+    final stars = samples.map((o) => _randomStar(o, rnd)).toList()
+      ..sort((a, b) => a.radius.compareTo(b.radius));
+    return stars;
+  }
+
+  /// Returns the radii of the stars generated for the given tile.
+  @visibleForTesting
+  Iterable<double> debugTileStarRadii(int tx, int ty) =>
+      _tileStars(tx, ty).map((s) => s.radius);
+
+  List<Offset> _poisson(double size, double minDist, math.Random rnd,
+      {int maxAttempts = 30}) {
+    final cellSize = minDist / math.sqrt2;
+    final gridSize = (size / cellSize).ceil();
+    final grid = List<Offset?>.filled(gridSize * gridSize, null);
+    final active = <Offset>[];
+    final samples = <Offset>[];
+
+    Offset first = Offset(rnd.nextDouble() * size, rnd.nextDouble() * size);
+    int gi = _gridIndex(first, cellSize, gridSize);
+    grid[gi] = first;
+    active.add(first);
+    samples.add(first);
+
+    while (active.isNotEmpty) {
+      final index = rnd.nextInt(active.length);
+      final point = active[index];
+      bool found = false;
+      for (int i = 0; i < maxAttempts; i++) {
+        final angle = rnd.nextDouble() * math.pi * 2;
+        final radius = minDist + rnd.nextDouble() * minDist;
+        final candidate = Offset(
+          point.dx + math.cos(angle) * radius,
+          point.dy + math.sin(angle) * radius,
+        );
+        if (candidate.dx >= 0 &&
+            candidate.dx < size &&
+            candidate.dy >= 0 &&
+            candidate.dy < size) {
+          final gx = (candidate.dx / cellSize).floor();
+          final gy = (candidate.dy / cellSize).floor();
+          bool ok = true;
+          for (int x = gx - 2; x <= gx + 2 && ok; x++) {
+            for (int y = gy - 2; y <= gy + 2 && ok; y++) {
+              if (x >= 0 && x < gridSize && y >= 0 && y < gridSize) {
+                final neighbor = grid[x + y * gridSize];
+                if (neighbor != null &&
+                    (neighbor - candidate).distance < minDist) {
+                  ok = false;
+                }
+              }
+            }
+          }
+          if (ok) {
+            grid[gx + gy * gridSize] = candidate;
+            active.add(candidate);
+            samples.add(candidate);
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) {
+        active.removeAt(index);
+      }
     }
 
-    final slowLayer = ParallaxLayer(
-      await buildLayer(),
-      velocityMultiplier: Vector2.all(1),
-    );
-    final mediumLayer = ParallaxLayer(
-      await buildLayer(),
-      velocityMultiplier:
-          Vector2.all(Constants.starSpeedMedium / Constants.starSpeedSlow),
-    );
-    final fastLayer = ParallaxLayer(
-      await buildLayer(),
-      velocityMultiplier:
-          Vector2.all(Constants.starSpeedFast / Constants.starSpeedSlow),
-    );
-
-    return Parallax(
-      [slowLayer, mediumLayer, fastLayer],
-      baseVelocity: Vector2(0, Constants.starSpeedSlow),
-    );
+    return samples;
   }
+
+  _Star _randomStar(Offset position, math.Random rnd) {
+    final roll = rnd.nextDouble();
+    double radius;
+    int brightness;
+    if (roll < 0.8) {
+      radius = Constants.starMaxSize * 0.25;
+      brightness = 150 + rnd.nextInt(40);
+    } else if (roll < 0.99) {
+      radius = Constants.starMaxSize * 0.5;
+      brightness = 180 + rnd.nextInt(60);
+    } else {
+      radius = Constants.starMaxSize;
+      brightness = 230 + rnd.nextInt(25);
+    }
+
+    final jitter = rnd.nextInt(25);
+    Color color;
+    if (rnd.nextBool()) {
+      // blue tint
+      color = Color.fromARGB(
+        255,
+        brightness,
+        brightness,
+        math.min(255, brightness + jitter),
+      );
+    } else {
+      // yellow tint
+      color = Color.fromARGB(
+        255,
+        math.min(255, brightness + jitter),
+        math.min(255, brightness + jitter),
+        brightness,
+      );
+    }
+
+    return _Star(position, radius, Paint()..color = color);
+  }
+
+  double _lerp(double a, double b, double t) => a + (b - a) * t;
+
+  int _gridIndex(Offset p, double cellSize, int gridSize) =>
+      (p.dx / cellSize).floor() + (p.dy / cellSize).floor() * gridSize;
+}
+
+class _Star {
+  _Star(this.position, this.radius, this.paint);
+  final Offset position;
+  final double radius;
+  final Paint paint;
 }

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -1,18 +1,19 @@
-
 # Starfield
 
-Deterministic world-space starfield drawn with `CustomPainter`.
+Deterministic world-space starfield rendered by `StarfieldComponent`.
 
 - Stars are generated per chunk using Poisson-disk sampling seeded by the
   `(chunkX, chunkY)` coordinates so results are reproducible.
-- A weighted radius/brightness distribution (≈80% tiny, 19% small, 1% medium)
-  gives variation; an optional subtle blue/yellow colour jitter adds depth.
-- Low-frequency Simplex noise modulates spawn probability for soft clusters and
-  voids.
-- Star data is cached per chunk. When rendering, the painter translates by
-  `-playerPosition` and draws circles via `canvas.drawCircle`, iterating from
-  faint to bright for gentle blending.
-- If rendering cost spikes, cache layers with `PictureRecorder` or
-  `Canvas.saveLayer`.
+- Low-frequency Simplex noise modulates the minimum distance between stars to
+  create subtle clusters and voids.
+- A weighted radius/brightness spread (≈80% tiny, 19% small, 1% medium) adds
+  variation, with optional subtle blue/yellow colour jitter.
+- Each chunk pre-renders its stars into a cached `Picture`. Tiles outside a
+  small margin around the camera are discarded to keep memory use bounded.
+  During `render` the canvas translates by `-cameraOrigin` so the player flies
+  over a static backdrop. Stars within each tile sort by radius so faint stars
+  render first for smoother blending.
+- A `debugDrawTiles` flag outlines each tile with a translucent stroke for
+  development verification.
 - Added to `SpaceGame` with a negative priority so it always renders beneath
   gameplay components.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -157,14 +157,18 @@ class Constants {
   /// Cell size for spatial grid used in proximity queries.
   static const double spatialGridCellSize = 200;
 
-  /// Number of stars spawned per parallax layer.
-  static const int starsPerLayer = 30;
-
-  /// Speeds for starfield layers in pixels per second.
-  static const double starSpeedSlow = 10;
-  static const double starSpeedMedium = 20;
-  static const double starSpeedFast = 40;
-
   /// Maximum star radius in logical pixels.
   static const double starMaxSize = 2;
+
+  /// Minimum distance between stars at highest density.
+  static const double starMinDistanceMin = 15;
+
+  /// Maximum distance between stars at lowest density.
+  static const double starMinDistanceMax = 40;
+
+  /// Noise frequency used to modulate star density.
+  static const double starNoiseScale = 0.1;
+
+  /// Extra tile padding kept around the camera for the starfield cache.
+  static const int starfieldCacheMargin = 1;
 }

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -23,8 +23,8 @@ Core game class and shared systems.
 ## Responsibilities
 
 - Load assets via a central registry before starting play.
-- Configure the world, including the deterministic world-space starfield and
-  camera.
+- Configure the world, including the deterministic world-space starfield that
+  prunes off-screen tiles, and the camera.
 - Spawn the player and register component spawners.
 - Maintain `GameState` values (`menu`, `playing`, `upgrades`, `paused`,
   `gameOver`) and swap overlays accordingly.

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -5,9 +5,9 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 ## Responsibilities
 
 - Preload assets via the central registry before entering gameplay.
-- Initialise the deterministic world-space starfield, set up a fixed-resolution
-  camera that follows the player via `camera.follow`, and register component
-  spawners.
+- Initialise the deterministic world-space starfield that prunes off-screen
+  tiles, set up a fixed-resolution camera that follows the player via
+  `camera.follow`, and register component spawners.
 - Spawn the player and register enemy or asteroid generators.
 - Provide small bullet, asteroid, enemy and mineral pickup pools to limit allocations.
 - Maintain `GameState` values (`menu`, `playing`, `paused`, `gameOver`)

--- a/lib/util/open_simplex_noise.dart
+++ b/lib/util/open_simplex_noise.dart
@@ -1,0 +1,117 @@
+import 'dart:math' as math;
+
+/// 2D Simplex noise implementation.
+///
+/// Adapted from Stefan Gustavson's public domain algorithm.
+class OpenSimplexNoise {
+  OpenSimplexNoise([int seed = 0]) {
+    final p = List<int>.generate(256, (i) => i);
+    final random = math.Random(seed);
+    for (int i = 255; i >= 0; i--) {
+      final j = random.nextInt(i + 1);
+      final temp = p[i];
+      p[i] = p[j];
+      p[j] = temp;
+    }
+    for (int i = 0; i < 512; i++) {
+      _perm[i] = p[i & 255];
+    }
+  }
+
+  final List<int> _perm = List<int>.filled(512, 0);
+
+  static const List<int> _grad3 = [
+    1,
+    1,
+    0,
+    -1,
+    1,
+    0,
+    1,
+    -1,
+    0,
+    -1,
+    -1,
+    0,
+    1,
+    0,
+    1,
+    -1,
+    0,
+    1,
+    1,
+    0,
+    -1,
+    -1,
+    0,
+    -1,
+    0,
+    1,
+    1,
+    0,
+    -1,
+    1,
+    0,
+    1,
+    -1,
+    0,
+    -1,
+    -1,
+  ];
+
+  double noise2D(double xin, double yin) {
+    const double F2 = 0.366025403; // (sqrt(3)-1)/2
+    const double G2 = 0.211324865; // (3-sqrt(3))/6
+
+    double n0 = 0, n1 = 0, n2 = 0;
+
+    final s = (xin + yin) * F2;
+    final i = (xin + s).floor();
+    final j = (yin + s).floor();
+    final t = (i + j) * G2;
+    final X0 = i - t;
+    final Y0 = j - t;
+    final x0 = xin - X0;
+    final y0 = yin - Y0;
+
+    int i1, j1;
+    if (x0 > y0) {
+      i1 = 1;
+      j1 = 0;
+    } else {
+      i1 = 0;
+      j1 = 1;
+    }
+
+    final x1 = x0 - i1 + G2;
+    final y1 = y0 - j1 + G2;
+    final x2 = x0 - 1 + 2 * G2;
+    final y2 = y0 - 1 + 2 * G2;
+
+    final ii = i & 255;
+    final jj = j & 255;
+    final gi0 = _perm[ii + _perm[jj]] % 12;
+    final gi1 = _perm[ii + i1 + _perm[jj + j1]] % 12;
+    final gi2 = _perm[ii + 1 + _perm[jj + 1]] % 12;
+
+    double t0 = 0.5 - x0 * x0 - y0 * y0;
+    if (t0 >= 0) {
+      t0 *= t0;
+      n0 = t0 * t0 * (_grad3[gi0 * 3] * x0 + _grad3[gi0 * 3 + 1] * y0);
+    }
+
+    double t1 = 0.5 - x1 * x1 - y1 * y1;
+    if (t1 >= 0) {
+      t1 *= t1;
+      n1 = t1 * t1 * (_grad3[gi1 * 3] * x1 + _grad3[gi1 * 3 + 1] * y1);
+    }
+
+    double t2 = 0.5 - x2 * x2 - y2 * y2;
+    if (t2 >= 0) {
+      t2 *= t2;
+      n2 = t2 * t2 * (_grad3[gi2 * 3] * x2 + _grad3[gi2 * 3 + 1] * y2);
+    }
+
+    return 70.0 * (n0 + n1 + n2);
+  }
+}

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -22,10 +22,10 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - Background stars are generated per world-space chunk using Poisson-disk
   sampling seeded by chunk coordinates. Low-frequency Simplex noise modulates
   density for clusters and voids. Stars follow a weighted radius/brightness
-  distribution with subtle colour jitter and are cached per chunk. A
-  `CustomPainter` translates by `-playerPosition` and draws faint-to-bright
-  circles, optionally caching layers with `PictureRecorder` if performance dips
-  so the field stays static as the player moves.
+  distribution with subtle colour jitter and pre-render per chunk to a cached
+  `Picture` translated by `-playerPosition`, pruning tiles outside a small
+  margin so memory stays bounded and drawing faint-to-bright circles so the
+  field stays static as the player moves.
 - Centralise audio assets in `assets.dart` and play them through a small
   audio service.
 - Persist the high score with `shared_preferences` using a lightweight storage

--- a/test/starfield_cache_prune_test.dart
+++ b/test/starfield_cache_prune_test.dart
@@ -1,0 +1,45 @@
+import 'dart:ui';
+
+import 'package:flame/game.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/components/starfield.dart';
+import 'package:space_game/constants.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  int _tileCount(Vector2 cameraPos, Vector2 viewSize) {
+    final left = cameraPos.x - viewSize.x / 2;
+    final top = cameraPos.y - viewSize.y / 2;
+    final right = left + viewSize.x;
+    final bottom = top + viewSize.y;
+    final startX = (left / Constants.starfieldTileSize).floor();
+    final endX = (right / Constants.starfieldTileSize).floor();
+    final startY = (top / Constants.starfieldTileSize).floor();
+    final endY = (bottom / Constants.starfieldTileSize).floor();
+    return (endX - startX + 1) * (endY - startY + 1);
+  }
+
+  test('prunes tiles outside camera range', () async {
+    final game = FlameGame();
+    game.onGameResize(Vector2.all(512));
+    final starfield = StarfieldComponent();
+    await game.add(starfield);
+
+    final recorder = PictureRecorder();
+    final canvas = Canvas(recorder);
+
+    game.camera.viewfinder.position = Vector2.zero();
+    starfield.render(canvas);
+    final originExpected =
+        _tileCount(game.camera.viewfinder.position, game.size);
+    expect(starfield.debugCacheSize, originExpected);
+
+    game.camera.viewfinder.position = Vector2(3000, 0);
+    starfield.render(canvas);
+    final movedExpected =
+        _tileCount(game.camera.viewfinder.position, game.size);
+    expect(starfield.debugCacheSize, movedExpected);
+  });
+}

--- a/test/starfield_debug_tiles_test.dart
+++ b/test/starfield_debug_tiles_test.dart
@@ -1,0 +1,23 @@
+import 'dart:ui';
+
+import 'package:flame/game.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/components/starfield.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('debugDrawTiles outlines tiles when enabled', () async {
+    final game = FlameGame();
+    game.onGameResize(Vector2.all(256));
+    final starfield = StarfieldComponent(debugDrawTiles: true);
+    await game.add(starfield);
+
+    final recorder = PictureRecorder();
+    final canvas = Canvas(recorder);
+
+    expect(starfield.debugDrawTiles, isTrue);
+    starfield.render(canvas); // should draw without throwing
+  });
+}

--- a/test/starfield_draw_order_test.dart
+++ b/test/starfield_draw_order_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:space_game/components/starfield.dart';
+
+void main() {
+  test('starfield tile stars are sorted by radius', () {
+    final starfield = StarfieldComponent();
+    final radii = starfield.debugTileStarRadii(0, 0).toList();
+    final sorted = List<double>.from(radii)..sort();
+    expect(radii, sorted);
+  });
+}


### PR DESCRIPTION
## Summary
- replace parallax starfield with cached world-space starfield driven by Poisson-disk sampling and simplex noise
- pre-render starfield tiles to cached `Picture` objects, pruning tiles outside a small camera margin to bound memory
- sort tile stars by radius so faint ones draw first and expose a helper for tests
- expose starfield tuning constants and simplex noise utility
- document deterministic starfield and mark related tasks complete
- add unit tests verifying starfield cache pruning, debug tile outlines, and draw-order sorting

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx -y markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bd8b03772483309ba648fbf2ea6bc1