### PR TITLE
Handle completed run cancellation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,11 +39,18 @@ jobs:
               }
             );
             for (const run of runs) {
-              await github.rest.actions.cancelWorkflowRun({
-                owner,
-                repo,
-                run_id: run.id,
-              });
+              try {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+              } catch (error) {
+                // Ignore "Cannot cancel" errors when the run completes before cancellation.
+                if (error.status !== 409) {
+                  throw error;
+                }
+              }
             }
       - name: Cache Flutter SDK
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- ignore 409 errors when cancelling preview deployments so completed runs don't fail the workflow

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68beac4a71d483308f8863a8d0e276ec