### PR TITLE
refactor: extract damage flash mixin

### DIFF
--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -8,8 +8,9 @@ Gameplay entities and reusable pieces.
   when it needs game context.
 - Use simple hit boxes like `CircleHitbox` or `RectangleHitbox` with
   `HasCollisionDetection` on the game.
-- Shared mixins like `DebugHealthText` provide common behaviours such as
-  rendering health values while in debug mode.
+- Shared mixins like `DebugHealthText` and `DamageFlash` provide common
+  behaviours such as rendering health values in debug mode or flashing sprites
+  when taking damage.
 - Pull tunable values from `constants.dart` and asset references from
   `assets.dart`.
 - Bullet, asteroid and enemy components use small object pools to reduce

--- a/lib/components/damage_flash.dart
+++ b/lib/components/damage_flash.dart
@@ -1,0 +1,43 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+
+import '../constants.dart';
+
+/// Mixin that applies a temporary red tint when [flashDamage] is called.
+///
+/// Components mixing this in must expose a [paint] via [HasPaint]. The flash
+/// duration defaults to [Constants.playerDamageFlashDuration] but can be
+/// overridden.
+///
+/// The mixin handles fading the colour filter over time during [update].
+mixin DamageFlash on Component, HasPaint {
+  static const _damageColor = Color(0xffff0000);
+
+  double _flashTime = 0;
+
+  /// Duration that the tint remains visible.
+  double get damageFlashDuration => Constants.playerDamageFlashDuration;
+
+  /// Triggers the red flash effect.
+  void flashDamage() {
+    _flashTime = damageFlashDuration;
+    paint.colorFilter = ColorFilter.mode(_damageColor, BlendMode.srcATop);
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (_flashTime > 0) {
+      _flashTime -= dt;
+      if (_flashTime <= 0) {
+        paint.colorFilter = null;
+      } else {
+        final alpha =
+            (255 * (_flashTime / damageFlashDuration)).clamp(0, 255).toInt();
+        paint.colorFilter =
+            ColorFilter.mode(_damageColor.withAlpha(alpha), BlendMode.srcATop);
+      }
+    }
+  }
+}

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -13,6 +13,7 @@ import 'damageable.dart';
 import 'explosion.dart';
 import 'offscreen_cleanup.dart';
 import 'spawn_remove_emitter.dart';
+import 'damage_flash.dart';
 
 /// Basic foe that drifts toward the player.
 ///
@@ -26,7 +27,8 @@ class EnemyComponent extends SpriteComponent
         SolidBody,
         Damageable,
         SpawnRemoveEmitter<EnemyComponent>,
