### PR TITLE
docs: note starfield layers and settings slider

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,8 +164,8 @@ tree spanning weapons and ship systems.
 - An upgrades overlay opens with the `U` key or HUD button and pauses gameplay
   while letting players buy basic upgrades that persist between sessions.
 - A settings overlay provides sliders for master volume, HUD, minimap, text,
-  joystick, targeting, Tractor Aura and mining ranges and includes a reset
-  button.
+  joystick, targeting, Tractor Aura and mining ranges, starfield tile size and
+  includes a reset button.
 - A `GameState` enum tracks the current phase.
 
 ## Input
@@ -188,15 +188,16 @@ tree spanning weapons and ship systems.
   `OffscreenCleanup` mixin. Asteroid and enemy spawners place new objects ahead
   of the player's current heading using this same radius so action stays in
   front of the ship.
-- A deterministic world-space starfield generates stars per chunk using
-  Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex
-  noise modulates density to create clusters and voids. Stars follow a weighted
-  size/brightness distribution with optional subtle colour jitter. Each chunk
-  pre-renders to a cached `Picture` translated by `-playerPosition`, dropping
-  tiles outside a small margin around the camera so memory stays bounded. The
-  player flies over a static backdrop while circles draw faint-to-bright. A
-  `debugDrawTiles` switch outlines tile boundaries when debug mode (`F1`) is
-  active for troubleshooting.
+- A deterministic multi-layer world-space starfield generates stars per chunk
+  using Poisson-disk sampling seeded by chunk coordinates. Low-frequency Simplex
+  noise modulates density to create clusters and voids. Layers apply parallax
+  factors and gentle alpha twinkling. Stars follow a weighted size/brightness
+  distribution with optional subtle colour jitter. Each chunk pre-renders to a
+  cached `Picture` translated by `-playerPosition`, dropping tiles outside a
+  small margin around the camera so memory stays bounded. Tile size is
+  adjustable via the settings overlay. The player flies over a static backdrop
+  while circles draw faint-to-bright. A `debugDrawTiles` switch outlines tile
+  boundaries when debug mode (`F1`) is active for troubleshooting.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -149,7 +149,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   noise modulates density for clusters, and each chunk pre-renders to a cached
   `Picture` that sorts stars by radius so faint ones draw first for smoother
   blending. A weighted size/brightness distribution with subtle colour jitter
-  adds variety.
+  adds variety, and layered parallax with gentle alpha twinkling adds depth.
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple
   object pools to reduce garbage collection overhead
@@ -193,12 +193,13 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   targeting and Tractor Aura ranges, an Engine Tuning option for faster
   movement and a Shield Booster that slowly regenerates health
 - Settings overlay with master volume slider and sliders for HUD, minimap,
-  text, joystick, targeting, Tractor Aura and mining ranges, plus a reset
-  button
+  text, joystick, targeting, Tractor Aura and mining ranges, starfield tile
+  size, plus a reset button
 - Game works offline after the first load thanks to the service worker
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.
   - Simplex noise modulates density for subtle clusters.
+  - Layered parallax with independent density multipliers and twinkle speeds adds depth.
   - Weighted size/brightness spread (≈80% tiny, 19% small, 1% medium) with optional
     colour jitter adds variety.
   - Each chunk pre-renders to a cached `Picture`, dropping tiles outside a small
@@ -206,6 +207,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
     so the player flies over a static backdrop. Stars sort by radius so faint
     ones render first for smoother blending. A `debugDrawTiles` option outlines
     tile boundaries when debug mode (`F1`) is active to aid development.
+  - Tile size can be tuned in the settings overlay to balance detail and performance.
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
   `P` to resume; `Q` returns to the menu from pause or game over
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ dedicated server or NAT traversal.
   between sessions, accessible via a HUD button or the `U` key. Current
   upgrades include a faster cannon, quicker mining pulses, a targeting
   computer, a Tractor Booster and Engine Tuning for higher speed
-- Settings overlay adjusts volume, HUD, minimap, text and joystick scales and
-  gameplay ranges, and includes a reset button
+- Settings overlay adjusts volume, HUD, minimap, text and joystick scales,
+  gameplay ranges and starfield tile size, and includes a reset button
 - Menu allows choosing between multiple ship sprites and remembers the selection
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
@@ -69,12 +69,14 @@ dedicated server or NAT traversal.
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.
   - Simplex noise modulates density for subtle clusters.
+  - Layered parallax with independent density multipliers and twinkle speeds adds depth.
   - Weighted radius/brightness spread (≈80% tiny, 19% small, 1% medium) with optional
     colour jitter adds variation.
   - Each chunk pre-renders to a cached `Picture`, dropping tiles outside a small
     margin around the camera, then draws with a translation of `-playerPosition`
     so the player flies over a static field. Draw faint stars first for smoother
     blending. A `debugDrawTiles` flag can outline tiles during development.
+  - Tile size can be tuned in the settings overlay to balance detail and performance.
 
 ## 🔮 Future Plans
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -76,8 +76,9 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Upgrades overlay accessible via HUD button or the `U` key where purchases
       persist across sessions.
 - [x] HUD button or `B` key toggles range rings for targeting, Tractor Aura and mining.
-- [x] Settings overlay with master volume slider and sliders for HUD, text,
-      joystick, targeting, Tractor Aura and mining ranges, plus reset button.
+- [x] Settings overlay with master volume slider and sliders for HUD, minimap,
+      text, joystick, targeting, Tractor Aura and mining ranges, starfield tile
+      size, plus reset button.
 
 - [x] Persist purchased upgrades across sessions using `StorageService`.
 - [x] Engine Tuning upgrade increases player movement speed.

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -4,7 +4,7 @@ Overlay providing runtime audio, UI scaling and range controls.
 
 ## Features
 
-- Sliders adjust volume, HUD button, minimap, text, joystick scales and gameplay ranges.
+- Sliders adjust volume, HUD button, minimap, text, joystick scales, gameplay ranges and starfield tile size.
 - Sections separate HUD scaling from range scaling for easier navigation.
 - Bordered layout limits width on large screens for clarity.
 - Opens from the HUD; closing returns to the game.

--- a/milestone-polish.md
+++ b/milestone-polish.md
@@ -15,7 +15,8 @@ See [PLAN.md](PLAN.md) for overall project goals and
 - [x] Menu allows choosing between multiple ship sprites and persists the selection.
 - [x] Option to mute or dim audio when the game is paused.
 - [x] Settings overlay with master volume slider and sliders for HUD, minimap,
-      text, joystick, targeting, Tractor Aura and mining ranges, plus reset button.
+      text, joystick, targeting, Tractor Aura and mining ranges, starfield tile
+      size, plus reset button.
 - [x] Engine Tuning upgrade boosts player speed.
 
 ## Design Notes


### PR DESCRIPTION
## Summary
- describe multi-layer parallax starfield with twinkling and configurable tile size
- document starfield tile size slider in settings overlay and related docs

## Testing
- `./scripts/dartw format .`
- `./scripts/dartw analyze`
- `npx --yes markdownlint-cli '**/*.md'`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bec6d86f688330940a9ab7cfb81916