### PR TITLE
Refactor StorageService with pattern matching

### DIFF
--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -24,23 +24,24 @@ class StorageService {
   /// Supported types are [int], [double], [bool], [String] and
   /// [List]<[String]>. Throws [UnsupportedError] for unsupported types.
   T getValue<T>(String key, T defaultValue) {
-    if (T == int) {
-      final value = _prefs.getInt(key);
-      return (value ?? defaultValue) as T;
-    } else if (T == double) {
-      final value = _prefs.getDouble(key);
-      return (value ?? defaultValue) as T;
-    } else if (T == bool) {
-      final value = _prefs.getBool(key);
-      return (value ?? defaultValue) as T;
-    } else if (T == String) {
-      final value = _prefs.getString(key);
-      return (value ?? defaultValue) as T;
-    } else if (T == List<String>) {
-      final value = _prefs.getStringList(key);
-      return (value ?? defaultValue) as T;
-    } else {
-      throw UnsupportedError('Type $T is not supported');
+    switch (defaultValue) {
+      case int _:
+        final value = _prefs.getInt(key);
+        return (value ?? defaultValue) as T;
+      case double _:
+        final value = _prefs.getDouble(key);
+        return (value ?? defaultValue) as T;
+      case bool _:
+        final value = _prefs.getBool(key);
+        return (value ?? defaultValue) as T;
+      case String _:
+        final value = _prefs.getString(key);
+        return (value ?? defaultValue) as T;
+      case List<String> _:
+        final value = _prefs.getStringList(key);
+        return (value ?? defaultValue) as T;
+      default:
+        throw UnsupportedError('Type $T is not supported');
     }
   }
 
@@ -49,18 +50,24 @@ class StorageService {
   /// Supported types are [int], [double], [bool], [String] and
   /// [List]<[String]>. Throws [UnsupportedError] for unsupported types.
   Future<void> setValue<T>(String key, T value) async {
-    if (T == int) {
-      await _prefs.setInt(key, value as int);
-    } else if (T == double) {
-      await _prefs.setDouble(key, value as double);
-    } else if (T == bool) {
-      await _prefs.setBool(key, value as bool);
-    } else if (T == String) {
-      await _prefs.setString(key, value as String);
-    } else if (T == List<String>) {
-      await _prefs.setStringList(key, value as List<String>);
-    } else {
-      throw UnsupportedError('Type ${value.runtimeType} is not supported');
+    switch (value) {
+      case int v:
+        await _prefs.setInt(key, v);
+        break;
+      case double v:
+        await _prefs.setDouble(key, v);
+        break;
+      case bool v:
+        await _prefs.setBool(key, v);
+        break;
+      case String v:
+        await _prefs.setString(key, v);
+        break;
+      case List<String> v:
+        await _prefs.setStringList(key, v);
+        break;
+      default:
+        throw UnsupportedError('Type ${value.runtimeType} is not supported');
     }
   }
 


### PR DESCRIPTION
## Summary
- refactor StorageService get/set helpers to use Dart's pattern matching for cleaner type handling

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bed6cb43a4833091fa206ff5f26ea4