### PR TITLE
Dispose TargetingService event subscriptions

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -450,6 +450,7 @@ class SpaceGame extends FlameGame
     settingsService.dispose();
     scoreService.dispose();
     upgradeService.dispose();
+    targetingService.dispose();
     stateMachine.dispose();
     audioService.dispose();
     super.onRemove();

--- a/lib/services/targeting_service.dart
+++ b/lib/services/targeting_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flame/components.dart';
 
 import '../components/player.dart';
@@ -6,18 +7,30 @@ import '../game/event_bus.dart';
 /// Tracks key targets like the player for AI systems to query.
 class TargetingService {
   TargetingService(GameEventBus events) {
-    events.on<ComponentSpawnEvent<PlayerComponent>>().listen((event) {
+    _spawnSub =
+        events.on<ComponentSpawnEvent<PlayerComponent>>().listen((event) {
       _player = event.component;
     });
-    events.on<ComponentRemoveEvent<PlayerComponent>>().listen((event) {
+    _removeSub =
+        events.on<ComponentRemoveEvent<PlayerComponent>>().listen((event) {
       if (_player == event.component) {
         _player = null;
       }
     });
   }
 
+  late final StreamSubscription<ComponentSpawnEvent<PlayerComponent>> _spawnSub;
+  late final StreamSubscription<ComponentRemoveEvent<PlayerComponent>>
+      _removeSub;
+
   PlayerComponent? _player;
 
   /// Current position of the tracked player, if any.
   Vector2? get playerPosition => _player?.position;
+
+  /// Cancels event subscriptions and releases resources.
+  void dispose() {
+    _spawnSub.cancel();
+    _removeSub.cancel();
+  }
 }

--- a/test/targeting_service_test.dart
+++ b/test/targeting_service_test.dart
@@ -29,5 +29,28 @@ void main() {
 
     bus.emit(ComponentRemoveEvent<PlayerComponent>(player));
     expect(targeting.playerPosition, isNull);
+    targeting.dispose();
+    bus.dispose();
+  });
+
+  test('disposing cancels event subscriptions', () {
+    final bus = GameEventBus();
+    final targeting = TargetingService(bus);
+    final player = _DummyPlayer()..position = Vector2.zero();
+
+    bus.emit(ComponentSpawnEvent<PlayerComponent>(player));
+    expect(targeting.playerPosition, player.position);
+
+    targeting.dispose();
+
+    // After disposal, further events should have no effect.
+    bus.emit(ComponentRemoveEvent<PlayerComponent>(player));
+    expect(targeting.playerPosition, player.position);
+
+    final newPlayer = _DummyPlayer()..position = Vector2(5, 6);
+    bus.emit(ComponentSpawnEvent<PlayerComponent>(newPlayer));
+    expect(targeting.playerPosition, player.position);
+
+    bus.dispose();
   });
 }


### PR DESCRIPTION
## Summary
- prevent TargetingService stream leak by tracking subscriptions and cancelling them on dispose
- dispose TargetingService during game teardown
- test TargetingService disposal behavior

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beaf89ae688330847f2bbaf52776ff