### PR TITLE
Avoid overlapping enemy spawns

### DIFF
--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -5,14 +5,15 @@ import 'package:meta/meta.dart';
 
 import '../assets.dart';
 import '../constants.dart';
+import '../enemy_faction.dart';
 import '../game/space_game.dart';
 import 'enemy.dart';
 
 /// Spawns enemies at timed intervals when started.
 class EnemySpawner extends Component with HasGameReference<SpaceGame> {
-  EnemySpawner();
+  EnemySpawner({math.Random? random}) : _random = random ?? math.Random();
 
-  final math.Random _random = math.Random();
+  final math.Random _random;
   final Timer _timer = Timer(Constants.enemySpawnInterval, repeat: true);
 
   /// Starts spawning enemies.
@@ -49,17 +50,34 @@ class EnemySpawner extends Component with HasGameReference<SpaceGame> {
     }
     final EnemyFaction faction = Assets.randomFaction();
     final unitPath = Assets.randomUnitForFaction(faction);
+    final spawnBoss = _random.nextDouble() < Constants.enemyBossChance;
+
+    final baseSize =
+        Constants.enemySize * (Constants.spriteScale + Constants.enemyScale);
+    final smallRadius = baseSize / 2;
+    final bossRadius = baseSize * Constants.enemyBossScale / 2;
+
+    final positions = <Vector2>[];
     for (var i = 0; i < Constants.enemyGroupSize; i++) {
-      final offset = (Vector2.random(_random) - Vector2.all(0.5)) *
-          (Constants.enemyGroupSpread * 2);
-      final position = base + offset;
+      Vector2 pos;
+      var attempts = 0;
+      do {
+        final angle = _random.nextDouble() * math.pi * 2;
+        final minRadius = spawnBoss ? smallRadius + bossRadius : baseSize;
+        final radius =
+            minRadius + _random.nextDouble() * Constants.enemyGroupSpread;
+        pos = base + Vector2(math.cos(angle), math.sin(angle)) * radius;
+        attempts++;
+      } while (
+          positions.any((p) => p.distanceTo(pos) < baseSize) && attempts < 10);
+      positions.add(pos);
       game.add(
         game.pools.acquire<EnemyComponent>(
-          (e) => e.reset(position, faction, spritePath: unitPath),
+          (e) => e.reset(pos, faction, spritePath: unitPath),
         ),
       );
     }
-    if (_random.nextDouble() < Constants.enemyBossChance) {
+    if (spawnBoss) {
       final bossPath = Assets.bossForFaction(faction);
       game.add(
         game.pools.acquire<EnemyComponent>(

--- a/test/enemy_boss_spacing_test.dart
+++ b/test/enemy_boss_spacing_test.dart
@@ -1,0 +1,84 @@
+import 'dart:math' as math;
+
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/components/enemy.dart';
+import 'package:space_game/components/enemy_spawner.dart';
+import 'package:space_game/components/player.dart';
+import 'package:space_game/constants.dart';
+import 'package:space_game/game/key_dispatcher.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+
+class _TestPlayer extends PlayerComponent {
+  _TestPlayer({required super.joystick, required super.keyDispatcher})
+      : super(spritePath: 'players/player1.png');
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+  }
+}
+
+class _TestGame extends SpaceGame {
+  _TestGame({required StorageService storage, required AudioService audio})
+      : super(storageService: storage, audioService: audio);
+
+  @override
+  Future<void> onLoad() async {
+    final keyDispatcher = KeyDispatcher();
+    add(keyDispatcher);
+    joystick = JoystickComponent(
+      knob: CircleComponent(radius: 1),
+      background: CircleComponent(radius: 2),
+    );
+    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await add(player);
+    onGameResize(
+      Vector2.all(Constants.playerSize *
+          (Constants.spriteScale + Constants.playerScale) *
+          2),
+    );
+    enemySpawner = EnemySpawner(random: math.Random(2));
+    add(enemySpawner);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('boss spawns away from minions', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([...Assets.players, ...Assets.enemies]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = _TestGame(storage: storage, audio: audio);
+    await game.onLoad();
+    await game.ready();
+    game.enemySpawner.spawnNow();
+    game.update(0);
+    await game.ready();
+    final enemies = game.children.whereType<EnemyComponent>().toList();
+    expect(enemies.length, Constants.enemyGroupSize + 1);
+    enemies.sort((a, b) => b.size.x.compareTo(a.size.x));
+    final boss = enemies.first;
+    final minions = enemies.skip(1).toList();
+    for (final m in minions) {
+      final distance = m.position.distanceTo(boss.position);
+      final minDistance = (m.size.x + boss.size.x) / 2;
+      expect(distance >= minDistance, isTrue);
+    }
+    for (var i = 0; i < minions.length; i++) {
+      for (var j = i + 1; j < minions.length; j++) {
+        final distance = minions[i].position.distanceTo(minions[j].position);
+        final minDistance = (minions[i].size.x + minions[j].size.x) / 2;
+        expect(distance >= minDistance, isTrue);
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Ensure enemy spawner spaces out spawned units and keeps bosses separate from minions
- Allow injecting a deterministic Random for testing
- Test that bosses never overlap minions when spawning

## Testing
- `scripts/dartw analyze lib/components/enemy_spawner.dart test/enemy_boss_spacing_test.dart`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bece40627c8330b78c9f32372dd98a