### PR TITLE
Destroy asteroids on bullet hit

### DIFF
--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -15,6 +15,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score
+- [ ] Shooting an asteroid with the main cannon does not drop minerals
 - [ ] Mining an asteroid increases the on-screen minerals
 - [ ] Score resets when restarting the game
 - [ ] Minerals reset when restarting the game

--- a/lib/components/asteroid.dart
+++ b/lib/components/asteroid.dart
@@ -74,6 +74,15 @@ class AsteroidComponent extends SpriteComponent
     renderHealth(canvas, _health);
   }
 
+  /// Immediately destroys the asteroid without dropping minerals.
+  void destroy() {
+    _health = 0;
+    game.addScore(Constants.asteroidScore);
+    if (!isRemoving) {
+      removeFromParent();
+    }
+  }
+
   /// Reduces health by [amount], dropping a limited number of minerals and
   /// removing the asteroid when depleted.
   void takeDamage(int amount) {

--- a/lib/components/asteroid.md
+++ b/lib/components/asteroid.md
@@ -4,9 +4,11 @@ Neutral obstacle that can be mined for score and minerals.
 
 ## Behaviour
 
-- Destroyed by repeated bullet or mining laser hits. Each hit awards score and
-  drops a mineral pickup worth `Constants.asteroidMinerals` at a random spot
-  within `Constants.mineralDropRadius` of the asteroid.
+- Mining laser pulses damage asteroids, dropping a mineral pickup worth
+  `Constants.asteroidMinerals` at a random spot within
+  `Constants.mineralDropRadius` for each point of damage.
+- Shots from the main cannon destroy asteroids instantly without dropping
+  minerals, but still award `Constants.asteroidScore` points.
 - Uses sprites from `assets.dart` and numbers from `constants.dart`.
 - Starts with 4–6 health and grants `Constants.asteroidScore` points per hit.
 - Uses a small object pool to reuse instances.

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -6,6 +6,7 @@ import 'package:flame/components.dart';
 import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
+import 'asteroid.dart';
 import 'damageable.dart';
 import 'offscreen_cleanup.dart';
 import 'spawn_remove_emitter.dart';
@@ -53,7 +54,10 @@ class BulletComponent extends SpriteComponent
     PositionComponent other,
   ) {
     super.onCollisionStart(intersectionPoints, other);
-    if (other case Damageable damageable) {
+    if (other is AsteroidComponent) {
+      other.destroy();
+      removeFromParent();
+    } else if (other case Damageable damageable) {
       damageable.takeDamage(Constants.bulletDamage);
       removeFromParent();
     }

--- a/test/bullet_asteroid_destroy_test.dart
+++ b/test/bullet_asteroid_destroy_test.dart
@@ -1,0 +1,120 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flame_audio/flame_audio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/asteroid.dart';
+import 'package:space_game/components/bullet.dart';
+import 'package:space_game/components/mineral.dart';
+import 'package:space_game/components/explosion.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+import 'test_joystick.dart';
+
+class _FakeAudioService implements AudioService {
+  @override
+  final ValueNotifier<bool> muted = ValueNotifier(false);
+  @override
+  final ValueNotifier<double> volume = ValueNotifier<double>(1);
+
+  @override
+  double get masterVolume => volume.value;
+
+  @override
+  AudioPlayer? get miningLoop => null;
+
+  @override
+  Future<void> startMiningLaser() async {}
+
+  @override
+  void stopAll() {}
+
+  @override
+  void stopMiningLaser() {}
+
+  @override
+  void playShoot() {}
+
+  @override
+  void playExplosion() {}
+
+  @override
+  Future<void> toggleMute() async {
+    muted.value = !muted.value;
+  }
+
+  @override
+  void setMasterVolume(double volume) {
+    this.volume.value = volume;
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: Assets.players.first);
+
+  @override
+  Future<void> onLoad() async {}
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    keyDispatcher = KeyDispatcher();
+    await add(keyDispatcher);
+    joystick = TestJoystick();
+    await add(joystick);
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('bullet destroys asteroid without minerals or explosion', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([
+      ...Assets.asteroids,
+      Assets.bullet,
+      ...Assets.players,
+    ]);
+    final storage = await StorageService.create();
+    final audio = _FakeAudioService();
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    game.onGameResize(Vector2.all(500));
+    await game.ready();
+
+    final asteroid = game.pools.acquire<AsteroidComponent>(
+      (a) => a.reset(Vector2.zero(), Vector2.zero()),
+    );
+    await game.add(asteroid);
+    final bullet = BulletComponent()..reset(Vector2.zero(), Vector2(1, 0));
+    await game.add(bullet);
+    game.update(0);
+
+    bullet.onCollisionStart({}, asteroid);
+    game.update(0);
+
+    expect(asteroid.parent, isNull);
+    expect(bullet.parent, isNull);
+    expect(game.pools.components<MineralComponent>(), isEmpty);
+    expect(game.children.whereType<ExplosionComponent>(), isEmpty);
+    expect(game.score.value, Constants.asteroidScore);
+  });
+}


### PR DESCRIPTION
## Summary
- Make main cannon shots instantly destroy asteroids without mineral drops
- Adjust asteroid docs and playtest checklist for new behavior
- Add test ensuring bullets remove asteroids without minerals or explosions

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bec339c96083309291b660a4fcc7ad