### PR TITLE
Synchronize joystick hitbox with visual scale

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -403,9 +403,13 @@ class SpaceGame extends FlameGame
     knob
       ..radius = 20 * scale
       ..position = Vector2.zero();
+    // Update cached values so the hitbox matches the visual size.
     joystick
+      ..size = Vector2.all(100 * scale)
+      ..knobRadius = 20 * scale
       ..anchor = Anchor.bottomLeft
       ..position = Vector2(40, size.y - 40);
+    joystick.onGameResize(size);
 
     // Scale the fire button to match the joystick and stay anchored
     // to the bottom-right corner.


### PR DESCRIPTION
## Summary
- update joystick size and knob radius when scaling so touch input matches visuals

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bea854aa248330992ab8a9b79b3f02