### PR TITLE
Prevent duplicate starfield rebuilds

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -129,6 +129,7 @@ class SpaceGame extends FlameGame
   final GameEventBus eventBus = GameEventBus();
   late final TargetingService targetingService;
   StarfieldComponent? _starfield;
+  int _starfieldRebuildId = 0;
   FpsTextComponent? _fpsText;
   bool _playerInitialized = false;
   final ValueNotifier<bool> showMinimap = ValueNotifier<bool>(true);
@@ -452,6 +453,8 @@ class SpaceGame extends FlameGame
   void _rebuildStarfield() {
     final tileSize = settingsService.starfieldTileSize.value;
     _starfield?.removeFromParent();
+    _starfield = null;
+    final buildId = ++_starfieldRebuildId;
     unawaited(() async {
       final sf = await StarfieldComponent(
         debugDrawTiles: debugMode,
@@ -462,6 +465,9 @@ class SpaceGame extends FlameGame
         ],
         tileSize: tileSize,
       );
+      if (buildId != _starfieldRebuildId) {
+        return;
+      }
       _starfield = sf;
       await add(sf);
     }());


### PR DESCRIPTION
## Summary
- track rebuild id to discard older starfield rebuilds

## Testing
- `./scripts/dartw analyze lib/game/space_game.dart`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bec58d79bc8330b82a76a91fa25852