### PR TITLE
feat: show player heading on minimap

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -155,7 +155,8 @@ tree spanning weapons and ship systems.
   showing a centered `PAUSED` label with a hint to press `Esc` or `P` to
   resume while gameplay halts.
 - During play the HUD provides score, minerals, health, a minimap toggle, range
-  rings toggle, pause and mute controls.
+  rings toggle, pause and mute controls. The minimap displays the player's
+  heading along with nearby asteroids, enemies and mineral pickups.
 - On player death, a game over overlay appears with restart, menu and mute buttons.
 - A help overlay lists controls and can be toggled with the `H` key, pausing the
   game when opened mid-run. `Esc` also closes it without triggering pause.
@@ -170,7 +171,7 @@ tree spanning weapons and ship systems.
 
 - On-screen joystick and fire button mirror keyboard controls (WASD + Space).
 - Input handling stays isolated from rendering for easier testing.
-- `N` toggles a minimap overlay for navigation.
+- `N` toggles a minimap overlay with a player-direction arrow for navigation.
 - `B` or a HUD button toggles range rings showing targeting, Tractor Aura and
   mining radii.
 - `H` toggles a help overlay for quick reference, and `Esc` closes it when

--- a/PLAN.md
+++ b/PLAN.md
@@ -173,7 +173,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Single endless level without progression for now
 - Player score, minerals and health shown in the HUD with simple
   start/game‑over screens
-- Toggable top-left minimap shows nearby asteroids, enemies and pickups
+- Toggable top-left minimap shows the player's heading and nearby asteroids,
+  enemies and pickups
 - HUD button or `B` key toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Local high score stored on device (e.g., shared preferences)
 - Menu offers a reset button to clear the high score

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -11,7 +11,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Bullets spawn from the front of the player's ship
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
 - [ ] Target button or `B` key toggles range rings display
-- [ ] Minimap icon or `N` key toggles minimap visibility
+- [ ] Minimap icon or `N` key toggles minimap with player heading arrow
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ dedicated server or NAT traversal.
 - Single endless level with quick restart
 - Player score, health and minerals displayed in the HUD; health drops on
   collision and minerals increase when collecting pickups from mined asteroids
-- Toggable top-left minimap shows nearby asteroids, enemies and pickups
+- Toggable top-left minimap shows the player's heading and nearby asteroids,
+  enemies and pickups
 - HUD button or `B` key toggles coloured range rings showing targeting, Tractor Aura and mining radii
 - Upgrades overlay lets you buy simple upgrades with minerals that persist
   between sessions, accessible via a HUD button or the `U` key. Current

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -36,4 +36,9 @@ Flutter overlays and HUD widgets.
   toggles the minimap, `B` toggles range rings, and `Esc` also closes overlays
   when visible.
 
+## Widgets
+
+- [MiniMapDisplay](minimap_display.md) – circular minimap showing nearby
+  entities with an arrow indicating player heading.
+
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/ui/minimap_display.dart
+++ b/lib/ui/minimap_display.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flame/components.dart';
@@ -8,6 +10,9 @@ import '../components/mineral.dart';
 import '../game/space_game.dart';
 
 /// Simple circular minimap showing nearby entities relative to the player.
+///
+/// The player appears as a small arrow indicating the current heading, while
+/// enemies, asteroids and mineral pickups render as dots.
 class MiniMapDisplay extends StatefulWidget {
   const MiniMapDisplay({super.key, required this.game, this.size = 80});
 
@@ -62,7 +67,26 @@ class _MiniMapPainter extends CustomPainter {
     canvas.drawCircle(center, radius, borderPaint);
 
     final playerPaint = Paint()..color = game.colorScheme.primary;
-    canvas.drawCircle(center, 3, playerPaint);
+    const double arrowRadius = 6;
+    final angle = game.player.angle;
+    final tip = Offset(
+      center.dx + math.cos(angle) * arrowRadius,
+      center.dy + math.sin(angle) * arrowRadius,
+    );
+    final left = Offset(
+      center.dx + math.cos(angle + 5 * math.pi / 6) * arrowRadius,
+      center.dy + math.sin(angle + 5 * math.pi / 6) * arrowRadius,
+    );
+    final right = Offset(
+      center.dx + math.cos(angle - 5 * math.pi / 6) * arrowRadius,
+      center.dy + math.sin(angle - 5 * math.pi / 6) * arrowRadius,
+    );
+    final path = Path()
+      ..moveTo(tip.dx, tip.dy)
+      ..lineTo(left.dx, left.dy)
+      ..lineTo(right.dx, right.dy)
+      ..close();
+    canvas.drawPath(path, playerPaint);
 
     final enemyPaint = Paint()..color = Colors.redAccent;
     final asteroidPaint = Paint()..color = Colors.grey;

--- a/lib/ui/minimap_display.md
+++ b/lib/ui/minimap_display.md
@@ -1,6 +1,9 @@
-# MiniMapDisplay
+# minimap_display.dart
 
-Flutter widget that paints a simple circular radar in the top-left of the HUD.
-It draws dots for nearby asteroids, enemies and mineral pickups relative to the
-player. The map listens to the game for repaints and can be toggled via the HUD
-map button.
+Renders a circular minimap widget that tracks nearby entities.
+
+- Player is drawn as a small arrow pointing in the current heading.
+- Enemies, asteroids and mineral pickups appear as coloured dots.
+- The canvas updates each tick via a `Ticker` so the overlay stays live.
+- `MiniMapDisplay` is typically embedded in the HUD and toggled with the `N`
+  key or minimap icon.


### PR DESCRIPTION
## Summary
- show player heading on HUD minimap with an arrow
- document minimap widget and update design docs

## Testing
- `npx markdownlint-cli '**/*.md'`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bec1b0d1ec8330aacd79c598e64a52