### PR TITLE
Fix event bus disposal timing in SpaceGame.onRemove

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -444,8 +444,10 @@ class SpaceGame extends FlameGame
     scoreService.dispose();
     upgradeService.dispose();
     stateMachine.dispose();
-    eventBus.dispose();
     super.onRemove();
+    // Dispose the event bus after children are removed so they can emit
+    // removal events without errors.
+    eventBus.dispose();
   }
 
   /// Requests keyboard focus for the surrounding [GameWidget].


### PR DESCRIPTION
## Summary
- Dispose event bus after child components remove to avoid closed stream errors

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beadef75c88330b2a456149c6e63a6