### PR TITLE
chore: hide object pool internals

### DIFF
--- a/lib/util/object_pool.dart
+++ b/lib/util/object_pool.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 /// Generic object pool to minimise allocations by reusing instances.
 class ObjectPool<T> {
   /// Creates a new pool that builds objects using [create].
@@ -11,8 +13,13 @@ class ObjectPool<T> {
   final int? maxSize;
   final List<T> _items = [];
 
-  /// Returns the cached items currently in the pool.
-  Iterable<T> get items => _items;
+  /// Returns an unmodifiable view of the cached items currently in the pool.
+  ///
+  /// Exposing the internal list directly would allow callers to modify it and
+  /// break the pool's bookkeeping. Returning an [UnmodifiableListView] keeps
+  /// the data read-only while still reflecting updates to the underlying list
+  /// without additional copying.
+  UnmodifiableListView<T> get items => UnmodifiableListView(_items);
 
   T acquire([void Function(T)? reset]) {
     final obj = _items.isNotEmpty ? _items.removeLast() : _create();


### PR DESCRIPTION
## Summary
- prevent callers from mutating `ObjectPool.items`

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea54d04948330af9e9ce840209c3a