### PR TITLE
Fix minimap arrow orientation

### DIFF
--- a/lib/ui/minimap_display.dart
+++ b/lib/ui/minimap_display.dart
@@ -68,7 +68,9 @@ class _MiniMapPainter extends CustomPainter {
 
     final playerPaint = Paint()..color = game.colorScheme.primary;
     const double arrowRadius = 6;
-    final angle = game.player.angle;
+    // Player's angle is 0 when facing north, but Canvas expects 0 on the east.
+    // Shift by 90 degrees so the minimap arrow aligns with the ship heading.
+    final angle = game.player.angle - math.pi / 2;
     final tip = Offset(
       center.dx + math.cos(angle) * arrowRadius,
       center.dy + math.sin(angle) * arrowRadius,


### PR DESCRIPTION
## Summary
- Align minimap player arrow direction with ship heading on the minimap

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bec823054c8330b18df55b1c0e6972