### PR TITLE
Resume engine when returning from paused focus state

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -324,6 +324,7 @@ class SpaceGame extends FlameGame
   /// Resumes the game from a paused state.
   void resumeGame() {
     stateMachine.resumeGame();
+    resumeEngine();
     _suppressVolumeSave = true;
     audioService.setMasterVolume(_storedVolume);
     _suppressVolumeSave = false;

--- a/test/resume_game_engine_test.dart
+++ b/test/resume_game_engine_test.dart
@@ -1,0 +1,47 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/assets.dart';
+import 'package:space_game/game/space_game.dart';
+import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/ui/hud_overlay.dart';
+import 'package:space_game/ui/menu_overlay.dart';
+import 'package:space_game/ui/pause_overlay.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('resumeGame resumes engine after external pause', () async {
+    SharedPreferences.setMockInitialValues({});
+    await Flame.images.loadAll([
+      ...Assets.players,
+      ...Assets.enemies,
+      ...Assets.asteroids,
+      ...Assets.explosions,
+      Assets.bullet,
+    ]);
+    final storage = await StorageService.create();
+    final audio = await AudioService.create(storage);
+    final game = SpaceGame(storageService: storage, audioService: audio);
+    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
+    game.overlays.addEntry(PauseOverlay.id, (_, __) => const SizedBox());
+    await game.onLoad();
+    game.onGameResize(Vector2.all(100));
+    await game.startGame();
+    await game.ready();
+
+    game.pauseGame();
+    expect(game.paused, isFalse);
+
+    game.pauseEngine();
+    expect(game.paused, isTrue);
+
+    game.resumeGame();
+    expect(game.paused, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure `resumeGame` restarts the Flame engine so gameplay resumes after focus loss
- add regression test covering engine resume on unpause

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bed829e968833083d37ac0e0e166fc