### PR TITLE
Fix joystick scaling flicker

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -389,12 +389,20 @@ class SpaceGame extends FlameGame
 
   void _updateJoystickScale() {
     final scale = settingsService.joystickScale.value;
-    // Rebuild the joystick to ensure the knob stays centred and scaling
-    // expands from the bottom-left corner.
-    joystick.removeFromParent();
-    joystick = _buildJoystick();
-    add(joystick);
-    joystick.onGameResize(size);
+    // Update the joystick in place to avoid flicker when scaling. Adjust the
+    // knob and background radii so growth originates from the bottom-left
+    // corner while keeping the knob centred.
+    final bg = joystick.background as CircleComponent;
+    final knob = joystick.knob as CircleComponent;
+    bg
+      ..radius = 50 * scale
+      ..position = Vector2.zero();
+    knob
+      ..radius = 20 * scale
+      ..position = Vector2.zero();
+    joystick
+      ..anchor = Anchor.bottomLeft
+      ..position = Vector2(40, size.y - 40);
 
     // Scale the fire button to match the joystick and stay anchored
     // to the bottom-right corner.

--- a/test/joystick_fire_button_scale_test.dart
+++ b/test/joystick_fire_button_scale_test.dart
@@ -38,8 +38,10 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     final bg = game.joystick.background as CircleComponent;
+    final knob = game.joystick.knob as CircleComponent;
     final fire = game.fireButton.button as CircleComponent;
     expect(bg.radius, 50 * 1.2);
+    expect(knob.radius, 20 * 1.2);
     expect(fire.radius, 30 * 1.2);
     expect(game.joystick.position.x, 40);
     expect(game.joystick.position.y, game.size.y - 40);


### PR DESCRIPTION
## Summary
- update joystick scale in place to avoid flicker
- cover joystick knob radius in scale test

## Testing
- `./scripts/flutterw analyze lib/game/space_game.dart test/joystick_fire_button_scale_test.dart`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea3ae2d488330904b600da73b5563