### PR TITLE
Structure enemy faction assets with boss placeholders

### DIFF
--- a/lib/assets.dart
+++ b/lib/assets.dart
@@ -13,15 +13,27 @@ class Assets {
     'players/player1.png',
     'players/player2.png',
   ];
-  static const Map<EnemyFaction, List<String>> enemyFactions = {
-    EnemyFaction.faction1: ['enemies/faction1/unit.png'],
-    EnemyFaction.faction2: ['enemies/faction2/unit.png'],
-    EnemyFaction.faction3: ['enemies/faction3/unit.png'],
-    EnemyFaction.faction4: ['enemies/faction4/unit.png'],
+  static const Map<EnemyFaction, EnemySpriteSet> enemyFactions = {
+    EnemyFaction.faction1: EnemySpriteSet(
+      units: ['enemies/faction1/unit.png'],
+      boss: 'enemies/faction1/unit.png',
+    ),
+    EnemyFaction.faction2: EnemySpriteSet(
+      units: ['enemies/faction2/unit.png'],
+      boss: 'enemies/faction2/unit.png',
+    ),
+    EnemyFaction.faction3: EnemySpriteSet(
+      units: ['enemies/faction3/unit.png'],
+      boss: 'enemies/faction3/unit.png',
+    ),
+    EnemyFaction.faction4: EnemySpriteSet(
+      units: ['enemies/faction4/unit.png'],
+      boss: 'enemies/faction4/unit.png',
+    ),
   };
 
   static List<String> get enemies =>
-      enemyFactions.values.expand((e) => e).toList();
+      enemyFactions.values.expand((e) => [...e.units, e.boss]).toList();
   static const List<String> asteroids = [
     'asteroids/asteroid1.png',
     'asteroids/asteroid2.png',
@@ -89,12 +101,26 @@ class Assets {
   static EnemyFaction randomFaction() =>
       EnemyFaction.values[_rand.nextInt(EnemyFaction.values.length)];
 
-  /// Returns a random enemy sprite path for [faction].
-  static String randomEnemyForFaction(EnemyFaction faction) {
-    final sprites = enemyFactions[faction]!;
+  /// Returns a random unit sprite path for [faction].
+  static String randomUnitForFaction(EnemyFaction faction) {
+    final sprites = enemyFactions[faction]!.units;
     return sprites[_rand.nextInt(sprites.length)];
   }
 
+  /// Returns the boss sprite path for [faction].
+  static String bossForFaction(EnemyFaction faction) =>
+      enemyFactions[faction]!.boss;
+
   /// Returns a random asteroid sprite path.
   static String randomAsteroid() => asteroids[_rand.nextInt(asteroids.length)];
+}
+
+class EnemySpriteSet {
+  const EnemySpriteSet({required this.units, required this.boss});
+
+  /// Sprite paths for standard units belonging to a faction.
+  final List<String> units;
+
+  /// Sprite path for the faction's boss unit.
+  final String boss;
 }

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -50,7 +50,10 @@ class EnemyComponent extends SpriteComponent
   }) {
     this.position.setFrom(position);
     this.faction = faction;
-    this.spritePath = spritePath ?? Assets.randomEnemyForFaction(faction);
+    this.spritePath = spritePath ??
+        (isBoss
+            ? Assets.bossForFaction(faction)
+            : Assets.randomUnitForFaction(faction));
     sprite = Sprite(Flame.images.fromCache(this.spritePath));
     final baseSize =
         Constants.enemySize * (Constants.spriteScale + Constants.enemyScale);

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -48,22 +48,23 @@ class EnemySpawner extends Component with HasGameReference<SpaceGame> {
       base = game.player.position +
           Vector2(math.cos(angle), math.sin(angle)) * spawnDistance;
     }
-    final faction = Assets.randomFaction();
-    final spritePath = Assets.randomEnemyForFaction(faction);
+    final EnemyFaction faction = Assets.randomFaction();
+    final unitPath = Assets.randomUnitForFaction(faction);
     for (var i = 0; i < Constants.enemyGroupSize; i++) {
       final offset = (Vector2.random(_random) - Vector2.all(0.5)) *
           (Constants.enemyGroupSpread * 2);
       final position = base + offset;
       game.add(
         game.pools.acquire<EnemyComponent>(
-          (e) => e.reset(position, faction, spritePath: spritePath),
+          (e) => e.reset(position, faction, spritePath: unitPath),
         ),
       );
     }
     if (_random.nextDouble() < Constants.enemyBossChance) {
+      final bossPath = Assets.bossForFaction(faction);
       game.add(
         game.pools.acquire<EnemyComponent>(
-          (e) => e.reset(base, faction, spritePath: spritePath, isBoss: true),
+          (e) => e.reset(base, faction, spritePath: bossPath, isBoss: true),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- group enemy sprites by faction with boss placeholders
- spawn same-type enemy groups with per-faction bosses
- reset enemies using faction-specific sprites

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68beca5c33308330a9b6f60c2bf5dda1