### PR TITLE
docs: mention minimap scaling in settings overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -162,8 +162,8 @@ tree spanning weapons and ship systems.
   game when opened mid-run. `Esc` also closes it without triggering pause.
 - An upgrades overlay opens with the `U` key or HUD button and pauses gameplay
   while letting players buy basic upgrades that persist between sessions.
-- A settings overlay provides sliders for HUD, text, joystick, targeting,
-  Tractor Aura and mining ranges and includes a reset button.
+- A settings overlay provides sliders for HUD, minimap, text, joystick,
+  targeting, Tractor Aura and mining ranges and includes a reset button.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -189,8 +189,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Upgrades overlay lets players spend minerals on simple upgrades that
   persist between sessions, opened with a HUD button or the `U` key and
   pausing gameplay
-- Settings overlay with sliders for HUD, text, joystick, targeting, Tractor Aura
-  and mining ranges, plus a reset button
+- Settings overlay with sliders for HUD, minimap, text, joystick, targeting,
+  Tractor Aura and mining ranges, plus a reset button
 - Game works offline after the first load thanks to the service worker
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.


### PR DESCRIPTION
## Summary
- document minimap scale slider in settings overlay within PLAN and DESIGN docs

## Testing
- `scripts/dartw format .`
- `scripts/dartw analyze`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bea81f4b3c8330b366c7478d928718