### PR TITLE
Reduce starfield density

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -177,9 +177,9 @@ class SpaceGame extends FlameGame
     _starfield = await StarfieldComponent(
       debugDrawTiles: debugMode,
       layers: const [
-        StarfieldLayerConfig(parallax: 0.2, density: 0.3, twinkleSpeed: 0.5),
-        StarfieldLayerConfig(parallax: 0.6, density: 0.6, twinkleSpeed: 0.8),
-        StarfieldLayerConfig(parallax: 1.0, density: 1, twinkleSpeed: 1),
+        StarfieldLayerConfig(parallax: 0.2, density: 0.15, twinkleSpeed: 0.5),
+        StarfieldLayerConfig(parallax: 0.6, density: 0.3, twinkleSpeed: 0.8),
+        StarfieldLayerConfig(parallax: 1.0, density: 0.5, twinkleSpeed: 1),
       ],
     );
     await add(_starfield!);


### PR DESCRIPTION
## Summary
- Decrease star counts across starfield layers to break up overly uniform background

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bec2fa89cc8330a6dacdc59f40aed6