### PR TITLE
Use merged listenables in HUD value display

### DIFF
--- a/lib/ui/hud_value_display.dart
+++ b/lib/ui/hud_value_display.dart
@@ -46,12 +46,11 @@ class HudValueDisplay extends StatelessWidget {
 
     final textScale = GameText.textScale;
     if (textScale != null) {
-      return ValueListenableBuilder<double>(
-        valueListenable: textScale,
-        builder: (context, scale, _) => ValueListenableBuilder<int>(
-          valueListenable: valueListenable,
-          builder: (context, value, _) => buildDisplay(value, scale),
-        ),
+      final merged = Listenable.merge([textScale, valueListenable]);
+      return AnimatedBuilder(
+        animation: merged,
+        builder: (context, _) =>
+            buildDisplay(valueListenable.value, textScale.value),
       );
     }
 


### PR DESCRIPTION
## Summary
- simplify `HudValueDisplay` by merging text scale and value listenables into a single `AnimatedBuilder`

## Testing
- `scripts/dartw format lib/ui/hud_value_display.dart`
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea54d04948330af9e9ce840209c3a