### PR TITLE
refactor: centralize angle normalization

### DIFF
--- a/lib/components/auto_aim_behavior.dart
+++ b/lib/components/auto_aim_behavior.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flame/components.dart';
 
 import '../game/space_game.dart';
+import '../util/angle_utils.dart';
 import '../util/nearest_component.dart';
 import 'enemy.dart';
 import 'player.dart';
@@ -22,7 +23,7 @@ class AutoAimBehavior extends Component
       maxDistance: game.upgradeService.targetingRange,
     );
     if (target != null) {
-      parent.targetAngle = _normalizeAngle(
+      parent.targetAngle = normalizeAngle(
         math.atan2(
               target.position.y - parent.position.y,
               target.position.x - parent.position.x,
@@ -31,15 +32,5 @@ class AutoAimBehavior extends Component
       );
       parent.updateRotation(dt);
     }
-  }
-
-  double _normalizeAngle(double a) {
-    while (a <= -math.pi) {
-      a += math.pi * 2;
-    }
-    while (a > math.pi) {
-      a -= math.pi * 2;
-    }
-    return a;
   }
 }

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -1,4 +1,3 @@
-import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flame/collisions.dart';
@@ -9,6 +8,7 @@ import 'package:flutter/services.dart';
 import '../constants.dart';
 import '../game/key_dispatcher.dart';
 import '../game/space_game.dart';
+import '../util/angle_utils.dart';
 import 'asteroid.dart';
 import 'auto_aim_behavior.dart';
 import 'enemy.dart';
@@ -154,7 +154,7 @@ class PlayerComponent extends SpriteComponent
 
   /// Smoothly rotates the player toward [targetAngle].
   void updateRotation(double dt) {
-    final rotationDelta = _normalizeAngle(targetAngle - angle);
+    final rotationDelta = normalizeAngle(targetAngle - angle);
     final maxDelta = Constants.playerRotationSpeed * dt;
     if (rotationDelta.abs() <= maxDelta) {
       angle = targetAngle;
@@ -204,15 +204,5 @@ class PlayerComponent extends SpriteComponent
       game.addMinerals(other.value);
       other.removeFromParent();
     }
-  }
-
-  double _normalizeAngle(double a) {
-    while (a <= -math.pi) {
-      a += math.pi * 2;
-    }
-    while (a > math.pi) {
-      a -= math.pi * 2;
-    }
-    return a;
   }
 }

--- a/lib/util/angle_utils.dart
+++ b/lib/util/angle_utils.dart
@@ -1,0 +1,16 @@
+import 'dart:math' as math;
+
+/// Utilities for working with angles.
+///
+/// Normalises angles to the `[-π, π]` range to avoid discontinuities when
+/// comparing or interpolating rotations.
+///
+double normalizeAngle(double angle) {
+  angle %= 2 * math.pi;
+  if (angle <= -math.pi) {
+    angle += 2 * math.pi;
+  } else if (angle > math.pi) {
+    angle -= 2 * math.pi;
+  }
+  return angle;
+}


### PR DESCRIPTION
## Summary
- deduplicate angle normalization into shared utility
- use normalizeAngle in auto-aim and player rotation

## Testing
- `scripts/dartw analyze lib/components/auto_aim_behavior.dart lib/components/player.dart lib/util/angle_utils.dart`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beb2e797188330aaa84b37d094a546