### PR TITLE
Guard sysctl fallback in flutterw concurrency detection

### DIFF
--- a/scripts/flutterw
+++ b/scripts/flutterw
@@ -35,7 +35,7 @@ if [[ "${1:-}" == "test" ]]; then
       if command -v nproc >/dev/null 2>&1; then
         test_concurrency=$(nproc)
       elif command -v sysctl >/dev/null 2>&1; then
-        test_concurrency=$(sysctl -n hw.ncpu)
+        test_concurrency=$(sysctl -n hw.ncpu 2>/dev/null || echo 1)
       else
         test_concurrency=1
       fi


### PR DESCRIPTION
## Summary
- safeguard sysctl based test concurrency detection in flutterw so missing `hw.ncpu` key falls back to single thread

## Testing
- `./scripts/flutterw test` *(fails: _FakeAudioService missing AudioService.volume)*

------
https://chatgpt.com/codex/tasks/task_e_68beb494f3308330aafdd56cdf001870