### PR TITLE
Ensure assets loaded before starting gameplay

### DIFF
--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -7,6 +7,7 @@ import '../assets.dart';
 import '../constants.dart';
 import '../game/space_game.dart';
 import 'enemy.dart';
+import '../enemy_faction.dart';
 
 /// Spawns enemies at timed intervals when started.
 class EnemySpawner extends Component with HasGameReference<SpaceGame> {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
@@ -24,7 +22,6 @@ import 'util/interaction.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Assets.loadEssential();
-  onFirstUserInteraction(() => unawaited(Assets.loadRemaining()));
   final storage = await StorageService.create();
   final audio = await AudioService.create(storage);
   final settings = SettingsService();
@@ -44,6 +41,8 @@ Future<void> main() async {
     colorScheme: colorScheme,
     gameColors: gameColors,
   );
+
+  onFirstUserInteraction(game.startLoadingAssets);
 
   // Pause the game and silence audio when the app is not visible.
   final lifecycleObserver = _AppLifecycleObserver(game);

--- a/lib/ui/game_over_overlay.dart
+++ b/lib/ui/game_over_overlay.dart
@@ -53,7 +53,7 @@ class GameOverOverlay extends StatelessWidget {
               children: [
                 ElevatedButton(
                   // Mirrors the Enter and R keyboard shortcuts.
-                  onPressed: game.startGame,
+                  onPressed: () => game.startGame(),
                   child: const GameText(
                     'Restart',
                     maxLines: 1,

--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -91,22 +91,36 @@ class MenuOverlay extends StatelessWidget {
               },
             ),
             SizedBox(height: spacing),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ElevatedButton(
-                  onPressed: game.startGame,
-                  child: const GameText(
-                    'Start',
-                    maxLines: 1,
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-                SizedBox(width: spacing),
-                HelpButton(game: game),
-                SizedBox(width: spacing),
-                MuteButton(game: game, iconSize: iconSize),
-              ],
+            ValueListenableBuilder<double>(
+              valueListenable: game.assetLoadProgress,
+              builder: (context, progress, _) {
+                final isLoaded = progress >= 1;
+                return Column(
+                  children: [
+                    if (!isLoaded) ...[
+                      LinearProgressIndicator(value: progress),
+                      SizedBox(height: spacing),
+                    ],
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        ElevatedButton(
+                          onPressed: isLoaded ? () => game.startGame() : null,
+                          child: const GameText(
+                            'Start',
+                            maxLines: 1,
+                            style: TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                        SizedBox(width: spacing),
+                        HelpButton(game: game),
+                        SizedBox(width: spacing),
+                        MuteButton(game: game, iconSize: iconSize),
+                      ],
+                    ),
+                  ],
+                );
+              },
             ),
           ],
         );

--- a/test/full_game_lifecycle_test.dart
+++ b/test/full_game_lifecycle_test.dart
@@ -32,7 +32,7 @@ void main() {
     expect(game.stateMachine.state, GameState.menu);
     expect(game.overlays.isActive(MenuOverlay.id), isTrue);
 
-    game.startGame();
+    await game.startGame();
     expect(game.stateMachine.state, GameState.playing);
     expect(game.overlays.isActive(HudOverlay.id), isTrue);
 

--- a/test/mining_laser_pause_test.dart
+++ b/test/mining_laser_pause_test.dart
@@ -44,7 +44,7 @@ void main() {
     game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
-    game.startGame();
+    await game.startGame();
     await game.ready();
 
     final laser = _TestMiningLaser(player: game.player);
@@ -87,7 +87,7 @@ void main() {
     game.overlays.addEntry(GameOverOverlay.id, (_, __) => const SizedBox());
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
-    game.startGame();
+    await game.startGame();
     await game.ready();
 
     const escDown = KeyDownEvent(
@@ -116,7 +116,7 @@ void main() {
     );
     game.keyDispatcher.onKeyEvent(rDown, {});
     game.keyDispatcher.onKeyEvent(rUp, {});
-
+    await game.ready();
     expect(audio.masterVolume, 1);
   });
 }

--- a/test/player_reset_orientation_test.dart
+++ b/test/player_reset_orientation_test.dart
@@ -50,7 +50,7 @@ void main() {
     game.joystick.relativeDelta.setZero();
 
     // Starting a new game should reset orientation and position.
-    game.startGame();
+    await game.startGame();
     game.onGameResize(Vector2.all(100));
     await game.ready();
     game.update(0);

--- a/test/player_respawn_test.dart
+++ b/test/player_respawn_test.dart
@@ -31,7 +31,7 @@ void main() {
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
 
-    game.startGame();
+    await game.startGame();
     game.player.position.setValues(20, 20);
 
     for (var i = 0; i < Constants.playerMaxHealth; i++) {
@@ -40,7 +40,7 @@ void main() {
 
     expect(game.stateMachine.state, GameState.gameOver);
 
-    game.startGame();
+    await game.startGame();
     expect(game.player.position, Vector2.zero());
   });
 }

--- a/test/restart_clears_explosions_test.dart
+++ b/test/restart_clears_explosions_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
 import 'package:flutter/widgets.dart';
@@ -32,14 +34,14 @@ void main() {
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
 
-    game.startGame();
+    await game.startGame();
     for (var i = 0; i < Constants.playerMaxHealth; i++) {
       game.hitPlayer();
     }
     await game.ready();
     expect(game.children.whereType<ExplosionComponent>(), isNotEmpty);
 
-    game.startGame();
+    await game.startGame();
     await game.ready();
     expect(game.children.whereType<ExplosionComponent>(), isEmpty);
   });
@@ -58,12 +60,12 @@ void main() {
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
 
-    game.startGame();
+    await game.startGame();
     for (var i = 0; i < Constants.playerMaxHealth; i++) {
       game.hitPlayer();
     }
     // Immediately restart without waiting for lifecycle events to process.
-    game.startGame();
+    unawaited(game.startGame());
     await game.ready();
     expect(game.children.whereType<ExplosionComponent>(), isEmpty);
   });

--- a/test/restart_removes_old_player_test.dart
+++ b/test/restart_removes_old_player_test.dart
@@ -32,7 +32,7 @@ void main() {
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
 
-    game.startGame();
+    await game.startGame();
     game.player.position.setValues(20, 20);
     // Kill the player.
     for (var i = 0; i < Constants.playerMaxHealth; i++) {
@@ -41,7 +41,7 @@ void main() {
     expect(game.stateMachine.state, GameState.gameOver);
 
     // Restart the game and ensure only one player exists at the spawn point.
-    game.startGame();
+    await game.startGame();
     final players = game.children.whereType<PlayerComponent>().toList();
     expect(players.length, 1);
     expect(players.first.position, Vector2.zero());


### PR DESCRIPTION
## Summary
- show asset loading progress on the menu and disable Start until finished
- wait for remaining assets before starting the game and skip audio preload when plugin is missing
- fix missing EnemyFaction import in EnemySpawner and update tests for async startGame

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bece8fea6083308cb243a016605a66