### PR TITLE
docs: document Q shortcut

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -175,6 +175,7 @@ tree spanning weapons and ship systems.
   mining radii.
 - `H` toggles a help overlay for quick reference, and `Esc` closes it when
   visible.
+- `Q` returns to the menu when pressed during pause or game over.
 
 ## Rendering & Camera
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ dedicated server or NAT traversal.
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `B` toggles range
   rings, `N` toggles the minimap, `F1` toggles debug overlays, `Enter` starts
-  or restarts from the menu or game over, `R` restarts at any time, `H` shows a
-  help overlay that `Esc` also closes, `U` opens an upgrades overlay that `Esc`
-  also closes)
+  or restarts from the menu or game over, `R` restarts at any time, `Q` returns
+  to the menu from pause or game over, `H` shows a help overlay that `Esc` also
+  closes, `U` opens an upgrades overlay that `Esc` also closes)
 - Game works offline after the first load
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -30,8 +30,9 @@ Flutter overlays and HUD widgets.
   scale and gameplay ranges, with a reset button; opened via HUD button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
-  time; `Escape` or `P` pauses or resumes; `H` shows or hides the help overlay,
-  `U` opens upgrades, `N` toggles the minimap, `B` toggles range rings, and
-  `Esc` also closes overlays when visible.
+  time; `Q` returns to the menu from pause or game over; `Escape` or `P` pauses
+  or resumes; `H` shows or hides the help overlay, `U` opens upgrades, `N`
+  toggles the minimap, `B` toggles range rings, and `Esc` also closes overlays
+  when visible.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -40,6 +40,7 @@ class HelpOverlay extends StatelessWidget {
               'Pause/Resume: Esc or P\n'
               'Start/Restart: Enter\n'
               'Restart anytime: R\n'
+              'Return to Menu: Q (from pause or game over)\n'
               'Toggle Help: H or Esc',
               textAlign: TextAlign.center,
             ),

--- a/lib/ui/help_overlay.md
+++ b/lib/ui/help_overlay.md
@@ -8,6 +8,7 @@ Lists available touch and keyboard controls.
 - Activated via the `H` key or help buttons on other overlays.
 - Pauses gameplay when opened during a run and resumes when closed.
 - Dismiss with the on-screen close button or by pressing `H` again or `Esc`.
-- Lists the `N` key for toggling the minimap and `B` for range rings.
+- Lists keys such as `N` to toggle the minimap, `B` for range rings and `Q`
+  to return to the menu from pause or game over.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/lib/ui/pause_overlay.md
+++ b/lib/ui/pause_overlay.md
@@ -10,6 +10,7 @@ Overlay displayed when the game is paused.
 - Triggered from the HUD pause button or the Escape or `P` key.
 - Visible only while the game state is `paused`.
 - Keyboard shortcuts still work: `R` restarts, `M` toggles audio mute and `H`
-  opens the help overlay which resumes when closed; `Esc` also closes it.
+  opens the help overlay which resumes when closed; `Q` returns to the menu; and
+  `Esc` also closes it.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- mention Q key in help overlay to return to menu
- document Q shortcut across design and UI docs

## Testing
- `./scripts/dartw analyze lib/ui/help_overlay.dart`
- `npx --yes markdownlint-cli DESIGN.md README.md lib/ui/README.md lib/ui/help_overlay.md lib/ui/pause_overlay.md`


------
https://chatgpt.com/codex/tasks/task_e_68bea81f4b3c8330b366c7478d928718