### PR TITLE
feat: tie starfield debug to game debug mode

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -192,7 +192,8 @@ tree spanning weapons and ship systems.
   pre-renders to a cached `Picture` translated by `-playerPosition`, dropping
   tiles outside a small margin around the camera so memory stays bounded. The
   player flies over a static backdrop while circles draw faint-to-bright. A
-  `debugDrawTiles` switch outlines tile boundaries for troubleshooting.
+  `debugDrawTiles` switch outlines tile boundaries when debug mode (`F1`) is
+  active for troubleshooting.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -182,10 +182,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   available on menu, HUD and game over overlays
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `N` toggles the
-  minimap, `F1` toggles debug overlays, `Enter` starts or restarts from the
-  menu or game over, `R` restarts at any time, `H` shows a help overlay that
-  `Esc` also closes, `U` opens an upgrades overlay that `Esc` also closes, `B`
-  toggles range rings)
+  minimap, `F1` toggles debug overlays and outlines starfield tiles, `Enter`
+  starts or restarts from the menu or game over, `R` restarts at any time, `H`
+  shows a help overlay that `Esc` also closes, `U` opens an upgrades overlay
+  that `Esc` also closes, `B` toggles range rings)
 - Upgrades overlay lets players spend minerals on simple upgrades that
   persist between sessions, opened with a HUD button or the `U` key and
   pausing gameplay
@@ -201,7 +201,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
     margin around the camera, then draws with a translation of `-playerPosition`
     so the player flies over a static backdrop. Stars sort by radius so faint
     ones render first for smoother blending. A `debugDrawTiles` option outlines
-    tile boundaries to aid development.
+    tile boundaries when debug mode (`F1`) is active to aid development.
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
   `P` to resume; `Q` returns to the menu from pause or game over
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -30,7 +30,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 ## Polish ([milestone-polish.md](milestone-polish.md))
 
-- [x] Parallax starfield renders behind gameplay.
+- [x] Deterministic world-space starfield renders behind gameplay.
 - [x] Implement `audio_service.dart` wrapping `flame_audio` with a
       mute toggle.
 - [x] Implement `storage_service.dart` using `shared_preferences`
@@ -69,7 +69,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       `Esc` also closes it.
 - [x] HUD displays current score, minerals and health.
 - [x] Limit player fire rate with a brief cooldown.
-- [x] Keyboard shortcut `F1` toggles debug overlays.
+- [x] Keyboard shortcut `F1` toggles debug overlays and outlines starfield tiles.
 - [x] Audio volume lowers when the game is paused.
 - [x] Menu includes button to reset the high score.
 - [x] Menu allows choosing between multiple ship sprites and persists the selection.
@@ -97,7 +97,6 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Attach a `CameraComponent` that follows the player with no fixed bounds.
 - [x] Spawn asteroids and enemies just ahead of the player and despawn those
       far behind.
-- [x] Tile the parallax starfield so it scrolls seamlessly.
 - [x] Add a minimap or other navigation aid for exploring the larger world.
 - [x] Replace the player-following parallax starfield with a deterministic
       world-space starfield:

