### PR TITLE
feat: add component tracker utility

### DIFF
--- a/lib/services/targeting_service.dart
+++ b/lib/services/targeting_service.dart
@@ -1,36 +1,19 @@
-import 'dart:async';
 import 'package:flame/components.dart';
 
 import '../components/player.dart';
 import '../game/event_bus.dart';
+import '../util/component_tracker.dart';
 
 /// Tracks key targets like the player for AI systems to query.
 class TargetingService {
-  TargetingService(GameEventBus events) {
-    _spawnSub =
-        events.on<ComponentSpawnEvent<PlayerComponent>>().listen((event) {
-      _player = event.component;
-    });
-    _removeSub =
-        events.on<ComponentRemoveEvent<PlayerComponent>>().listen((event) {
-      if (_player == event.component) {
-        _player = null;
-      }
-    });
-  }
+  TargetingService(GameEventBus events)
+      : _playerTracker = ComponentTracker<PlayerComponent>(events);
 
-  late final StreamSubscription<ComponentSpawnEvent<PlayerComponent>> _spawnSub;
-  late final StreamSubscription<ComponentRemoveEvent<PlayerComponent>>
-      _removeSub;
-
-  PlayerComponent? _player;
+  final ComponentTracker<PlayerComponent> _playerTracker;
 
   /// Current position of the tracked player, if any.
-  Vector2? get playerPosition => _player?.position;
+  Vector2? get playerPosition => _playerTracker.component?.position;
 
   /// Cancels event subscriptions and releases resources.
-  void dispose() {
-    _spawnSub.cancel();
-    _removeSub.cancel();
-  }
+  void dispose() => _playerTracker.dispose();
 }

--- a/lib/util/component_tracker.dart
+++ b/lib/util/component_tracker.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flame/components.dart';
+
+import '../game/event_bus.dart';
+
+/// Tracks the most recently spawned component of type [T].
+///
+/// Listens for [ComponentSpawnEvent] and [ComponentRemoveEvent] on the
+/// provided [GameEventBus] and exposes the current instance via [component].
+/// Call [dispose] to cancel internal subscriptions when no longer needed.
+class ComponentTracker<T extends Component> {
+  ComponentTracker(GameEventBus events) {
+    _spawnSub = events.on<ComponentSpawnEvent<T>>().listen((event) {
+      _component = event.component;
+    });
+    _removeSub = events.on<ComponentRemoveEvent<T>>().listen((event) {
+      if (identical(_component, event.component)) {
+        _component = null;
+      }
+    });
+  }
+
+  late final StreamSubscription<ComponentSpawnEvent<T>> _spawnSub;
+  late final StreamSubscription<ComponentRemoveEvent<T>> _removeSub;
+
+  T? _component;
+
+  /// Currently tracked component instance, if any.
+  T? get component => _component;
+
+  /// Cancels internal event subscriptions.
+  void dispose() {
+    _spawnSub.cancel();
+    _removeSub.cancel();
+  }
+}

--- a/test/component_tracker_test.dart
+++ b/test/component_tracker_test.dart
@@ -1,0 +1,39 @@
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:space_game/util/component_tracker.dart';
+import 'package:space_game/game/event_bus.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('tracks component spawn and removal', () {
+    final bus = GameEventBus();
+    final tracker = ComponentTracker<PositionComponent>(bus);
+    final component = PositionComponent();
+
+    bus.emit(ComponentSpawnEvent<PositionComponent>(component));
+    expect(tracker.component, component);
+
+    bus.emit(ComponentRemoveEvent<PositionComponent>(component));
+    expect(tracker.component, isNull);
+
+    tracker.dispose();
+    bus.dispose();
+  });
+
+  test('disposing stops tracking further events', () {
+    final bus = GameEventBus();
+    final tracker = ComponentTracker<PositionComponent>(bus);
+    final component = PositionComponent();
+
+    bus.emit(ComponentSpawnEvent<PositionComponent>(component));
+    expect(tracker.component, component);
+
+    tracker.dispose();
+
+    bus.emit(ComponentRemoveEvent<PositionComponent>(component));
+    expect(tracker.component, component);
+
+    bus.dispose();
+  });
+}

--- a/test/enemy_damage_flash_test.dart
+++ b/test/enemy_damage_flash_test.dart
@@ -20,7 +20,10 @@ class _FakeAudioService implements AudioService {
   final ValueNotifier<bool> muted = ValueNotifier(false);
 
   @override
-  double get masterVolume => 1;
+  final ValueNotifier<double> volume = ValueNotifier(1);
+
+  @override
+  double get masterVolume => volume.value;
 
   @override
   AudioPlayer? get miningLoop => null;


### PR DESCRIPTION
## Summary
- add reusable `ComponentTracker` for spawn/remove tracking
- refactor `TargetingService` to use `ComponentTracker`
- cover tracker with tests

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beb57cbf14833088f8f03cf09bfac9