### PR TITLE
Document enemy factions and fix web interaction helper

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -99,7 +99,9 @@ tree spanning weapons and ship systems.
   component is added or removed, enabling pooling and targeting helpers.
 - Use simple hit boxes (`CircleHitbox`, `RectangleHitbox`) and
   `HasCollisionDetection`.
-- An `EnemySpawner` system releases groups of enemies at timed intervals.
+- An `EnemySpawner` system releases groups of enemies at timed intervals. Ships
+  draw from random factions with unique sprites, and a rare boss variant can
+  appear for added challenge.
 - Mining asteroids with the laser awards mineral pickups each time.
 - The player mounts two weapons: an auto-firing mining laser that targets
   asteroids in range and a primary cannon that locks onto the nearest enemy.

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,6 +18,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
 - Solo-friendly workflow with minimal tooling
 - Core loop focused on mining asteroids for minerals while fending off enemy
   groups
+- Enemy ships belong to distinct factions and occasionally spawn tougher boss
+  variants for extra challenge
 - Auto-firing mining laser targets asteroids while the main cannon locks onto
   the closest enemy
 - A blue Tractor Aura around the ship pulls in nearby pickups

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ dedicated server or NAT traversal.
 ## 🧩 MVP Features
 
 - Touch/joystick movement and shooting
-- Enemy groups spawn periodically and the main weapon smoothly auto-aims at the
-  closest foe
+- Enemy groups spawn periodically from random factions, and the main weapon
+  smoothly auto-aims at the closest foe while rare boss variants add extra
+  challenge
 - Asteroids can be mined for mineral pickups using an auto-targeting laser;
   each hit drops a mineral nearby
 - A blue Tractor Aura draws nearby pickups toward the ship

--- a/TASKS.md
+++ b/TASKS.md
@@ -88,6 +88,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 ## Next Steps
 
 - [x] Spawn enemy groups on a timer.
+- [x] Enemies spawn from random factions with occasional boss variants.
 - [x] Add a mining laser that automatically targets and fires at nearby
       asteroids.
 - [x] Drop mineral pickups from asteroids and track the player's total.

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 
 import '../assets.dart';
 import '../constants.dart';
+import '../enemy_faction.dart';
 import '../game/space_game.dart';
 import 'enemy.dart';
 

--- a/lib/util/interaction_web.dart
+++ b/lib/util/interaction_web.dart
@@ -1,5 +1,15 @@
+// ignore_for_file: deprecated_member_use
 import 'dart:html' as html;
 
 void onFirstUserInteraction(void Function() callback) {
-  html.window.onPointerDown.first.then((_) => callback());
+  var fired = false;
+  void handler(html.Event _) {
+    if (fired) return;
+    fired = true;
+    callback();
+  }
+
+  // Listen for desktop and mobile interactions.
+  html.window.onMouseDown.first.then(handler);
+  html.window.onTouchStart.first.then(handler);
 }


### PR DESCRIPTION
## Summary
- document enemy factions and rare boss ships across design docs
- add missing `EnemyFaction` import
- simplify first user interaction handler for web

## Testing
- `./scripts/dartw format lib/components/enemy_spawner.dart lib/util/interaction_web.dart`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68becd8088308330a0566c4ca8fd280b