### PR TITLE
Fix AudioService mock and clean test import

### DIFF
--- a/test/enemy_damage_flash_test.dart
+++ b/test/enemy_damage_flash_test.dart
@@ -18,6 +18,8 @@ import 'test_joystick.dart';
 
 class _FakeAudioService implements AudioService {
   final ValueNotifier<bool> muted = ValueNotifier(false);
+  @override
+  final ValueNotifier<double> volume = ValueNotifier(1);
 
   @override
   double get masterVolume => 1;

--- a/test/starfield_density_guard_test.dart
+++ b/test/starfield_density_guard_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flame/game.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
## Summary
- implement volume notifier in _FakeAudioService
- remove unused dart:ui import from starfield density guard test

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beb43f9e28833084694567e2965a74