### PR TITLE
Default to parallel Flutter tests

### DIFF
--- a/scripts/flutterw
+++ b/scripts/flutterw
@@ -9,9 +9,36 @@ source "$(dirname "$0")/bootstrap_flutter.sh"
 echo "[flutterw] Flutter SDK ready"
 # Restore original args for the actual flutter invocation.
 set -- "${args[@]}"
+test_concurrency=""
+if [[ "${1:-}" == "test" ]]; then
+  found_concurrency=false
+  for ((i=1; i<=$#; i++)); do
+    arg=${!i}
+    if [[ $arg == --concurrency ]]; then
+      found_concurrency=true
+      next_index=$((i+1))
+      if (( next_index <= $# )); then
+        test_concurrency=${!next_index}
+      fi
+      break
+    elif [[ $arg == --concurrency=* ]]; then
+      found_concurrency=true
+      test_concurrency=${arg#--concurrency=}
+      break
+    fi
+  done
+  if [[ $found_concurrency == false ]]; then
+    test_concurrency=${FLUTTER_TEST_CONCURRENCY:-$(nproc)}
+    set -- "$@" --concurrency "$test_concurrency"
+  fi
+fi
 echo "[flutterw] starting at $(date)"
 echo "[flutterw] flutter $@"
 if [[ "${1:-}" == "test" ]]; then
-  echo "[flutterw] running tests..."
+  if [[ -n "$test_concurrency" ]]; then
+    echo "[flutterw] running tests with concurrency $test_concurrency..."
+  else
+    echo "[flutterw] running tests..."
+  fi
 fi
 exec ".tooling/flutter/bin/flutter" "$@"

--- a/test/README.md
+++ b/test/README.md
@@ -11,3 +11,21 @@ Current suites verify:
 - Help overlay pause behaviour
 
 Tests use `flutter_test` and `flame_test` as noted in [../PLAN.md](../PLAN.md).
+
+## Running tests
+
+Execute the suite with the Flutter wrapper script:
+
+```bash
+scripts/flutterw test
+```
+
+The wrapper automatically enables parallel execution by passing a
+`--concurrency` value equal to the number of CPU cores. Set a different
+concurrency with the `FLUTTER_TEST_CONCURRENCY` environment variable or by
+specifying `--concurrency` explicitly:
+
+```bash
+FLUTTER_TEST_CONCURRENCY=8 scripts/flutterw test
+scripts/flutterw test --concurrency 4
+```


### PR DESCRIPTION
## Summary
- run Flutter tests with `--concurrency` by default
- document how to override parallelism via env or CLI

## Testing
- `npx --yes markdownlint-cli test/README.md`
- `FLUTTER_TEST_CONCURRENCY=4 script -q -c "scripts/flutterw test" /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68beadbbb6c08330b8a5dbfd4f9d5828