### PR TITLE
feat: add master volume slider

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -162,8 +162,9 @@ tree spanning weapons and ship systems.
   game when opened mid-run. `Esc` also closes it without triggering pause.
 - An upgrades overlay opens with the `U` key or HUD button and pauses gameplay
   while letting players buy basic upgrades that persist between sessions.
-- A settings overlay provides sliders for HUD, minimap, text, joystick,
-  targeting, Tractor Aura and mining ranges and includes a reset button.
+- A settings overlay provides sliders for master volume, HUD, minimap, text,
+  joystick, targeting, Tractor Aura and mining ranges and includes a reset
+  button.
 - A `GameState` enum tracks the current phase.
 
 ## Input

--- a/PLAN.md
+++ b/PLAN.md
@@ -189,8 +189,9 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Upgrades overlay lets players spend minerals on simple upgrades that
   persist between sessions, opened with a HUD button or the `U` key and
   pausing gameplay
-- Settings overlay with sliders for HUD, minimap, text, joystick, targeting,
-  Tractor Aura and mining ranges, plus a reset button
+- Settings overlay with master volume slider and sliders for HUD, minimap,
+  text, joystick, targeting, Tractor Aura and mining ranges, plus a reset
+  button
 - Game works offline after the first load thanks to the service worker
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -39,9 +39,9 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it
-- [ ] Settings overlay sliders adjust HUD button, minimap, text, joystick sizes
-      and gameplay ranges (default 0.75 for buttons and text) and reset button
-      restores defaults
+- [ ] Settings overlay sliders adjust volume, HUD button, minimap, text,
+      joystick sizes and gameplay ranges (default 0.75 for buttons and text)
+      and reset button restores defaults
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ dedicated server or NAT traversal.
 - HUD button or `B` key toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Upgrades overlay lets you buy simple upgrades with minerals that persist
   between sessions, accessible via a HUD button or the `U` key
-- Settings overlay adjusts HUD, minimap, text and joystick scales and gameplay
-  ranges, and includes a reset button
+- Settings overlay adjusts volume, HUD, minimap, text and joystick scales and
+  gameplay ranges, and includes a reset button
 - Menu allows choosing between multiple ship sprites and remembers the selection
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over

--- a/TASKS.md
+++ b/TASKS.md
@@ -76,8 +76,8 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Upgrades overlay accessible via HUD button or the `U` key where purchases
       persist across sessions.
 - [x] HUD button or `B` key toggles range rings for targeting, Tractor Aura and mining.
-- [x] Settings overlay with sliders for HUD, text, joystick, targeting,
-      Tractor Aura and mining ranges, plus reset button.
+- [x] Settings overlay with master volume slider and sliders for HUD, text,
+      joystick, targeting, Tractor Aura and mining ranges, plus reset button.
 
 - [x] Persist purchased upgrades across sessions using `StorageService`.
 

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -3,7 +3,7 @@
 Optional helpers for cross-cutting concerns.
 
 - `audio_service.dart` wraps `flame_audio` to play sound effects and
-  handles a mute toggle persisted via `StorageService`.
+  handles a mute toggle and master volume slider persisted via `StorageService`.
 - `storage_service.dart` stores the local high score and mute setting using
   `shared_preferences`.
 - `score_service.dart` tracks score, minerals and health values.

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -26,8 +26,9 @@ Flutter overlays and HUD widgets.
   pauses gameplay when opened mid-run; `Esc` also closes it.
 - [UpgradesOverlay](upgrades_overlay.md) – lists purchasable ship upgrades;
   opened with `U` and pauses gameplay.
-- [SettingsOverlay](settings_overlay.md) – adjust HUD, minimap, text, joystick
-  scale and gameplay ranges, with a reset button; opened via HUD button.
+- [SettingsOverlay](settings_overlay.md) – adjust volume, HUD, minimap, text,
+  joystick scale and gameplay ranges, with a reset button; opened via HUD
+  button.
 - The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
   `Enter` starts or restarts from the menu or game over; `R` restarts at any
   time; `Q` returns to the menu from pause or game over; `Escape` or `P` pauses

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -39,12 +39,27 @@ class SettingsOverlay extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   GameText(
-                    'UI Settings',
+                    'Settings',
                     style: Theme.of(context).textTheme.headlineSmall,
                     maxLines: 1,
                     color: Theme.of(context).colorScheme.onSurface,
                   ),
                   SizedBox(height: spacing),
