### PR TITLE
feat: add predicate support to nearest component lookup

### DIFF
--- a/lib/components/auto_aim_behavior.dart
+++ b/lib/components/auto_aim_behavior.dart
@@ -19,7 +19,7 @@ class AutoAimBehavior extends Component
     final enemies = game.pools.components<EnemyComponent>();
     final target = enemies.findClosest(
       parent.position,
-      game.upgradeService.targetingRange,
+      maxDistance: game.upgradeService.targetingRange,
     );
     if (target != null) {
       parent.targetAngle = _normalizeAngle(

--- a/lib/components/mining_laser.dart
+++ b/lib/components/mining_laser.dart
@@ -53,7 +53,7 @@ class MiningLaserComponent extends Component with HasGameReference<SpaceGame> {
       );
       _target = asteroids.findClosest(
         player.position,
-        miningRange,
+        maxDistance: miningRange,
       );
       _pulseTimer
         ..stop()

--- a/lib/util/nearest_component.dart
+++ b/lib/util/nearest_component.dart
@@ -2,13 +2,24 @@ import 'package:flame/components.dart';
 
 /// Extension providing nearest-component search utilities.
 extension NearestComponent<T extends PositionComponent> on Iterable<T> {
-  /// Finds the closest component to [origin] within [maxDistance].
+  /// Finds the closest component to [origin].
   ///
-  /// Returns `null` if no component is within the distance threshold.
-  T? findClosest(Vector2 origin, double maxDistance) {
+  /// Components further than [maxDistance] are ignored. The optional [where]
+  /// predicate can be used to filter which components are considered.
+  ///
+  /// Returns `null` if no component satisfies the criteria.
+  T? findClosest(
+    Vector2 origin, {
+    double maxDistance = double.infinity,
+    bool Function(T component)? where,
+  }) {
+    assert(maxDistance >= 0, 'maxDistance must be non-negative');
     T? closest;
     var closestDistanceSquared = maxDistance * maxDistance;
     for (final component in this) {
+      if (where != null && !where(component)) {
+        continue;
+      }
       final distanceSquared = component.position.distanceToSquared(origin);
       if (distanceSquared < closestDistanceSquared) {
         closest = component;

--- a/test/nearest_component_test.dart
+++ b/test/nearest_component_test.dart
@@ -20,7 +20,7 @@ void main() {
     final origin = Vector2.zero();
     final result = components.findClosest(
       origin,
-      8,
+      maxDistance: 8,
     );
     expect(result, equals(components[1]));
   });
@@ -33,8 +33,21 @@ void main() {
     final origin = Vector2.zero();
     final result = components.findClosest(
       origin,
-      4,
+      maxDistance: 4,
     );
     expect(result, isNull);
+  });
+
+  test('findClosestComponent with predicate', () {
+    final components = [
+      _TestComponent(Vector2(10, 0)),
+      _TestComponent(Vector2(5, 0)),
+    ];
+    final origin = Vector2.zero();
+    final result = components.findClosest(
+      origin,
+      where: (c) => c.position.x > 6,
+    );
+    expect(result, equals(components[0]));
   });
 }


### PR DESCRIPTION
## Summary
- expand nearest component helper with optional max distance and predicate filter
- apply new lookup in mining laser and auto-aim behavior
- test predicate filtering

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea25f107483308769f64b60f2528b