### PR TITLE
Dispose audio resources

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -445,6 +445,7 @@ class SpaceGame extends FlameGame
     upgradeService.dispose();
     stateMachine.dispose();
     eventBus.dispose();
+    audioService.dispose();
     super.onRemove();
   }
 

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -118,12 +118,21 @@ class AudioService {
 
   /// Stops the looping mining laser sound if playing.
   void stopMiningLaser() {
-    _miningLoop?.stop();
+    final loop = _miningLoop;
+    loop?.stop();
+    loop?.dispose();
     _miningLoop = null;
   }
 
   /// Stops all ongoing audio loops.
   void stopAll() {
     stopMiningLaser();
+  }
+
+  /// Releases all resources and disposes internal notifiers.
+  void dispose() {
+    stopAll();
+    muted.dispose();
+    _shootPool?.dispose();
   }
 }

--- a/lib/services/audio_service.md
+++ b/lib/services/audio_service.md
@@ -9,6 +9,7 @@ Lightweight wrapper around `flame_audio`.
 - Expose a mute toggle and master volume persisted via `StorageService`.
 - Provide simple methods like `playShoot()`, `playExplosion()` and
   `stopAll()` to halt loops.
+- Free audio resources with `dispose()` when the service is no longer needed.
 - Reuse the shoot sound via a web-only `AudioPool` to avoid network
   fetches on rapid fire.
 

--- a/test/audio_service_test.dart
+++ b/test/audio_service_test.dart
@@ -47,11 +47,13 @@ void main() {
 
     service.stopMiningLaser();
     expect(player.stopped, isTrue);
+    expect(player.disposed, isTrue);
     expect(service.miningLoop, isNull);
 
     await service.startMiningLaser();
     await service.toggleMute();
     expect(player.stopped, isTrue);
+    expect(player.disposed, isTrue);
     expect(service.miningLoop, isNull);
 
     await service.startMiningLaser();
@@ -82,16 +84,39 @@ void main() {
 
     service.stopAll();
     expect(player.stopped, isTrue);
+    expect(player.disposed, isTrue);
+    expect(service.miningLoop, isNull);
+  });
+
+  test('dispose stops loops and releases resources', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final player = _FakeAudioPlayer();
+    final service = await AudioService.create(
+      storage,
+      loop: (_, {double volume = 1}) async => player,
+    );
+
+    await service.startMiningLaser();
+    service.dispose();
+    expect(player.stopped, isTrue);
+    expect(player.disposed, isTrue);
     expect(service.miningLoop, isNull);
   });
 }
 
 class _FakeAudioPlayer implements AudioPlayer {
   bool stopped = false;
+  bool disposed = false;
 
   @override
   Future<void> stop() async {
     stopped = true;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
   }
 
   @override

--- a/test/enemy_damage_test.dart
+++ b/test/enemy_damage_test.dart
@@ -54,6 +54,9 @@ class _FakeAudioService implements AudioService {
   void setMasterVolume(double volume) {
     _masterVolume = volume;
   }
+
+  @override
+  void dispose() {}
 }
 
 class _TestPlayer extends PlayerComponent {

--- a/test/player_collision_test.dart
+++ b/test/player_collision_test.dart
@@ -56,6 +56,9 @@ class _FakeAudioService implements AudioService {
   void setMasterVolume(double volume) {
     _masterVolume = volume;
   }
+
+  @override
+  void dispose() {}
 }
 
 class _FakeOverlayService implements OverlayService {

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -75,6 +75,9 @@ class _FakeAudioService implements AudioService {
 
   @override
   AudioPlayer? get miningLoop => null;
+
+  @override
+  void dispose() {}
 }
 
 class _Harness {


### PR DESCRIPTION
## Summary
- ensure AudioService stops and disposes active audio players
- clean up AudioService when the game is removed
- document and test audio resource disposal

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bead10f1ec833088053b50009c9905