+                  GameText(
+                    'Audio',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    maxLines: 1,
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                  SizedBox(height: spacing),
+                  _buildSlider(
+                    context,
+                    'Volume',
+                    game.audioService.volume,
+                    spacing,
+                    min: 0,
+                    max: 1,
+                  ),
                   GameText(
                     'HUD Scaling',
                     style: Theme.of(context).textTheme.titleMedium,
@@ -109,7 +124,10 @@ class SettingsOverlay extends StatelessWidget {
                   ),
                   SizedBox(height: spacing),
                   ElevatedButton(
-                    onPressed: settings.reset,
+                    onPressed: () {
+                      settings.reset();
+                      game.audioService.setMasterVolume(1);
+                    },
                     child: const GameText(
                       'Reset',
                       maxLines: 1,

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -1,10 +1,10 @@
 # SettingsOverlay
 
-Overlay providing runtime UI scaling and range controls.
+Overlay providing runtime audio, UI scaling and range controls.
 
 ## Features
 
-- Sliders adjust HUD button, minimap, text, joystick scales and gameplay ranges.
+- Sliders adjust volume, HUD button, minimap, text, joystick scales and gameplay ranges.
 - Sections separate HUD scaling from range scaling for easier navigation.
 - Bordered layout limits width on large screens for clarity.
 - Opens from the HUD; closing returns to the game.

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -14,8 +14,8 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Simple HUD and menus layered with Flutter overlays.
 - [x] Menu allows choosing between multiple ship sprites and persists the selection.
 - [x] Option to mute or dim audio when the game is paused.
-- [x] Settings overlay with sliders for HUD, minimap, text, joystick, targeting,
-      Tractor Aura and mining ranges, plus reset button.
+- [x] Settings overlay with master volume slider and sliders for HUD, minimap,
+      text, joystick, targeting, Tractor Aura and mining ranges, plus reset button.
 
 ## Design Notes
 

--- a/test/enemy_damage_test.dart
+++ b/test/enemy_damage_test.dart
@@ -20,10 +20,12 @@ import 'test_joystick.dart';
 class _FakeAudioService implements AudioService {
   final ValueNotifier<bool> muted = ValueNotifier(false);
   int explosions = 0;
-  double _masterVolume = 1;
 
   @override
-  double get masterVolume => _masterVolume;
+  final ValueNotifier<double> volume = ValueNotifier<double>(1);
+
+  @override
+  double get masterVolume => volume.value;
 
   @override
   AudioPlayer? get miningLoop => null;
@@ -52,7 +54,7 @@ class _FakeAudioService implements AudioService {
 
   @override
   void setMasterVolume(double volume) {
-    _masterVolume = volume;
+    this.volume.value = volume;
   }
 }
 

--- a/test/player_collision_test.dart
+++ b/test/player_collision_test.dart
@@ -24,10 +24,12 @@ import 'test_joystick.dart';
 class _FakeAudioService implements AudioService {
   @override
   final ValueNotifier<bool> muted = ValueNotifier(false);
-  double _masterVolume = 1;
 
   @override
-  double get masterVolume => _masterVolume;
+  final ValueNotifier<double> volume = ValueNotifier<double>(1);
+
+  @override
+  double get masterVolume => volume.value;
 
   @override
   AudioPlayer? get miningLoop => null;
@@ -54,7 +56,7 @@ class _FakeAudioService implements AudioService {
 
   @override
   void setMasterVolume(double volume) {
-    _masterVolume = volume;
+    this.volume.value = volume;
   }
 }
 

--- a/test/settings_overlay_test.dart
+++ b/test/settings_overlay_test.dart
@@ -26,10 +26,10 @@ void main() {
     await tester.pumpWidget(MaterialApp(home: SettingsOverlay(game: game)));
 
     final slider = find.byType(Slider).first;
-    final initial = game.settingsService.hudButtonScale.value;
+    final initial = audio.masterVolume;
     await tester.drag(slider, const Offset(50, 0));
     await tester.pump();
-    expect(game.settingsService.hudButtonScale.value, isNot(initial));
+    expect(audio.masterVolume, isNot(initial));
   });
 
   testWidgets('reset button restores defaults', (tester) async {
@@ -44,6 +44,7 @@ void main() {
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);
     game.settingsService.hudButtonScale.value = 1.2;
+    audio.setMasterVolume(0.5);
 
     await tester.pumpWidget(MaterialApp(home: SettingsOverlay(game: game)));
     await tester.tap(find.text('Reset'));
@@ -51,5 +52,6 @@ void main() {
 
     expect(game.settingsService.hudButtonScale.value,
         SettingsService.defaultHudButtonScale);
+    expect(audio.masterVolume, 1);
   });
 }

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -43,14 +43,16 @@ class _FakeAudioService implements AudioService {
 
   @override
   final ValueNotifier<bool> muted = ValueNotifier(false);
-  double _volume = 1;
 
   @override
-  double get masterVolume => _volume;
+  final ValueNotifier<double> volume = ValueNotifier<double>(1);
+
+  @override
+  double get masterVolume => volume.value;
 
   @override
   void setMasterVolume(double volume) {
-    _volume = volume;
+    this.volume.value = volume;
   }
 
   @override


### PR DESCRIPTION
## Summary
- add master volume slider in settings overlay
- persist and restore audio volume through new ValueNotifier in AudioService
- document volume controls and update tests
- fix settings overlay bullet indentation in design doc

## Testing
- `./scripts/dartw analyze`
- `npx markdownlint-cli '**/*.md'`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beaca87f4883309a724f6b44d35e19