--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -18,11 +18,13 @@ class StarfieldComponent extends Component with HasGameReference<FlameGame> {
   late final OpenSimplexNoise _noise = OpenSimplexNoise(_seed);
   final Map<math.Point<int>, Picture> _cache = {};
 
-  /// Whether to draw debug outlines around generated tiles.
-  final bool debugDrawTiles;
+  /// Whether to draw debug outlines around generated tiles. This can be toggled
+  /// at runtime so `SpaceGame.toggleDebug` can enable tile borders when debug
+  /// mode is active.
+  bool debugDrawTiles;
 
   static final Paint _outlinePaint = Paint()
-    ..color = const Color(0x40FFFFFF)
+    ..color = Constants.starfieldTileOutlineColor
     ..style = PaintingStyle.stroke;
 
   /// Exposes the current cache size for tests.

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -14,6 +14,8 @@ Deterministic world-space starfield rendered by `StarfieldComponent`.
   over a static backdrop. Stars within each tile sort by radius so faint stars
   render first for smoother blending.
 - A `debugDrawTiles` flag outlines each tile with a translucent stroke for
-  development verification.
+  development verification. `SpaceGame.toggleDebug` flips this on whenever the
+  game's debug mode is enabled so tile borders appear alongside other debug
+  visuals.
 - Added to `SpaceGame` with a negative priority so it always renders beneath
   gameplay components.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 /// Centralised tunable values for the game.
 class Constants {
   /// Distance from the player after which entities are removed.
@@ -168,6 +170,9 @@ class Constants {
 
   /// Noise frequency used to modulate star density.
   static const double starNoiseScale = 0.1;
+
+  /// Colour used for starfield tile outlines in debug mode.
+  static const Color starfieldTileOutlineColor = Color(0x40FFFFFF);
 
   /// Extra tile padding kept around the camera for the starfield cache.
   static const int starfieldCacheMargin = 1;

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -165,7 +165,7 @@ class SpaceGame extends FlameGame
     joystick = _buildJoystick();
     await add(joystick);
 
-    _starfield = await StarfieldComponent();
+    _starfield = await StarfieldComponent(debugDrawTiles: debugMode);
     await add(_starfield!);
 
     player = PlayerComponent(
@@ -321,6 +321,9 @@ class SpaceGame extends FlameGame
     // Ensure pooled components also reflect the new debug mode so reused
     // instances don't retain stale debug flags.
     pools.applyDebugMode(debugMode);
+
+    // Outline starfield tiles when debug visuals are enabled.
+    _starfield?.debugDrawTiles = debugMode;
 
     if (debugMode) {
       if (_fpsText != null && !_fpsText!.isMounted) {

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -6,26 +6,27 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 
 - Preload assets via the central registry before entering gameplay.
 - Initialise the deterministic world-space starfield that prunes off-screen
-  tiles, set up a fixed-resolution camera that follows the player via
-  `camera.follow`, and register component spawners.
+   tiles, set up a fixed-resolution camera that follows the player via
+   `camera.follow`, and register component spawners.
 - Spawn the player and register enemy or asteroid generators.
 - Provide small bullet, asteroid, enemy and mineral pickup pools to limit allocations.
 - Maintain `GameState` values (`menu`, `playing`, `paused`, `gameOver`)
-  and toggle overlays.
+   and toggle overlays.
 - Route joystick, button and keyboard input to the player component.
 - Handle keyboard shortcuts such as `Escape` or `P` for pause, `M` for mute,
-  `Enter` to start or restart from the menu or game over, `R` to restart at any
-  time, `Q` to return to the menu from pause or game over, `Esc` to return to the
-  menu from game over, and `H` to show or hide the help overlay (`Esc` also
-  closes it).
+   `Enter` to start or restart from the menu or game over, `R` to restart at any
+   time, `Q` to return to the menu from pause or game over, `Esc` to return to the
+   menu from game over, and `H` to show or hide the help overlay (`Esc` also
+   closes it). Pressing `F1` toggles debug mode, outlining starfield tiles and
+   showing hit boxes.
 - Expose helpers to pause, resume or return to the menu.
 - Drive the update cycle while delegating work to components and services.
 - Persist and load the high score and selected player sprite index through
-  `StorageService`.
-- Exposes `ValueNotifier<int>`s for the current score, minerals, health and
-  persisted high score so Flutter overlays can render values without touching
-  the game loop.
+   `StorageService`.
+- Expose `ValueNotifier<int>`s for the current score, minerals, health and
+   persisted high score so Flutter overlays can render values without touching
+   the game loop.
 - Provide access to `AudioService` for playing sound effects and toggling mute.
-- Offers a method to reset the saved high score.
+- Offer a method to reset the saved high score.
 
 See [../../PLAN.md](../../PLAN.md) for the roadmap.


### PR DESCRIPTION
## Summary
- allow toggling starfield tile outlines when debug mode is enabled
- centralize starfield tile outline color constant
- document that F1 debug overlays outline starfield tiles

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`

------
https://chatgpt.com/codex/tasks/task_e_68bea251edcc8330a3134d9a2f76dd68