### PR TITLE
test: cover starfield debug toggle

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -183,7 +183,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   available on menu, HUD and game over overlays
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `N` toggles the
-  minimap, `F1` toggles debug overlays and outlines starfield tiles, `Enter`
+  minimap, `F1` toggles debug overlays with an FPS counter and outlines starfield
+  tiles, `Enter`
   starts or restarts from the menu or game over, `R` restarts at any time, `H`
   shows a help overlay that `Esc` also closes, `U` opens an upgrades overlay
   that `Esc` also closes, `O` opens the settings overlay, `B` toggles range rings)
@@ -206,7 +207,8 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
     margin around the camera, then draws with a translation of `-playerPosition`
     so the player flies over a static backdrop. Stars sort by radius so faint
     ones render first for smoother blending. A `debugDrawTiles` option outlines
-    tile boundaries when debug mode (`F1`) is active to aid development.
+    tile boundaries when debug mode (`F1`) is active to aid development, and an
+    FPS counter is displayed.
   - Tile size can be tuned in the settings overlay to balance detail and performance.
 - Pause or resume with a `PAUSED` overlay prompting players to press `Esc` or
   `P` to resume; `Q` returns to the menu from pause or game over

--- a/PLAYTEST_CHECKLIST.md
+++ b/PLAYTEST_CHECKLIST.md
@@ -12,6 +12,8 @@ _Update this file whenever a player-facing feature is added or changed._
 - [ ] When stationary, the ship rotates toward the nearest enemy within range
 - [ ] Target button or `B` key toggles range rings display
 - [ ] Minimap icon or `N` key toggles minimap with player heading arrow
