### PR TITLE
feat: add generic storage helpers

### DIFF
--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -19,68 +19,91 @@ class StorageService {
   static const _mutedKey = 'muted';
   static const _playerSpriteKey = 'playerSpriteIndex';
 
+  /// Retrieves a stored value for [key] or returns [defaultValue] if unset.
+  ///
+  /// Supported types are [int], [double], [bool], [String] and
+  /// [List]<[String]>. Throws [UnsupportedError] for unsupported types.
+  T getValue<T>(String key, T defaultValue) {
+    final value = _prefs.get(key);
+    return value is T ? value : defaultValue;
+  }
+
+  /// Persists [value] for [key].
+  ///
+  /// Supported types are [int], [double], [bool], [String] and
+  /// [List]<[String]>. Throws [UnsupportedError] for unsupported types.
+  Future<void> setValue<T>(String key, T value) async {
+    if (value is int) {
+      await _prefs.setInt(key, value);
+    } else if (value is double) {
+      await _prefs.setDouble(key, value);
+    } else if (value is bool) {
+      await _prefs.setBool(key, value);
+    } else if (value is String) {
+      await _prefs.setString(key, value);
+    } else if (value is List<String>) {
+      await _prefs.setStringList(key, value);
+    } else {
+      throw UnsupportedError('Type ${value.runtimeType} is not supported');
+    }
+  }
+
   /// Returns the stored high score or `0` if none exists.
-  int getHighScore() => _prefs.getInt(_highScoreKey) ?? 0;
+  int getHighScore() => getInt(_highScoreKey, 0);
 
   /// Persists a new high score value.
-  Future<void> setHighScore(int value) async {
-    await _prefs.setInt(_highScoreKey, value);
-  }
+  Future<void> setHighScore(int value) => setInt(_highScoreKey, value);
 
   /// Clears the stored high score.
-  Future<void> resetHighScore() async {
-    await _prefs.remove(_highScoreKey);
-  }
+  Future<void> resetHighScore() async => _prefs.remove(_highScoreKey);
 
   /// Whether audio is muted; defaults to `false` if unset.
-  bool isMuted() => _prefs.getBool(_mutedKey) ?? false;
+  bool isMuted() => getBool(_mutedKey, false);
 
   /// Persists the mute flag.
-  Future<void> setMuted(bool value) async {
-    await _prefs.setBool(_mutedKey, value);
-  }
+  Future<void> setMuted(bool value) => setBool(_mutedKey, value);
 
   /// Returns the selected player sprite index or `0` if unset.
-  int getPlayerSpriteIndex() => _prefs.getInt(_playerSpriteKey) ?? 0;
+  int getPlayerSpriteIndex() => getInt(_playerSpriteKey, 0);
 
   /// Persists the selected player sprite index.
-  Future<void> setPlayerSpriteIndex(int value) async {
-    await _prefs.setInt(_playerSpriteKey, value);
-  }
+  Future<void> setPlayerSpriteIndex(int value) =>
+      setInt(_playerSpriteKey, value);
 
   /// Retrieves a double value for [key] or returns [defaultValue] if unset.
   double getDouble(String key, double defaultValue) =>
-      _prefs.getDouble(key) ?? defaultValue;
+      getValue<double>(key, defaultValue);
 
   /// Persists a double [value] for [key].
-  Future<void> setDouble(String key, double value) async {
-    await _prefs.setDouble(key, value);
-  }
+  Future<void> setDouble(String key, double value) =>
+      setValue<double>(key, value);
 
   /// Retrieves a boolean for [key] or returns [defaultValue] if unset.
   bool getBool(String key, bool defaultValue) =>
-      _prefs.getBool(key) ?? defaultValue;
+      getValue<bool>(key, defaultValue);
 
   /// Persists a boolean [value] for [key].
-  Future<void> setBool(String key, bool value) async {
-    await _prefs.setBool(key, value);
-  }
+  Future<void> setBool(String key, bool value) => setValue<bool>(key, value);
 
   /// Retrieves an integer for [key] or returns [defaultValue] if unset.
-  int getInt(String key, int defaultValue) =>
-      _prefs.getInt(key) ?? defaultValue;
+  int getInt(String key, int defaultValue) => getValue<int>(key, defaultValue);
 
   /// Persists an integer [value] for [key].
-  Future<void> setInt(String key, int value) async {
-    await _prefs.setInt(key, value);
-  }
+  Future<void> setInt(String key, int value) => setValue<int>(key, value);
+
+  /// Retrieves a string for [key] or returns [defaultValue] if unset.
+  String getString(String key, String defaultValue) =>
+      getValue<String>(key, defaultValue);
+
+  /// Persists a string [value] for [key].
+  Future<void> setString(String key, String value) =>
+      setValue<String>(key, value);
 
   /// Retrieves a list of strings for [key] or returns [defaultValue] if unset.
   List<String> getStringList(String key, List<String> defaultValue) =>
-      _prefs.getStringList(key) ?? defaultValue;
+      getValue<List<String>>(key, defaultValue);
 
   /// Persists a list of strings [value] for [key].
-  Future<void> setStringList(String key, List<String> value) async {
-    await _prefs.setStringList(key, value);
-  }
+  Future<void> setStringList(String key, List<String> value) =>
+      setValue<List<String>>(key, value);
 }

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -7,13 +7,15 @@ Handles local persistence using `shared_preferences`.
 - Save and load the local high score.
 - Store settings such as the mute flag.
 - Persist the selected player sprite index.
-- Provide simple async getters and setters.
+- Provide simple async getters and setters for primitive values.
 - Future expansion can add save/load for other data.
 
 ## Usage
 
 Create the service with `await StorageService.create()` and call
 `getHighScore()`/`setHighScore()` or `isMuted()`/`setMuted()` to read or update
-values. Call `resetHighScore()` to clear the stored high score.
+values. Generic helpers `getValue`/`setValue` are also available for storing
+`int`, `double`, `bool`, `String` and `List<String>` values under custom keys.
+Call `resetHighScore()` to clear the stored high score.
 
 See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -30,5 +30,19 @@ void main() {
       await storage.setPlayerSpriteIndex(1);
       expect(storage.getPlayerSpriteIndex(), 1);
     });
+
+    test('generic get/set handles strings', () async {
+      SharedPreferences.setMockInitialValues({});
+      final storage = await StorageService.create();
+      await storage.setValue<String>('greeting', 'hello');
+      expect(storage.getValue<String>('greeting', ''), 'hello');
+    });
+
+    test('string helpers persist values', () async {
+      SharedPreferences.setMockInitialValues({});
+      final storage = await StorageService.create();
+      await storage.setString('name', 'Alice');
+      expect(storage.getString('name', ''), 'Alice');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- consolidate SharedPreferences access with `getValue`/`setValue`
- support storing strings and generic primitives
- document and test new storage helpers

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea25f107483308769f64b60f2528b