### PR TITLE
ci: cancel in-progress preview deploys

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,7 +12,9 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
-    continue-on-error: true
+    concurrency:
+      group: preview-${{ github.head_ref }}
+      cancel-in-progress: true
     environment:
       name: preview
       url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/
@@ -41,6 +43,7 @@ jobs:
         run: ./scripts/flutterw build web --release --base-href "/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/"
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
+        continue-on-error: true
         with:
           branch: gh-pages
           folder: build/web


### PR DESCRIPTION
## Summary
- avoid red PR checks by cancelling in-progress preview deploys
- tolerate deploy failures so cancelled runs don't fail

## Testing
- `./scripts/dartw format .github/workflows/deploy-preview.yml` (fails: source could not be parsed)
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea4d98c608330bf529408cabdde8e