### PR TITLE
Fix settings overlay headings visibility

### DIFF
--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -46,16 +46,18 @@ class GameText extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget buildText(double scale) {
       final scheme = Theme.of(context).colorScheme;
-      final mergedStyle = _baseStyle.merge(style).copyWith(
-            color: color ?? scheme.primary,
-            decoration: TextDecoration.none,
-          );
-      final baseSize = mergedStyle.fontSize ?? _baseStyle.fontSize!;
+      final mergedStyle = _baseStyle.merge(style);
+      final effectiveColor = color ?? mergedStyle.color ?? scheme.primary;
+      final textStyle = mergedStyle.copyWith(
+        color: effectiveColor,
+        decoration: TextDecoration.none,
+      );
+      final baseSize = textStyle.fontSize ?? _baseStyle.fontSize!;
       return AutoSizeText(
         data,
         maxLines: maxLines,
         textAlign: textAlign,
-        style: mergedStyle.copyWith(fontSize: baseSize * scale),
+        style: textStyle.copyWith(fontSize: baseSize * scale),
       );
     }
 

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -42,12 +42,14 @@ class SettingsOverlay extends StatelessWidget {
                     'UI Settings',
                     style: Theme.of(context).textTheme.headlineSmall,
                     maxLines: 1,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
                   SizedBox(height: spacing),
                   GameText(
                     'HUD Scaling',
                     style: Theme.of(context).textTheme.titleMedium,
                     maxLines: 1,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
                   SizedBox(height: spacing),
                   _buildSlider(
@@ -78,6 +80,7 @@ class SettingsOverlay extends StatelessWidget {
                     'Range Scaling',
                     style: Theme.of(context).textTheme.titleMedium,
                     maxLines: 1,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
                   SizedBox(height: spacing),
                   _buildSlider(

--- a/test/game_text_test.dart
+++ b/test/game_text_test.dart
@@ -1,0 +1,22 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/ui/game_text.dart';
+
+void main() {
+  testWidgets('GameText uses provided style color', (tester) async {
+    const color = Colors.red;
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: GameText(
+          'test',
+          style: TextStyle(color: color),
+        ),
+      ),
+    ));
+
+    final autoText = tester.widget<AutoSizeText>(find.byType(AutoSizeText));
+    expect(autoText.style?.color, color);
+  });
+}


### PR DESCRIPTION
## Summary
- Ensure settings overlay section headings use the theme surface color
- Respect text style colors in `GameText`
- Test `GameText` color handling

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bea618a80083309e191fc166241d57