### PR TITLE
Guard against zero-density starfield layers

### DIFF
--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -23,6 +23,7 @@ class StarfieldLayerConfig {
   final double parallax;
 
   /// Multiplier applied to star density. Values >1 increase star count.
+  /// Values ≤0 disable the layer.
   final double density;
 
   /// Speed factor for star alpha animation.
@@ -171,6 +172,10 @@ class StarfieldComponent extends Component with HasGameReference<FlameGame> {
     if (layer.cache.containsKey(key) || layer.pending.containsKey(key)) {
       return;
     }
+    if (layer.config.density <= 0) {
+      layer.cache[key] = const <_Star>[];
+      return;
+    }
     final future =
         Future(() => _generateTileStars(_seed, tx, ty, layer.config.density));
     layer.pending[key] = future;
@@ -220,6 +225,9 @@ class _Star {
 
 List<_Star> _generateTileStars(
     int seed, int tx, int ty, double densityMultiplier) {
+  if (densityMultiplier <= 0) {
+    return const <_Star>[];
+  }
   final noise = OpenSimplexNoise(seed);
   final rnd = math.Random(seed ^ tx ^ (ty << 16));
   final n = noise.noise2D(

--- a/test/starfield_density_guard_test.dart
+++ b/test/starfield_density_guard_test.dart
@@ -1,0 +1,32 @@
+import 'dart:ui';
+
+import 'package:flame/game.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/components/starfield.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('layer density <= 0 generates no stars', () {
+    final zeroLayer =
+        StarfieldComponent(layers: const [StarfieldLayerConfig(density: 0)]);
+    final negativeLayer =
+        StarfieldComponent(layers: const [StarfieldLayerConfig(density: -1)]);
+    expect(zeroLayer.debugTileStarRadii(0, 0), isEmpty);
+    expect(negativeLayer.debugTileStarRadii(0, 0), isEmpty);
+  });
+
+  test('zero density layer does not crash during update', () async {
+    final game = FlameGame();
+    game.onGameResize(Vector2.all(256));
+    final starfield =
+        StarfieldComponent(layers: const [StarfieldLayerConfig(density: 0)]);
+    await game.add(starfield);
+
+    starfield.update(0);
+    await starfield.debugWaitForPending();
+
+    expect(starfield.debugTileStarRadii(0, 0), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Avoid crashing when starfield layer density is zero or negative by returning no stars
- Document that non-positive density disables a layer
- Test non-positive density starfield behavior and update path

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68beaf97f208833099a4ea405db5aba0