### PR TITLE
Start asset loading at launch for menu progress bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,6 @@ import 'ui/game_text.dart';
 import 'services/storage_service.dart';
 import 'services/audio_service.dart';
 import 'services/settings_service.dart';
-import 'util/interaction.dart';
 
 /// Application entry point.
 Future<void> main() async {
@@ -42,7 +41,10 @@ Future<void> main() async {
     gameColors: gameColors,
   );
 
-  onFirstUserInteraction(game.startLoadingAssets);
+  // Begin loading non-essential assets immediately. Progress is reported to
+  // the main menu overlay, which shows a loading bar until all assets are
+  // ready. The game itself will await completion before starting.
+  game.startLoadingAssets();
 
   // Pause the game and silence audio when the app is not visible.
   final lifecycleObserver = _AppLifecycleObserver(game);


### PR DESCRIPTION
## Summary
- Load remaining assets as soon as the game is constructed
- Display progress in menu overlay until all assets are ready

## Testing
- `scripts/dartw format lib/main.dart`
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bed1ee9e44833085986743da62045c