### PR TITLE
Refactor overlay handling and object pool view

### DIFF
--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -16,10 +16,9 @@ class OverlayService {
 
   void _showOnly(String id, Iterable<String> remove) {
     final overlays = game.overlays;
-    for (final overlay in remove) {
-      overlays.remove(overlay);
-    }
-    overlays.add(id);
+    overlays
+      ..removeAll(remove)
+      ..add(id);
   }
 
   static const _exclusiveOverlays = <String, Set<String>>{

--- a/lib/util/object_pool.dart
+++ b/lib/util/object_pool.dart
@@ -12,14 +12,15 @@ class ObjectPool<T> {
   final T Function() _create;
   final int? maxSize;
   final List<T> _items = [];
+  late final UnmodifiableListView<T> _itemsView = UnmodifiableListView(_items);
 
   /// Returns an unmodifiable view of the cached items currently in the pool.
   ///
   /// Exposing the internal list directly would allow callers to modify it and
-  /// break the pool's bookkeeping. Returning an [UnmodifiableListView] keeps
-  /// the data read-only while still reflecting updates to the underlying list
-  /// without additional copying.
-  UnmodifiableListView<T> get items => UnmodifiableListView(_items);
+  /// break the pool's bookkeeping. The view is cached to avoid allocating a
+  /// new wrapper on each access while still reflecting changes to the
+  /// underlying list.
+  UnmodifiableListView<T> get items => _itemsView;
 
   T acquire([void Function(T)? reset]) {
     final obj = _items.isNotEmpty ? _items.removeLast() : _create();

--- a/test/enemy_damage_flash_test.dart
+++ b/test/enemy_damage_flash_test.dart
@@ -18,6 +18,7 @@ import 'test_joystick.dart';
 
 class _FakeAudioService implements AudioService {
   final ValueNotifier<bool> muted = ValueNotifier(false);
+  final ValueNotifier<double> volume = ValueNotifier(1);
 
   @override
   double get masterVolume => 1;


### PR DESCRIPTION
## Summary
- Use `removeAll` to streamline overlay updates
- Cache unmodifiable view in object pool to avoid repeated allocations
- Fix enemy damage flash test stub to satisfy audio service contract

## Testing
- `scripts/dartw analyze lib/services/overlay_service.dart lib/util/object_pool.dart test/enemy_damage_flash_test.dart`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beb57cbf14833088f8f03cf09bfac9