### PR TITLE
feat: add keyboard shortcut for settings overlay

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,9 +163,9 @@ tree spanning weapons and ship systems.
   game when opened mid-run. `Esc` also closes it without triggering pause.
 - An upgrades overlay opens with the `U` key or HUD button and pauses gameplay
   while letting players buy basic upgrades that persist between sessions.
-- A settings overlay provides sliders for master volume, HUD, minimap, text,
-  joystick, targeting, Tractor Aura and mining ranges, starfield tile size and
-  includes a reset button.
+- A settings overlay opens with the `O` key or HUD button and provides sliders
+  for master volume, HUD, minimap, text, joystick, targeting, Tractor Aura and
+  mining ranges, starfield tile size and includes a reset button.
 - A `GameState` enum tracks the current phase.
 
 ## Input
@@ -177,6 +177,7 @@ tree spanning weapons and ship systems.
   mining radii.
 - `H` toggles a help overlay for quick reference, and `Esc` closes it when
   visible.
+- `O` opens the settings overlay for runtime tweaks.
 - `Q` returns to the menu when pressed during pause or game over.
 
 ## Rendering & Camera

--- a/PLAN.md
+++ b/PLAN.md
@@ -186,7 +186,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   minimap, `F1` toggles debug overlays and outlines starfield tiles, `Enter`
   starts or restarts from the menu or game over, `R` restarts at any time, `H`
   shows a help overlay that `Esc` also closes, `U` opens an upgrades overlay
-  that `Esc` also closes, `B` toggles range rings)
+  that `Esc` also closes, `O` opens the settings overlay, `B` toggles range rings)
 - Upgrades overlay lets players spend minerals on simple upgrades that
   persist between sessions, opened with a HUD button or the `U` key and
   pausing gameplay. Available upgrades cover fire rate, mining speed,
@@ -194,7 +194,7 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   movement and a Shield Booster that slowly regenerates health
 - Settings overlay with master volume slider and sliders for HUD, minimap,
   text, joystick, targeting, Tractor Aura and mining ranges, starfield tile
-  size, plus a reset button
+  size, plus a reset button, accessible via HUD button or `O` key
 - Game works offline after the first load thanks to the service worker
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -41,9 +41,9 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] Pressing `H` shows a help overlay; `Esc` or `H` closes it and resumes play
 - [ ] Pressing `U` shows an upgrades overlay and pauses the game; `Esc` or `U`
       closes it
-- [ ] Settings overlay sliders adjust volume, HUD button, minimap, text,
-      joystick sizes and gameplay ranges (default 0.75 for buttons and text)
-      and reset button restores defaults
+- [ ] Settings button or `O` key opens settings overlay; sliders adjust volume,
+      HUD button, minimap, text, joystick sizes and gameplay ranges (default
+      0.75 for buttons and text) and reset button restores defaults
 - [ ] Local high score persists between sessions
 - [ ] PWA installability and offline play after initial load
 - [ ] Performance acceptable on target devices

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ dedicated server or NAT traversal.
   upgrades include a faster cannon, quicker mining pulses, a targeting
   computer, a Tractor Booster and Engine Tuning for higher speed
 - Settings overlay adjusts volume, HUD, minimap, text and joystick scales,
-  gameplay ranges and starfield tile size, and includes a reset button
+  gameplay ranges and starfield tile size, and includes a reset button;
+  accessible via HUD button or `O` key
 - Menu allows choosing between multiple ship sprites and remembers the selection
 - Local high score stored on device using `shared_preferences`
 - Basic sound effects with a mute toggle on menu, HUD and game over
@@ -64,7 +65,8 @@ dedicated server or NAT traversal.
   rings, `N` toggles the minimap, `F1` toggles debug overlays, `Enter` starts
   or restarts from the menu or game over, `R` restarts at any time, `Q` returns
   to the menu from pause or game over, `H` shows a help overlay that `Esc` also
-  closes, `U` opens an upgrades overlay that `Esc` also closes)
+  closes, `U` opens an upgrades overlay that `Esc` also closes, `O` opens the
+  settings overlay)
 - Game works offline after the first load
 - Deterministic world-space starfield replaces the parallax background:
   - Stars spawn per chunk via Poisson-disk sampling seeded by chunk coordinates.

--- a/TASKS.md
+++ b/TASKS.md
@@ -62,6 +62,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Mute toggle available on menu, HUD, pause and game over overlays.
 - [x] Keyboard shortcut `M` toggles mute.
 - [x] Keyboard shortcut `P` pauses or resumes the game.
