### PR TITLE
feat: add shield regeneration upgrade

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -139,8 +139,9 @@ tree spanning weapons and ship systems.
 ## Upgrades
 
 - Minerals earned from asteroids fund upgrades such as faster cannon fire,
-  quicker mining pulses, extended targeting and Tractor Aura ranges, and engine
-  tuning for higher speed without bloating the core loop.
+  quicker mining pulses, extended targeting and Tractor Aura ranges, engine
+  tuning for higher speed and a Shield Booster that slowly regenerates
+  health without bloating the core loop.
 - `UpgradeService` tracks available upgrades and purchases using minerals.
 
 ## Game State Flow

--- a/PLAN.md
+++ b/PLAN.md
@@ -189,8 +189,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Upgrades overlay lets players spend minerals on simple upgrades that
   persist between sessions, opened with a HUD button or the `U` key and
   pausing gameplay. Available upgrades cover fire rate, mining speed,
-  targeting and Tractor Aura ranges, plus an Engine Tuning option for
-  faster movement
+  targeting and Tractor Aura ranges, an Engine Tuning option for faster
+  movement and a Shield Booster that slowly regenerates health
 - Settings overlay with master volume slider and sliders for HUD, minimap,
   text, joystick, targeting, Tractor Aura and mining ranges, plus a reset
   button

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -21,6 +21,7 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] HUD shows current score, minerals and health during play
 - [ ] Collisions reduce player health; game over when health reaches zero
 - [ ] Player ship flashes red when taking damage
+- [ ] Shield Booster upgrade regenerates health over time when purchased
 - [ ] Game states transition: menu → playing → upgrades → paused → game over
       → restart or menu
 - [ ] Player can choose a ship from the menu before starting

--- a/TASKS.md
+++ b/TASKS.md
@@ -81,6 +81,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 - [x] Persist purchased upgrades across sessions using `StorageService`.
 - [x] Engine Tuning upgrade increases player movement speed.
+- [x] Shield Booster upgrade slowly regenerates player health.
 
 ## Next Steps
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -58,6 +58,10 @@ class Constants {
   /// Seconds that the player sprite flashes red after taking damage.
   static const double playerDamageFlashDuration = 0.2;
 
+  /// Seconds between automatic health regeneration ticks when the Shield
+  /// Booster upgrade is purchased.
+  static const double playerHealthRegenInterval = 5;
+
   /// Radius of the player's Tractor Aura in pixels.
   static const double playerTractorAuraRadius = 150;
 

--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -22,6 +22,7 @@ class LifecycleManager {
   void onStart() {
     game.audioService.stopAll();
     game.scoreService.reset();
+    game.resetHealthRegenTimer();
     game.pools.clear();
     // Process any queued lifecycle events so components added just before the
     // previous session ended (like the player's explosion on death) are

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -92,6 +92,8 @@ class SpaceGame extends FlameGame
   double _storedVolume = 1;
   bool _suppressVolumeSave = false;
 
+  double _healthRegenTimer = 0;
+
   /// Provides runtime-adjustable UI settings.
   final SettingsService settingsService;
 
@@ -296,6 +298,9 @@ class SpaceGame extends FlameGame
   /// Adds [value] to the current mineral count.
   void addMinerals(int value) => scoreService.addMinerals(value);
 
+  /// Resets the shield regeneration timer.
+  void resetHealthRegenTimer() => _healthRegenTimer = 0;
+
   /// Pauses the game and shows the `PAUSED` overlay.
   void pauseGame() {
     stateMachine.pauseGame();
@@ -455,6 +460,20 @@ class SpaceGame extends FlameGame
             stateMachine.state == GameState.upgrades);
     final effectiveDt = shouldFreeze ? 0.0 : dt;
     super.update(effectiveDt);
+
+    if (_isLoaded &&
+        stateMachine.state == GameState.playing &&
+        upgradeService.hasShieldRegen &&
+        scoreService.health.value < Constants.playerMaxHealth) {
+      _healthRegenTimer += effectiveDt;
+      if (_healthRegenTimer >= Constants.playerHealthRegenInterval) {
+        _healthRegenTimer = 0;
+        scoreService.health.value =
+            (scoreService.health.value + 1).clamp(0, Constants.playerMaxHealth);
+      }
+    } else {
+      _healthRegenTimer = 0;
+    }
   }
 
   @override

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -13,7 +13,8 @@ Optional helpers for cross-cutting concerns.
 - `targeting_service.dart` assists auto-aim queries.
 - `upgrade_service.dart` manages purchasing upgrades with minerals,
   persists bought upgrades via `StorageService`, and derives gameplay modifiers
-  like fire rate and mining speed.
+  like fire rate, mining speed, targeting and Tractor Aura ranges, player speed
+  and health regeneration.
 - Keep services lightweight; add them only when a milestone needs them.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/services/upgrade_service.dart
+++ b/lib/services/upgrade_service.dart
@@ -37,6 +37,7 @@ class UpgradeService {
     Upgrade(id: 'targetingRange1', name: 'Targeting Computer', cost: 20),
     Upgrade(id: 'tractorRange1', name: 'Tractor Booster', cost: 25),
     Upgrade(id: 'speed1', name: 'Engine Tuning', cost: 30),
+    Upgrade(id: 'shieldRegen1', name: 'Shield Booster', cost: 40),
   ];
 
   final ValueNotifier<Set<String>> _purchased =
@@ -44,6 +45,9 @@ class UpgradeService {
   ValueListenable<Set<String>> get purchased => _purchased;
 
   bool isPurchased(String id) => _purchased.value.contains(id);
+
+  /// Whether the shield regeneration upgrade has been purchased.
+  bool get hasShieldRegen => isPurchased('shieldRegen1');
 
   bool canAfford(Upgrade upgrade) =>
       scoreService.minerals.value >= upgrade.cost && !isPurchased(upgrade.id);

--- a/lib/services/upgrade_service.md
+++ b/lib/services/upgrade_service.md
@@ -10,6 +10,7 @@ Manages purchasing upgrades using collected minerals.
 - Deduct mineral costs via `ScoreService` when buying.
 - Provide a `ValueListenable` of purchased upgrade ids for UI widgets.
 - Provide derived values like bullet cooldown, mining pulse interval, targeting
-  range and Tractor Aura radius based on purchased upgrades.
+  range, Tractor Aura radius, player speed and health regeneration based on
+  purchased upgrades.
 
 See [../../PLAN.md](../../PLAN.md) for progression goals.


### PR DESCRIPTION
## Summary
- add Shield Booster upgrade and health regen timer
- document new upgrade in design and playtest guides

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`
- `npx markdownlint-cli '**/*.md'` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68bec1b0d1ec8330aacd79c598e64a52