### PR TITLE
feat: add tunable starfield tile size

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -5,7 +5,7 @@ class Constants {
   /// Distance from the player after which entities are removed.
   static const double despawnRadius = 1500;
 
-  /// Size of a single generated starfield tile in pixels.
+  /// Default size of a single generated starfield tile in pixels.
   static const double starfieldTileSize = 512;
 
   /// Player movement speed in pixels per second.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -181,8 +181,10 @@ class SpaceGame extends FlameGame
         StarfieldLayerConfig(parallax: 0.6, density: 0.6, twinkleSpeed: 0.8),
         StarfieldLayerConfig(parallax: 1.0, density: 1, twinkleSpeed: 1),
       ],
+      tileSize: settingsService.starfieldTileSize.value,
     );
     await add(_starfield!);
+    settingsService.starfieldTileSize.addListener(_rebuildStarfield);
 
     player = PlayerComponent(
       joystick: joystick,
@@ -445,6 +447,24 @@ class SpaceGame extends FlameGame
     fireButton.size = Vector2.all(60 * scale);
     fireButton.anchor = Anchor.bottomRight;
     fireButton.onGameResize(size);
+  }
+
+  void _rebuildStarfield() {
+    final tileSize = settingsService.starfieldTileSize.value;
+    _starfield?.removeFromParent();
+    unawaited(() async {
+      final sf = await StarfieldComponent(
+        debugDrawTiles: debugMode,
+        layers: const [
+          StarfieldLayerConfig(parallax: 0.2, density: 0.3, twinkleSpeed: 0.5),
+          StarfieldLayerConfig(parallax: 0.6, density: 0.6, twinkleSpeed: 0.8),
+          StarfieldLayerConfig(parallax: 1.0, density: 1, twinkleSpeed: 1),
+        ],
+        tileSize: tileSize,
+      );
+      _starfield = sf;
+      await add(sf);
+    }());
   }
 
   /// Ensures the camera stays centred on the player.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -3,7 +3,8 @@ import 'package:flutter/foundation.dart';
 import '../constants.dart';
 import 'storage_service.dart';
 
