### PR TITLE
test: fix duplicate volume variable

### DIFF
--- a/test/enemy_damage_flash_test.dart
+++ b/test/enemy_damage_flash_test.dart
@@ -17,8 +17,8 @@ import 'package:space_game/services/storage_service.dart';
 import 'test_joystick.dart';
 
 class _FakeAudioService implements AudioService {
+  @override
   final ValueNotifier<bool> muted = ValueNotifier(false);
-  final ValueNotifier<double> volume = ValueNotifier(1);
 
   @override
   final ValueNotifier<double> volume = ValueNotifier(1);


### PR DESCRIPTION
## Summary
- remove duplicate volume notifier in enemy damage flash test
- ensure test fake audio service overrides muted and volume once

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beb866865c83308704febe3727a543