+- [x] Keyboard shortcut `O` opens the settings overlay.
 - [x] Keyboard shortcuts: `Enter` starts or restarts from the menu or game over;
       `R` restarts during play, pause or game over.
 - [x] Keyboard shortcut `Q` returns to the menu from pause or game over.
@@ -78,7 +79,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] HUD button or `B` key toggles range rings for targeting, Tractor Aura and mining.
 - [x] Settings overlay with master volume slider and sliders for HUD, minimap,
       text, joystick, targeting, Tractor Aura and mining ranges, starfield tile
-      size, plus reset button.
+      size, plus reset button, accessible via HUD button or `O` key.
 
 - [x] Persist purchased upgrades across sessions using `StorageService`.
 - [x] Engine Tuning upgrade increases player movement speed.

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -5,7 +5,6 @@ import 'package:meta/meta.dart';
 
 import '../assets.dart';
 import '../constants.dart';
-import '../enemy_faction.dart';
 import '../game/space_game.dart';
 import 'enemy.dart';
 

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -7,8 +7,8 @@ import 'key_dispatcher.dart';
 
 /// Registers global keyboard shortcuts and wires them to actions.
 ///
-/// Supported keys: `Esc`, `P`, `M`, `Enter`, `R`, `H`, `U`, `F1`, `N`, `B` and
-/// `Q`.
+/// Supported keys: `Esc`, `P`, `M`, `Enter`, `R`, `H`, `U`, `F1`, `N`, `B`, `O`
+/// and `Q`.
 class ShortcutManager {
   ShortcutManager({
     required KeyDispatcher keyDispatcher,
@@ -22,6 +22,7 @@ class ShortcutManager {
     required void Function() toggleDebug,
     required void Function() toggleMinimap,
     required void Function() toggleRangeRings,
+    required void Function() toggleSettings,
     required void Function() returnToMenu,
     required bool Function() isHelpVisible,
   }) {
@@ -88,6 +89,11 @@ class ShortcutManager {
     keyDispatcher.register(
       LogicalKeyboardKey.keyB,
       onDown: toggleRangeRings,
+    );
+
+    keyDispatcher.register(
+      LogicalKeyboardKey.keyO,
+      onDown: toggleSettings,
     );
 
     keyDispatcher.register(LogicalKeyboardKey.keyQ, onDown: () {

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -233,6 +233,7 @@ class SpaceGame extends FlameGame
       toggleDebug: toggleDebug,
       toggleMinimap: toggleMinimap,
       toggleRangeRings: toggleRangeRings,
+      toggleSettings: toggleSettings,
       returnToMenu: returnToMenu,
       isHelpVisible: () => overlays.isActive(HelpOverlay.id),
     );

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -36,7 +36,7 @@ class HelpOverlay extends StatelessWidget {
               'Toggle Debug: F1\n'
               'Toggle Range Rings: B or HUD button\n'
               'Upgrades: U or HUD button\n'
-              'Settings: HUD button\n'
+              'Settings: O or HUD button\n'
               'Pause/Resume: Esc or P\n'
               'Start/Restart: Enter\n'
               'Restart anytime: R\n'

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -104,6 +104,7 @@ class _Harness {
       toggleDebug: () => debugCalled = true,
       toggleMinimap: () => minimapCalled = true,
       toggleRangeRings: () => rangeRingsCalled = true,
+      toggleSettings: () => settingsCalled = true,
       returnToMenu: () => menuCalled = true,
       isHelpVisible: () => helpVisible,
     );
@@ -120,6 +121,7 @@ class _Harness {
   bool debugCalled = false;
   bool minimapCalled = false;
   bool rangeRingsCalled = false;
+  bool settingsCalled = false;
   bool menuCalled = false;
   bool helpVisible = false;
 
@@ -237,6 +239,12 @@ void main() {
       final h = _Harness();
       h.press(LogicalKeyboardKey.keyB, PhysicalKeyboardKey.keyB);
       expect(h.rangeRingsCalled, isTrue);
+    });
+
+    test('O toggles settings', () {
+      final h = _Harness();
+      h.press(LogicalKeyboardKey.keyO, PhysicalKeyboardKey.keyO);
+      expect(h.settingsCalled, isTrue);
     });
 
     test('Q returns to menu from pause or game over', () {


### PR DESCRIPTION
## Summary
- add `O` key binding for the settings overlay
- document new shortcut across help and project docs
- clean up enemy spawner import

## Testing
- `./scripts/dartw analyze`
- `npx --yes markdownlint-cli '**/*.md'`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68becb14b6c8833082743b39aa31d61b