-/// Holds tweakable UI scale values and gameplay ranges for live prototyping.
+/// Holds tweakable UI scale values, gameplay ranges and performance tweaks for
+/// live prototyping.
 class SettingsService {
   SettingsService({StorageService? storage}) : _storage = storage {
     hudButtonScale = _initNotifier(_hudScaleKey, defaultHudButtonScale);
@@ -15,6 +16,8 @@ class SettingsService {
     tractorRange =
         _initNotifier(_tractorRangeKey, Constants.playerTractorAuraRadius);
     miningRange = _initNotifier(_miningRangeKey, Constants.playerMiningRange);
+    starfieldTileSize =
+        _initNotifier(_starfieldTileSizeKey, Constants.starfieldTileSize);
   }
 
   static const double defaultHudButtonScale = 0.75;
@@ -43,6 +46,9 @@ class SettingsService {
   /// Maximum distance to auto-mine asteroids, in pixels.
   late final ValueNotifier<double> miningRange;
 
+  /// Size of each generated starfield tile.
+  late final ValueNotifier<double> starfieldTileSize;
+
   StorageService? _storage;
 
   /// Attaches a [StorageService] after construction and loads any persisted
@@ -65,6 +71,8 @@ class SettingsService {
     tractorRange.value =
         storage.getDouble(_tractorRangeKey, tractorRange.value);
     miningRange.value = storage.getDouble(_miningRangeKey, miningRange.value);
+    starfieldTileSize.value =
+        storage.getDouble(_starfieldTileSizeKey, starfieldTileSize.value);
   }
 
   /// Restores all values to their defaults.
@@ -76,6 +84,7 @@ class SettingsService {
     targetingRange.value = Constants.playerAutoAimRange;
     tractorRange.value = Constants.playerTractorAuraRadius;
     miningRange.value = Constants.playerMiningRange;
+    starfieldTileSize.value = Constants.starfieldTileSize;
   }
 
   static const _hudScaleKey = 'hudButtonScale';
@@ -85,6 +94,7 @@ class SettingsService {
   static const _targetingRangeKey = 'targetingRange';
   static const _tractorRangeKey = 'tractorRange';
   static const _miningRangeKey = 'miningRange';
+  static const _starfieldTileSizeKey = 'starfieldTileSize';
 
   ValueNotifier<double> _initNotifier(String key, double defaultValue) {
     final notifier = ValueNotifier<double>(
@@ -102,5 +112,6 @@ class SettingsService {
     targetingRange.dispose();
     tractorRange.dispose();
     miningRange.dispose();
+    starfieldTileSize.dispose();
   }
 }

--- a/lib/services/settings_service.md
+++ b/lib/services/settings_service.md
@@ -1,11 +1,13 @@
 # SettingsService
 
-Stores tweakable UI scales and gameplay ranges with persistence.
+Stores tweakable UI scales, gameplay ranges and performance tuning values with
+persistence.
 
 ## Responsibilities
 
 - Hold `ValueNotifier`s for HUD, minimap, text and joystick scales.
 - Track targeting, Tractor Aura and mining ranges.
+- Expose starfield tile size for performance scaling.
 - Persist changes via `StorageService` and reload on startup.
 - Provide `reset()` to restore default values for all settings.
 

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -122,6 +122,21 @@ class SettingsOverlay extends StatelessWidget {
                     min: 50,
                     max: 600,
                   ),
+                  GameText(
+                    'Performance',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    maxLines: 1,
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                  SizedBox(height: spacing),
+                  _buildSlider(
+                    context,
+                    'Starfield Tile',
+                    settings.starfieldTileSize,
+                    spacing,
+                    min: 256,
+                    max: 1024,
+                  ),
                   SizedBox(height: spacing),
                   ElevatedButton(
                     onPressed: () {

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -18,6 +18,7 @@ void main() {
     expect(settings.targetingRange.value, Constants.playerAutoAimRange);
     expect(settings.tractorRange.value, Constants.playerTractorAuraRadius);
     expect(settings.miningRange.value, Constants.playerMiningRange);
+    expect(settings.starfieldTileSize.value, Constants.starfieldTileSize);
   });
 
   test('notifiers update when values change', () {
@@ -30,6 +31,7 @@ void main() {
     var targetingNotified = false;
     var tractorNotified = false;
     var miningNotified = false;
+    var starfieldNotified = false;
 
     settings.hudButtonScale.addListener(() => hudNotified = true);
     settings.minimapScale.addListener(() => minimapNotified = true);
@@ -38,6 +40,7 @@ void main() {
     settings.targetingRange.addListener(() => targetingNotified = true);
     settings.tractorRange.addListener(() => tractorNotified = true);
     settings.miningRange.addListener(() => miningNotified = true);
+    settings.starfieldTileSize.addListener(() => starfieldNotified = true);
 
     settings.hudButtonScale.value = 1.2;
     settings.minimapScale.value = 1.4;
@@ -46,6 +49,7 @@ void main() {
     settings.targetingRange.value = 350;
     settings.tractorRange.value = 250;
     settings.miningRange.value = 180;
+    settings.starfieldTileSize.value = 256;
 
     expect(hudNotified, isTrue);
     expect(minimapNotified, isTrue);
@@ -54,6 +58,7 @@ void main() {
     expect(targetingNotified, isTrue);
     expect(tractorNotified, isTrue);
     expect(miningNotified, isTrue);
+    expect(starfieldNotified, isTrue);
 
     expect(settings.hudButtonScale.value, 1.2);
     expect(settings.minimapScale.value, 1.4);
@@ -62,6 +67,7 @@ void main() {
     expect(settings.targetingRange.value, 350);
     expect(settings.tractorRange.value, 250);
     expect(settings.miningRange.value, 180);
+    expect(settings.starfieldTileSize.value, 256);
   });
 
   test('reset restores default values', () {
@@ -73,6 +79,7 @@ void main() {
     settings.targetingRange.value = 400;
     settings.tractorRange.value = 300;
     settings.miningRange.value = 200;
+    settings.starfieldTileSize.value = 256;
 
     settings.reset();
 
@@ -84,6 +91,7 @@ void main() {
     expect(settings.targetingRange.value, Constants.playerAutoAimRange);
     expect(settings.tractorRange.value, Constants.playerTractorAuraRadius);
     expect(settings.miningRange.value, Constants.playerMiningRange);
+    expect(settings.starfieldTileSize.value, Constants.starfieldTileSize);
   });
 
   test('values persist across sessions', () async {


### PR DESCRIPTION
## Summary
- expose starfield tile size as a runtime setting and rebuild the starfield when it changes
- surface new starfield tile size slider in Settings overlay
- document and test the new setting

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bec1ae9fd88330a3a5048b9292d0c9