### PR TITLE
feat: centralise starfield layer tuning

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -189,9 +189,11 @@ tree spanning weapons and ship systems.
   front of the ship.
 - A deterministic world-space starfield generates stars per chunk using
   Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex
-  noise modulates density to create clusters and voids. Stars follow a weighted
-  size/brightness distribution with optional subtle colour jitter. Each chunk
-  pre-renders to a cached `Picture` translated by `-playerPosition`, dropping
+  noise modulates density to create clusters and voids. Multiple parallax layers
+  with independent density and twinkle speed values add depth while star alpha
+  animates over time for a subtle twinkle. Stars follow a weighted
+  size/brightness distribution with optional colour jitter. Each chunk pre-renders
+  to a cached `Picture` translated by `-playerPosition`, dropping
   tiles outside a small margin around the camera so memory stays bounded. The
   player flies over a static backdrop while circles draw faint-to-bright. A
   `debugDrawTiles` switch outlines tile boundaries when debug mode (`F1`) is

--- a/PLAN.md
+++ b/PLAN.md
@@ -195,6 +195,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Game works offline after the first load thanks to the service worker
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.
+  - Multiple parallax layers with independent density and twinkle speed create
+    depth.
   - Simplex noise modulates density for subtle clusters.
   - Weighted size/brightness spread (≈80% tiny, 19% small, 1% medium) with optional
     colour jitter adds variety.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -159,6 +159,15 @@ class Constants {
   /// Cell size for spatial grid used in proximity queries.
   static const double spatialGridCellSize = 200;
 
+  /// Layer configurations for the starfield background. Each record defines
+  /// `parallax`, `density` and `twinkleSpeed` values.
+  static const List<({double parallax, double density, double twinkleSpeed})>
+      starfieldLayers = [
+    (parallax: 0.2, density: 0.3, twinkleSpeed: 0.5),
+    (parallax: 0.6, density: 0.6, twinkleSpeed: 0.8),
+    (parallax: 1.0, density: 1.0, twinkleSpeed: 1.0),
+  ];
+
   /// Maximum star radius in logical pixels.
   static const double starMaxSize = 2;
 

--- a/lib/constants.md
+++ b/lib/constants.md
@@ -9,6 +9,8 @@ Holds tunable values and configuration numbers used across the game.
   so they are easy to tweak.
 - Include timing values such as `bulletCooldown` and spawn intervals so
   behaviour like fire rates and spawn rates can be adjusted centrally.
+- Starfield configuration, including `starfieldTileSize` and `starfieldLayers`
+  for parallax depth and twinkle speeds, lives here too.
 - Use a global `spriteScale` for the default 3× enlargement, with per-entity
   scale offsets like `playerScale` layered on top.
 - Expose values as `const` when possible so the compiler can optimise them.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -176,11 +176,15 @@ class SpaceGame extends FlameGame
 
     _starfield = await StarfieldComponent(
       debugDrawTiles: debugMode,
-      layers: const [
-        StarfieldLayerConfig(parallax: 0.2, density: 0.3, twinkleSpeed: 0.5),
-        StarfieldLayerConfig(parallax: 0.6, density: 0.6, twinkleSpeed: 0.8),
-        StarfieldLayerConfig(parallax: 1.0, density: 1, twinkleSpeed: 1),
-      ],
+      layers: Constants.starfieldLayers
+          .map(
+            (l) => StarfieldLayerConfig(
+              parallax: l.parallax,
+              density: l.density,
+              twinkleSpeed: l.twinkleSpeed,
+            ),
+          )
+          .toList(),
     );
     await add(_starfield!);
 

--- a/test/enemy_damage_flash_test.dart
+++ b/test/enemy_damage_flash_test.dart
@@ -20,6 +20,9 @@ class _FakeAudioService implements AudioService {
   final ValueNotifier<bool> muted = ValueNotifier(false);
 
   @override
+  ValueNotifier<double> volume = ValueNotifier(1);
+
+  @override
   double get masterVolume => 1;
 
   @override

--- a/test/starfield_density_guard_test.dart
+++ b/test/starfield_density_guard_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flame/game.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
## Summary
- move starfield layer settings into `Constants.starfieldLayers`
- describe multi-layer starfield with twinkle speed in design docs
- tidy tests for analyzer warnings

## Testing
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68beb321458c8330b7bb0d139f4482f0