### PR TITLE
refactor: remove duplicate enemy faction imports

### DIFF
--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -4,12 +4,10 @@ import 'package:flame/components.dart';
 import 'package:meta/meta.dart';
 
 import '../assets.dart';
-import '../enemy_faction.dart';
 import '../constants.dart';
 import '../enemy_faction.dart';
 import '../game/space_game.dart';
 import 'enemy.dart';
-import '../enemy_faction.dart';
 
 /// Spawns enemies at timed intervals when started.
 class EnemySpawner extends Component with HasGameReference<SpaceGame> {


### PR DESCRIPTION
## Summary
- dedupe enemy faction imports in EnemySpawner

## Testing
- `scripts/flutterw analyze --no-pub`
- `scripts/flutterw test --no-pub`


------
https://chatgpt.com/codex/tasks/task_e_68bed116b1d48330b410f1525b64e9b7