### PR TITLE
Dispose service notifiers on game teardown

### DIFF
--- a/lib/game/game_state_machine.dart
+++ b/lib/game/game_state_machine.dart
@@ -61,4 +61,9 @@ class GameStateMachine {
     overlays.showMenu();
     onMenu();
   }
+
+  /// Releases resources held by the state machine.
+  void dispose() {
+    stateNotifier.dispose();
+  }
 }

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -434,6 +434,16 @@ class SpaceGame extends FlameGame
     camera.viewfinder.anchor = Anchor.center;
   }
 
+  @override
+  void onRemove() {
+    settingsService.dispose();
+    scoreService.dispose();
+    upgradeService.dispose();
+    stateMachine.dispose();
+    eventBus.dispose();
+    super.onRemove();
+  }
+
   /// Requests keyboard focus for the surrounding [GameWidget].
   void focusGame() => focusNode.requestFocus();
 }

--- a/lib/services/score_service.dart
+++ b/lib/services/score_service.dart
@@ -48,4 +48,12 @@ class ScoreService {
       await storageService.setHighScore(highScore.value);
     }
   }
+
+  /// Releases resources held by the service.
+  void dispose() {
+    score.dispose();
+    highScore.dispose();
+    minerals.dispose();
+    health.dispose();
+  }
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -92,4 +92,15 @@ class SettingsService {
     notifier.addListener(() => _storage?.setDouble(key, notifier.value));
     return notifier;
   }
+
+  /// Releases resources held by the service.
+  void dispose() {
+    hudButtonScale.dispose();
+    textScale.dispose();
+    joystickScale.dispose();
+    minimapScale.dispose();
+    targetingRange.dispose();
+    tractorRange.dispose();
+    miningRange.dispose();
+  }
 }

--- a/lib/services/upgrade_service.dart
+++ b/lib/services/upgrade_service.dart
@@ -97,4 +97,9 @@ class UpgradeService {
     );
     return true;
   }
+
+  /// Releases resources held by the service.
+  void dispose() {
+    _purchased.dispose();
+  }
 }


### PR DESCRIPTION
## Summary
- add dispose methods to ScoreService, SettingsService, UpgradeService, and GameStateMachine
- invoke service disposal in SpaceGame.onRemove to prevent lingering notifiers

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beaa38d0648330bbea04f71548aac7