### PR TITLE
Parallelize analyze and test jobs

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze-and-test:
+  analyze:
     runs-on: ubuntu-latest
     env:
       PUB_CACHE: ${{ github.workspace }}/.pub-cache
@@ -48,6 +48,30 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           exit $exit_code
+  test:
+    runs-on: ubuntu-latest
+    env:
+      PUB_CACHE: ${{ github.workspace }}/.pub-cache
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Cache Flutter SDK
+        uses: actions/cache@v4
+        with:
+          path: .tooling/flutter
+          key: ${{ runner.os }}-flutter-${{ hashFiles('scripts/bootstrap_flutter.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+      - name: Install dependencies
+        run: mkdir -p $PUB_CACHE && ./scripts/flutterw pub get
       - name: Test
         run: |
           set -o pipefail

--- a/PLAN.md
+++ b/PLAN.md
@@ -256,7 +256,7 @@ in [TASKS.md](TASKS.md).
 - Format with `fvm dart format .`
 - Analyze with `fvm dart analyze` (guided by `.analysis_options.yaml`)
 - Lint docs with `npx markdownlint-cli '**/*.md'`
-- Once tests exist, run `fvm flutter test`
+- Run tests with `scripts/flutterw test` (auto-detects CPU cores for `--concurrency`)
 - Use `flutter_test` for widget tests and `flame_test` for component/system tests
   once tests are added
 - Cover object pools with unit tests to ensure instances are reused


### PR DESCRIPTION
## Summary
- run analysis and test as separate GitHub Actions jobs so they can execute in parallel
- document new `scripts/flutterw test` workflow that auto-selects test concurrency

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bec239950c8330a11874d6580275b6