### PR TITLE
feat: centralize tractor aura colors and document components

### DIFF
--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -38,6 +38,16 @@ Gameplay entities and reusable pieces.
   star tiles and prunes those far from the camera.
 - [ExplosionComponent](explosion.md) – short animation and sound played when
   a ship is destroyed.
+- `EnemySpawner` – releases timed groups of enemies ahead of the player.
+- `AsteroidSpawner` – scatters asteroids around the player as they travel.
+- `PlayerInputBehavior` – handles joystick and keyboard input for the player.
+- `AutoAimBehavior` – rotates the player toward the nearest enemy when idle.
+- `TractorAuraRenderer` – draws a radial gradient showing the Tractor Aura.
+- `OffscreenCleanup` – mixin that removes components far from the camera.
+- `SpawnRemoveEmitter` – mixin emitting spawn/remove events for pooling.
+- `Damageable` – mixin tracking hit points on a component.
+- `DamageFlash` – mixin flashing a sprite when taking damage.
+- `DebugHealthText` – mixin rendering remaining health in debug mode.
 
 ## Planned Components
 

--- a/lib/components/tractor_aura_renderer.dart
+++ b/lib/components/tractor_aura_renderer.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flame/components.dart';
 
+import '../constants.dart';
 import '../game/space_game.dart';
 import 'player.dart';
 
@@ -19,8 +20,8 @@ class TractorAuraRenderer extends Component
       auraCenter,
       auraRadius,
       [
-        const Color(0x5500aaff),
-        const Color(0x0000aaff),
+        Constants.tractorAuraInnerColor,
+        Constants.tractorAuraOuterColor,
       ],
     );
     canvas.drawCircle(auraCenter, auraRadius, _paint);

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -68,6 +68,12 @@ class Constants {
   /// Speed pickups move toward the player within the Tractor Aura.
   static const double tractorAuraPullSpeed = 200;
 
+  /// Inner color of the player's Tractor Aura gradient.
+  static const Color tractorAuraInnerColor = Color(0x5500aaff);
+
+  /// Outer color of the player's Tractor Aura gradient.
+  static const Color tractorAuraOuterColor = Color(0x0000aaff);
+
   /// Bullet travel speed in pixels per second.
   static const double bulletSpeed = 400;
 


### PR DESCRIPTION
## Summary
- centralize tractor aura gradient colors in constants
- document additional components and mixins

## Testing
- `./scripts/dartw format lib/constants.dart lib/components/tractor_aura_renderer.dart`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx --yes markdownlint-cli "**/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68bec1b0d1ec8330aacd79c598e64a52