### PR TITLE
Reduce explosion lifetime to 1.5 seconds

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -104,7 +104,7 @@ class Constants {
   static const double explosionFrameDuration = 0.05;
 
   /// Seconds an explosion stays on screen before being removed.
-  static const double explosionLifetime = 2;
+  static const double explosionLifetime = 1.5;
 
   /// Enemy movement speed in pixels per second.
   static const double enemySpeed = 100;


### PR DESCRIPTION
## Summary
- shorten explosion lifetime constant to 1.5s so on-screen explosions fade sooner

## Testing
- `./scripts/flutterw test` *(fails: could not complete, process hung while loading tests)*
- `./scripts/flutterw test test/explosion_component_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68becf00bbac8330959060818c386e29