### PR TITLE
feat: parallelize service worker caching

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -9,14 +9,16 @@ const CORE_ASSETS = [
 ];
 
 async function cacheAssets(cache, assets) {
-  for (const asset of assets) {
-    const url = asset.startsWith("assets/") ? `assets/${asset}` : asset;
-    try {
-      await cache.add(url);
-    } catch (err) {
-      console.warn(`Failed to cache ${url}`, err);
-    }
-  }
+  await Promise.all(
+    assets.map(async (asset) => {
+      const url = asset.startsWith("assets/") ? `assets/${asset}` : asset;
+      try {
+        await cache.add(url);
+      } catch (err) {
+        console.warn(`Failed to cache ${url}`, err);
+      }
+    }),
+  );
 }
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Summary
- parallelize service worker asset caching for faster install

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bec6d8949c8330b56319cdad537fb0