### PR TITLE
chore: speed up CI flutter commands

### DIFF
--- a/scripts/dartw
+++ b/scripts/dartw
@@ -5,6 +5,8 @@ args=("$@")
 set --
 source "$(dirname "$0")/bootstrap_flutter.sh"
 set -- "${args[@]}"
+export FLUTTER_SUPPRESS_ANALYTICS=1
+export DART_SUPPRESS_ANALYTICS=1
 if [[ "${1-}" == "format" && $# -eq 1 ]]; then
   set -- "$1" .
 fi

--- a/scripts/flutterw
+++ b/scripts/flutterw
@@ -9,6 +9,21 @@ source "$(dirname "$0")/bootstrap_flutter.sh"
 echo "[flutterw] Flutter SDK ready"
 # Restore original args for the actual flutter invocation.
 set -- "${args[@]}"
+export FLUTTER_SUPPRESS_ANALYTICS=1
+export DART_SUPPRESS_ANALYTICS=1
+
+if [[ -n ${CI:-} && ${1:-} != "pub" ]]; then
+  found_no_pub=false
+  for arg in "$@"; do
+    if [[ $arg == --no-pub ]]; then
+      found_no_pub=true
+      break
+    fi
+  done
+  if [[ $found_no_pub == false ]]; then
+    set -- "$@" --no-pub
+  fi
+fi
 test_concurrency=""
 if [[ "${1:-}" == "test" ]]; then
   found_concurrency=false


### PR DESCRIPTION
## Summary
- disable analytics for flutter and dart wrappers
- skip implicit `pub get` in CI to save time

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test --no-pub`
- `./scripts/dartw format --output=none --set-exit-if-changed .`


------
https://chatgpt.com/codex/tasks/task_e_68bec239950c8330a11874d6580275b6