+- [ ] `F1` toggles debug overlays with hit boxes, starfield tile outlines and an
+      FPS counter
 - [ ] Asteroids spawn randomly and drift across the screen
 - [ ] Enemies and asteroids show varied sprites
 - [ ] Shooting an asteroid destroys it and increases the on-screen score

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ dedicated server or NAT traversal.
   hint to press `Esc` or `P` to resume, leaving the interface visible
 - Keyboard controls for desktop playtests (`WASD`/arrow keys to move, `Space` to
   shoot, `Escape` or `P` to pause or resume, `M` to mute, `B` toggles range
-  rings, `N` toggles the minimap, `F1` toggles debug overlays, `Enter` starts
+  rings, `N` toggles the minimap, `F1` toggles debug overlays with an FPS counter
+  and starfield tile outlines, `Enter` starts
   or restarts from the menu or game over, `R` restarts at any time, `Q` returns
   to the menu from pause or game over, `H` shows a help overlay that `Esc` also
   closes, `U` opens an upgrades overlay that `Esc` also closes, `O` opens the

--- a/lib/components/enemy_spawner.dart
+++ b/lib/components/enemy_spawner.dart
@@ -4,12 +4,10 @@ import 'package:flame/components.dart';
 import 'package:meta/meta.dart';
 
 import '../assets.dart';
-import '../enemy_faction.dart';
 import '../constants.dart';
 import '../enemy_faction.dart';
 import '../game/space_game.dart';
 import 'enemy.dart';
-import '../enemy_faction.dart';
 
 /// Spawns enemies at timed intervals when started.
 class EnemySpawner extends Component with HasGameReference<SpaceGame> {

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -16,9 +16,9 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 - Handle keyboard shortcuts such as `Escape` or `P` for pause, `M` for mute,
    `Enter` to start or restart from the menu or game over, `R` to restart at any
    time, `Q` to return to the menu from pause or game over, `Esc` to return to the
-   menu from game over, and `H` to show or hide the help overlay (`Esc` also
-   closes it). Pressing `F1` toggles debug mode, outlining starfield tiles and
-   showing hit boxes.
+  menu from game over, and `H` to show or hide the help overlay (`Esc` also
+   closes it). Pressing `F1` toggles debug mode, outlining starfield tiles,
+   showing hit boxes and displaying an FPS counter.
 - Expose helpers to pause, resume or return to the menu.
 - Drive the update cycle while delegating work to components and services.
 - Persist and load the high score and selected player sprite index through

--- a/lib/ui/README.md
+++ b/lib/ui/README.md
@@ -29,8 +29,9 @@ Flutter overlays and HUD widgets.
 - [SettingsOverlay](settings_overlay.md) – adjust volume, HUD, minimap, text,
   joystick scale and gameplay ranges, with a reset button; opened via HUD
   button.
-- The `M` key toggles mute in any overlay; `F1` toggles debug overlays;
-  `Enter` starts or restarts from the menu or game over; `R` restarts at any
+- The `M` key toggles mute in any overlay; `F1` toggles debug overlays with an
+  FPS counter and starfield tile outlines; `Enter` starts or restarts from the
+  menu or game over; `R` restarts at any
   time; `Q` returns to the menu from pause or game over; `Escape` or `P` pauses
   or resumes; `H` shows or hides the help overlay, `U` opens upgrades, `N`
   toggles the minimap, `B` toggles range rings, and `Esc` also closes overlays

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -33,7 +33,7 @@ class HelpOverlay extends StatelessWidget {
               'Shoot: Space\n'
               'Mute: M\n'
               'Toggle Minimap: N or HUD button\n'
-              'Toggle Debug: F1\n'
+              'Toggle Debug (FPS/tiles): F1\n'
               'Toggle Range Rings: B or HUD button\n'
               'Upgrades: U or HUD button\n'
               'Settings: O or HUD button\n'

--- a/lib/ui/help_overlay.md
+++ b/lib/ui/help_overlay.md
@@ -9,6 +9,7 @@ Lists available touch and keyboard controls.
 - Pauses gameplay when opened during a run and resumes when closed.
 - Dismiss with the on-screen close button or by pressing `H` again or `Esc`.
 - Lists keys such as `N` to toggle the minimap, `B` for range rings and `Q`
-  to return to the menu from pause or game over.
+  to return to the menu from pause or game over, and `F1` to toggle debug
+  mode with hit boxes, starfield tile outlines and an FPS counter.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.

--- a/test/README.md
+++ b/test/README.md
@@ -9,6 +9,8 @@ Current suites verify:
 - OverlayService overlay transitions
 - Player shot cooldown logic
 - Help overlay pause behaviour
+- Debug mode toggling propagates to hit boxes, pooled objects and starfield tile
+  outlines
 
 Tests use `flutter_test` and `flame_test` as noted in [../PLAN.md](../PLAN.md).
 

--- a/test/debug_mode_toggle_test.dart
+++ b/test/debug_mode_toggle_test.dart
@@ -2,11 +2,13 @@ import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/widgets.dart';
 
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/storage_service.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/components/enemy.dart';
+import 'package:space_game/components/starfield.dart';
 
 class _HitboxGame extends SpaceGame {
   _HitboxGame({required StorageService storage, required AudioService audio})
@@ -84,5 +86,27 @@ void main() {
     final reused = game.pools.acquire<EnemyComponent>((_) {});
     final reusedHitbox = reused.children.query<CircleHitbox>().first;
     expect(reusedHitbox.debugMode, isFalse);
+  });
+
+  test('toggleDebug updates starfield debugDrawTiles', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    // Register minimal overlay builders expected by onLoad.
+    game.overlays.addEntry('menuOverlay', (_, __) => const SizedBox());
+    game.overlays.addEntry('hudOverlay', (_, __) => const SizedBox());
+    game.overlays.addEntry('pauseOverlay', (_, __) => const SizedBox());
+    game.overlays.addEntry('gameOverOverlay', (_, __) => const SizedBox());
+    game.overlays.addEntry('helpOverlay', (_, __) => const SizedBox());
+    game.overlays.addEntry('upgradesOverlay', (_, __) => const SizedBox());
+    game.overlays.addEntry('settingsOverlay', (_, __) => const SizedBox());
+    await game.onLoad();
+    final starfield = game.children.whereType<StarfieldComponent>().single;
+    expect(starfield.debugDrawTiles, isTrue);
+    game.toggleDebug();
+    expect(starfield.debugDrawTiles, isFalse);
+    game.toggleDebug();
+    expect(starfield.debugDrawTiles, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- document that F1 debug mode shows FPS and starfield tile outlines
- add unit test ensuring starfield tile outlines toggle with debug mode
- clean up duplicate imports in enemy spawner

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test test/debug_mode_toggle_test.dart`
- `npx markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68bed014b87c8330afeb5351f1d632ac