### PR TITLE
Improve asset loading diagnostics

### DIFF
--- a/lib/assets.dart
+++ b/lib/assets.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 import 'package:flame/flame.dart';
 import 'package:flame_audio/flame_audio.dart';
 
+import 'log.dart';
+
 /// Central registry for asset paths and preloading.
 class Assets {
   // Flame automatically prefixes these with `assets/images/` when loading.
@@ -41,7 +43,7 @@ class Assets {
 
   /// Preloads all images and audio assets.
   static Future<void> load() async {
-    await Flame.images.loadAll([
+    final imagePaths = [
       ...players,
       ...enemies,
       ...asteroids,
@@ -51,10 +53,30 @@ class Assets {
       scoreIcon,
       healthIcon,
       settingsIcon,
-    ]);
+    ];
 
-    await FlameAudio.audioCache
-        .loadAll([shootSfx, explosionSfx, miningLaserSfx]);
+    await Future.wait(imagePaths.map(_loadImage));
+
+    final audioPaths = [shootSfx, explosionSfx, miningLaserSfx];
+    await Future.wait(audioPaths.map(_loadAudio));
+  }
+
+  static Future<void> _loadImage(String path) async {
+    try {
+      await Flame.images.load(path);
+    } catch (e) {
+      log('Failed to load image asset $path: $e');
+      rethrow;
+    }
+  }
+
+  static Future<void> _loadAudio(String path) async {
+    try {
+      await FlameAudio.audioCache.load(path);
+    } catch (e) {
+      log('Failed to load audio asset $path: $e');
+      rethrow;
+    }
   }
 
   static final Random _rand = Random();

--- a/test/assets_load_test.dart
+++ b/test/assets_load_test.dart
@@ -5,7 +5,7 @@ import 'package:space_game/assets.dart';
 
 class _FakeAudioCache extends AudioCache {
   @override
-  Future<List<Uri>> loadAll(List<String> files) async => [];
+  Future<Uri> load(String file) async => Uri();
 
   @override
   Future<void> clearAll() async {}


### PR DESCRIPTION
## Summary
- log individual asset load failures and rethrow
- adjust asset loading test for new audio cache interface

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bec1b52f548330a2ba2fc86a11b306