### PR TITLE
feat: hash assets manifest for service worker version

### DIFF
--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -4,6 +4,7 @@ import 'package:flame/components.dart';
 import 'package:meta/meta.dart';
 
 import '../assets.dart';
+import '../enemy_faction.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
 import 'enemy.dart';

--- a/web/README.md
+++ b/web/README.md
@@ -4,7 +4,9 @@ PWA configuration and static web files.
 
 - `manifest.json` defines PWA metadata like `start_url`, `display` and colour values.
 - `icons/` holds 192x192 and 512x512 app icons.
-- `index.html` bootstraps the Flutter app and registers `sw.js`.
+- `index.html` bootstraps the Flutter app and registers `sw.js` after hashing
+  `assets_manifest.json` so the cache version updates automatically when
+  assets change.
 - `sw.js` precaches core files, then caches optional assets from
   `assets_manifest.json` in the background and serves requests with a
   stale-while-revalidate strategy.

--- a/web/index.html
+++ b/web/index.html
@@ -13,7 +13,6 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <meta name="cache-bust" content="1">
     <style>
       html,
       body {
@@ -40,10 +39,25 @@
       });
 
       if ('serviceWorker' in navigator) {
-        document.addEventListener('DOMContentLoaded', () => {
-          const version =
-            document.querySelector('meta[name="cache-bust"]')?.content ||
-            '1';
+        // Compute a content hash of `assets_manifest.json` so the service worker
+        // cache name automatically changes when any asset changes. This avoids
+        // manual version bumps.
+        document.addEventListener('DOMContentLoaded', async () => {
+          let version;
+          try {
+            const response = await fetch('assets_manifest.json');
+            const text = await response.text();
+            const buffer = await crypto.subtle.digest(
+              'SHA-256',
+              new TextEncoder().encode(text),
+            );
+            version = Array.from(new Uint8Array(buffer))
+              .map((b) => b.toString(16).padStart(2, '0'))
+              .join('');
+          } catch (err) {
+            console.warn('Asset hash failed, using timestamp', err);
+            version = Date.now().toString();
+          }
           navigator.serviceWorker.register(`sw.js?v=${version}`);
         });
       }

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,3 +1,6 @@
+// VERSION is a content hash of `assets_manifest.json` computed in
+// `index.html` and passed as the `v` query parameter. This ensures the cache
+// is invalidated whenever any asset changes.
 const VERSION = new URL(self.location.href).searchParams.get("v") || "v1";
 const CACHE_NAME = `space-game-cache-${VERSION}`;
 const CORE_ASSETS = [


### PR DESCRIPTION
## Summary
- derive service worker version from a hash of `assets_manifest.json`
- document service worker versioning
- fix missing `EnemyFaction` import in enemy spawner

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68becd3f8a8883308946104a7142caca