### PR TITLE
Expose high score reset status

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -303,7 +303,9 @@ class SpaceGame extends FlameGame
   }
 
   /// Clears the saved high score.
-  Future<void> resetHighScore() => scoreService.resetHighScore();
+  ///
+  /// Returns `true` if the score was removed from storage.
+  Future<bool> resetHighScore() => scoreService.resetHighScore();
 
   /// Transitions to the game over state.
   void gameOver() => stateMachine.gameOver();

--- a/lib/services/score_service.dart
+++ b/lib/services/score_service.dart
@@ -34,9 +34,12 @@ class ScoreService {
     return health.value <= 0;
   }
 
-  Future<void> resetHighScore() async {
+  /// Clears the high score both in memory and persistent storage.
+  ///
+  /// Returns `true` if the underlying storage was successfully updated.
+  Future<bool> resetHighScore() async {
     highScore.value = 0;
-    await storageService.resetHighScore();
+    return storageService.resetHighScore();
   }
 
   Future<void> updateHighScoreIfNeeded() async {

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -55,7 +55,9 @@ class StorageService {
   Future<void> setHighScore(int value) => setInt(_highScoreKey, value);
 
   /// Clears the stored high score.
-  Future<void> resetHighScore() async => _prefs.remove(_highScoreKey);
+  ///
+  /// Returns `true` if the value was successfully removed from storage.
+  Future<bool> resetHighScore() => _prefs.remove(_highScoreKey);
 
   /// Whether audio is muted; defaults to `false` if unset.
   bool isMuted() => getBool(_mutedKey, false);

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -16,6 +16,7 @@ Create the service with `await StorageService.create()` and call
 `getHighScore()`/`setHighScore()` or `isMuted()`/`setMuted()` to read or update
 values. Generic helpers `getValue`/`setValue` are also available for storing
 `int`, `double`, `bool`, `String` and `List<String>` values under custom keys.
-Call `resetHighScore()` to clear the stored high score.
+Call `resetHighScore()` to clear the stored high score. The method returns a
+`bool` indicating whether the value was successfully removed.
 
 See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/test/score_service_test.dart
+++ b/test/score_service_test.dart
@@ -38,7 +38,7 @@ void main() {
     expect(score.highScore.value, 15);
     expect(storage.getHighScore(), 15);
 
-    await score.resetHighScore();
+    expect(await score.resetHighScore(), isTrue);
     expect(score.highScore.value, 0);
     expect(storage.getHighScore(), 0);
   });

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -19,7 +19,7 @@ void main() {
       SharedPreferences.setMockInitialValues({'highScore': 99});
       final storage = await StorageService.create();
       expect(storage.getHighScore(), 99);
-      await storage.resetHighScore();
+      expect(await storage.resetHighScore(), isTrue);
       expect(storage.getHighScore(), 0);
     });
 


### PR DESCRIPTION
## Summary
- return a boolean from `StorageService.resetHighScore` and propagate through `ScoreService` and `SpaceGame`
- update docs and tests to verify reset success

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea81a4dc083309354e6dc63d30fe9