### PR TITLE
Spawn enemy groups with consistent type

### DIFF
--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -33,15 +33,25 @@ class EnemyComponent extends SpriteComponent
   EnemyComponent() : super(anchor: Anchor.center);
 
   late EnemyFaction faction;
+  late String spritePath;
 
   int _health = Constants.enemyMaxHealth;
 
   /// Prepares the enemy for reuse.
-  void reset(Vector2 position, EnemyFaction faction, {bool isBoss = false}) {
+  ///
+  /// [spritePath] allows callers to supply a specific sprite so that a group of
+  /// enemies can share the same visual even when multiple sprites exist for a
+  /// faction. If omitted, a random sprite for [faction] is chosen.
+  void reset(
+    Vector2 position,
+    EnemyFaction faction, {
+    String? spritePath,
+    bool isBoss = false,
+  }) {
     this.position.setFrom(position);
     this.faction = faction;
-    final path = Assets.randomEnemyForFaction(faction);
-    sprite = Sprite(Flame.images.fromCache(path));
+    this.spritePath = spritePath ?? Assets.randomEnemyForFaction(faction);
+    sprite = Sprite(Flame.images.fromCache(this.spritePath));
     final baseSize =
         Constants.enemySize * (Constants.spriteScale + Constants.enemyScale);
     size = Vector2.all(baseSize * (isBoss ? Constants.enemyBossScale : 1));

--- a/lib/components/enemy.md
+++ b/lib/components/enemy.md
@@ -13,5 +13,6 @@ Basic foe that drifts toward the player.
 - Uses `CircleHitbox` or `RectangleHitbox` depending on art.
 - Mixes in `HasGameReference<SpaceGame>` for access to global state.
 - Uses a small object pool to reuse instances.
+- Stores the selected sprite path on each instance for identification.
 
 See [../../PLAN.md](../../PLAN.md) for core loop goals.

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -49,18 +49,21 @@ class EnemySpawner extends Component with HasGameReference<SpaceGame> {
           Vector2(math.cos(angle), math.sin(angle)) * spawnDistance;
     }
     final faction = Assets.randomFaction();
+    final spritePath = Assets.randomEnemyForFaction(faction);
     for (var i = 0; i < Constants.enemyGroupSize; i++) {
       final offset = (Vector2.random(_random) - Vector2.all(0.5)) *
           (Constants.enemyGroupSpread * 2);
       final position = base + offset;
       game.add(
-        game.pools.acquire<EnemyComponent>((e) => e.reset(position, faction)),
+        game.pools.acquire<EnemyComponent>(
+          (e) => e.reset(position, faction, spritePath: spritePath),
+        ),
       );
     }
     if (_random.nextDouble() < Constants.enemyBossChance) {
       game.add(
         game.pools.acquire<EnemyComponent>(
-          (e) => e.reset(base, faction, isBoss: true),
+          (e) => e.reset(base, faction, spritePath: spritePath, isBoss: true),
         ),
       );
     }

--- a/test/enemy_group_spawn_test.dart
+++ b/test/enemy_group_spawn_test.dart
@@ -61,11 +61,14 @@ void main() {
     game.enemySpawner.spawnNow();
     game.update(0);
     await game.ready();
-    final count = game.children.whereType<EnemyComponent>().length;
+    final enemies = game.children.whereType<EnemyComponent>().toList();
+    final count = enemies.length;
     expect(
       count == Constants.enemyGroupSize ||
           count == Constants.enemyGroupSize + 1,
       isTrue,
     );
+    final spritePaths = enemies.map((e) => e.spritePath).toSet();
+    expect(spritePaths.length, equals(1));
   });
 }


### PR DESCRIPTION
## Summary
- Allow `EnemyComponent` to accept a specific sprite path and store it for identification
- Spawn enemy groups (and bosses) with a single sprite type per faction
- Test that spawner emits enemies sharing the same sprite

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bec8b71b4c8330ad44df3f0dbd11c7