-        OffscreenCleanup {
+        OffscreenCleanup,
+        DamageFlash {
   EnemyComponent()
       : super(
           size: Vector2.all(
@@ -70,6 +72,7 @@ class EnemyComponent extends SpriteComponent
 
   /// Reduces health by [amount] and removes the enemy when depleted.
   void takeDamage(int amount) {
+    flashDamage();
     _health -= amount;
     if (_health <= 0 && !isRemoving) {
       game

--- a/lib/components/enemy.md
+++ b/lib/components/enemy.md
@@ -6,7 +6,8 @@ Basic foe that drifts toward the player.
 
 - Spawned in timed groups at screen edges and move toward the player ship.
 - Damages the player on contact and has a single health point.
-- Destroyed when hit by a bullet, awarding score on defeat.
+- Flashes red when hit using the `DamageFlash` mixin and is destroyed when
+  health is depleted, awarding score on defeat.
 - Sprites resolved through `assets.dart`; speeds and hit points from `constants.dart`.
 - Awards score when destroyed, using `Constants.enemyScore`.
 - Uses `CircleHitbox` or `RectangleHitbox` depending on art.

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -16,13 +16,15 @@ import 'mineral.dart';
 import 'player_input_behavior.dart';
 import 'spawn_remove_emitter.dart';
 import 'tractor_aura_renderer.dart';
+import 'damage_flash.dart';
 
 /// Controllable player ship.
 class PlayerComponent extends SpriteComponent
     with
         HasGameReference<SpaceGame>,
         CollisionCallbacks,
-        SpawnRemoveEmitter<PlayerComponent> {
+        SpawnRemoveEmitter<PlayerComponent>,
+        DamageFlash {
   PlayerComponent({
     required this.joystick,
     required this.keyDispatcher,
@@ -72,11 +74,6 @@ class PlayerComponent extends SpriteComponent
     ..style = PaintingStyle.stroke
     ..color = const Color(0x66ffff00);
 
-  static const _damageColor = Color(0xffff0000);
-
-  /// Remaining time for the damage flash effect.
-  double _damageFlashTime = 0;
-
   late final PlayerInputBehavior _input;
   late final AutoAimBehavior _autoAim;
 
@@ -110,12 +107,6 @@ class PlayerComponent extends SpriteComponent
   /// Toggles visibility of the player's range rings.
   void toggleRangeRings() {
     showRangeRings = !showRangeRings;
-  }
-
-  /// Triggers a short red flash that fades out to indicate damage taken.
-  void flashDamage() {
-    _damageFlashTime = Constants.playerDamageFlashDuration;
-    paint.colorFilter = ColorFilter.mode(_damageColor, BlendMode.srcATop);
   }
 
   /// Allows external callers to fire a bullet.
@@ -175,25 +166,6 @@ class PlayerComponent extends SpriteComponent
   @override
   void update(double dt) {
     super.update(dt);
-    _updateDamageFlash(dt);
-  }
-
-  void _updateDamageFlash(double dt) {
-    if (_damageFlashTime > 0) {
-      _damageFlashTime -= dt;
-      if (_damageFlashTime <= 0) {
-        paint.colorFilter = null;
-      } else {
-        final alpha =
-            (255 * (_damageFlashTime / Constants.playerDamageFlashDuration))
-                .clamp(0, 255)
-                .toInt();
-        paint.colorFilter = ColorFilter.mode(
-          _damageColor.withAlpha(alpha),
-          BlendMode.srcATop,
-        );
-      }
-    }
   }
 
   @override

--- a/lib/components/player.md
+++ b/lib/components/player.md
@@ -8,7 +8,7 @@ Controllable ship for the player.
 - Fires `BulletComponent`s with a short cooldown when the shoot button or space
   bar is pressed, in the direction the ship is facing.
 - Colliding with enemies or asteroids reduces health via `SpaceGame.hitPlayer`
-  and briefly tints the ship red with a quick fade to show damage.
+  and briefly tints the ship red via the `DamageFlash` mixin to show damage.
 - When stationary, periodically rotates to face the nearest enemy within range.
 - Collects `MineralComponent`s on contact to increase the mineral counter.
 - A blue Tractor Aura pulls nearby pickups toward the ship.

--- a/test/enemy_damage_flash_test.dart
+++ b/test/enemy_damage_flash_test.dart
@@ -1,0 +1,104 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flame_audio/flame_audio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/enemy.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+import 'test_joystick.dart';
+
+class _FakeAudioService implements AudioService {
+  final ValueNotifier<bool> muted = ValueNotifier(false);
+
+  @override
+  double get masterVolume => 1;
+
+  @override
+  AudioPlayer? get miningLoop => null;
+
+  @override
+  Future<void> startMiningLaser() async {}
+
+  @override
+  void stopAll() {}
+
+  @override
+  void stopMiningLaser() {}
+
+  @override
+  void playShoot() {}
+
+  @override
+  void playExplosion() {}
+
+  @override
+  Future<void> toggleMute() async {}
+
+  @override
+  void setMasterVolume(double volume) {}
+
+  @override
+  void dispose() {}
+}
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: Assets.players.first);
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    keyDispatcher = KeyDispatcher();
+    await add(keyDispatcher);
+    joystick = TestJoystick();
+    await add(joystick);
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.enemies, ...Assets.players]);
+  });
+
+  test('enemy flashes red when damaged', () async {
+    final storage = await StorageService.create();
+    final audio = _FakeAudioService();
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(1000));
+    await game.ready();
+
+    final enemy = EnemyComponent()..reset(Vector2.zero());
+    await game.add(enemy);
+    game.update(0);
+
+    expect(enemy.paint.colorFilter, isNull);
+
+    enemy.takeDamage(0);
+    expect(enemy.paint.colorFilter, isNotNull);
+
+    game.update(Constants.playerDamageFlashDuration);
+    expect(enemy.paint.colorFilter, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- extract a reusable DamageFlash mixin for temporary red tinting
- apply DamageFlash to player and enemies and document behaviour
- cover enemy flash effect with a new test

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beaf89ae688330847f2bbaf52776ff