### PR TITLE
Add grey background and close control to settings overlay

### DIFF
--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -28,136 +28,143 @@ class SettingsOverlay extends StatelessWidget {
                 : width;
             return Container(
               width: maxWidth,
+              constraints: BoxConstraints(
+                maxHeight: constraints.maxHeight,
+              ),
               padding: EdgeInsets.all(spacing),
               decoration: BoxDecoration(
+                color: Colors.grey.withValues(alpha: 0.5),
                 border: Border.all(
                   color: Theme.of(context).colorScheme.outline,
                 ),
                 borderRadius: BorderRadius.circular(spacing),
               ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  GameText(
-                    'Settings',
-                    style: Theme.of(context).textTheme.headlineSmall,
-                    maxLines: 1,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                  SizedBox(height: spacing),
-                  GameText(
-                    'Audio',
-                    style: Theme.of(context).textTheme.titleMedium,
-                    maxLines: 1,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                  SizedBox(height: spacing),
-                  _buildSlider(
-                    context,
-                    'Volume',
-                    game.audioService.volume,
-                    spacing,
-                    min: 0,
-                    max: 1,
-                  ),
-                  GameText(
-                    'HUD Scaling',
-                    style: Theme.of(context).textTheme.titleMedium,
-                    maxLines: 1,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                  SizedBox(height: spacing),
-                  _buildSlider(
-                    context,
-                    'HUD Buttons',
-                    settings.hudButtonScale,
-                    spacing,
-                  ),
-                  _buildSlider(
-                    context,
-                    'Minimap',
-                    settings.minimapScale,
-                    spacing,
-                  ),
-                  _buildSlider(
-                    context,
-                    'Text',
-                    settings.textScale,
-                    spacing,
-                  ),
-                  _buildSlider(
-                    context,
-                    'Joypad',
-                    settings.joystickScale,
-                    spacing,
-                  ),
-                  GameText(
-                    'Range Scaling',
-                    style: Theme.of(context).textTheme.titleMedium,
-                    maxLines: 1,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                  SizedBox(height: spacing),
-                  _buildSlider(
-                    context,
-                    'Targeting Range',
-                    settings.targetingRange,
-                    spacing,
-                    min: 50,
-                    max: 600,
-                  ),
-                  _buildSlider(
-                    context,
-                    'Tractor Range',
-                    settings.tractorRange,
-                    spacing,
-                    min: 50,
-                    max: 600,
-                  ),
-                  _buildSlider(
-                    context,
-                    'Mining Range',
-                    settings.miningRange,
-                    spacing,
-                    min: 50,
-                    max: 600,
-                  ),
-                  GameText(
-                    'Performance',
-                    style: Theme.of(context).textTheme.titleMedium,
-                    maxLines: 1,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                  SizedBox(height: spacing),
-                  _buildSlider(
-                    context,
-                    'Starfield Tile',
-                    settings.starfieldTileSize,
-                    spacing,
-                    min: 256,
-                    max: 1024,
-                  ),
-                  SizedBox(height: spacing),
-                  ElevatedButton(
-                    onPressed: () {
-                      settings.reset();
-                      game.audioService.setMasterVolume(1);
-                    },
-                    child: const GameText(
-                      'Reset',
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    GameText(
+                      'Settings',
+                      style: Theme.of(context).textTheme.headlineSmall,
                       maxLines: 1,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
-                  ),
-                  SizedBox(height: spacing),
-                  ElevatedButton(
-                    onPressed: game.toggleSettings,
-                    child: const GameText(
-                      'Close',
+                    SizedBox(height: spacing),
+                    GameText(
+                      'Audio',
+                      style: Theme.of(context).textTheme.titleMedium,
                       maxLines: 1,
-                      style: TextStyle(fontWeight: FontWeight.bold),
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
-                  ),
-                ],
+                    SizedBox(height: spacing),
+                    _buildSlider(
+                      context,
+                      'Volume',
+                      game.audioService.volume,
+                      spacing,
+                      min: 0,
+                      max: 1,
+                    ),
+                    GameText(
+                      'HUD Scaling',
+                      style: Theme.of(context).textTheme.titleMedium,
+                      maxLines: 1,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                    SizedBox(height: spacing),
+                    _buildSlider(
+                      context,
+                      'HUD Buttons',
+                      settings.hudButtonScale,
+                      spacing,
+                    ),
+                    _buildSlider(
+                      context,
+                      'Minimap',
+                      settings.minimapScale,
+                      spacing,
+                    ),
+                    _buildSlider(
+                      context,
+                      'Text',
+                      settings.textScale,
+                      spacing,
+                    ),
+                    _buildSlider(
+                      context,
+                      'Joypad',
+                      settings.joystickScale,
+                      spacing,
+                    ),
+                    GameText(
+                      'Range Scaling',
+                      style: Theme.of(context).textTheme.titleMedium,
+                      maxLines: 1,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                    SizedBox(height: spacing),
+                    _buildSlider(
+                      context,
+                      'Targeting Range',
+                      settings.targetingRange,
+                      spacing,
+                      min: 50,
+                      max: 600,
+                    ),
+                    _buildSlider(
+                      context,
+                      'Tractor Range',
+                      settings.tractorRange,
+                      spacing,
+                      min: 50,
+                      max: 600,
+                    ),
+                    _buildSlider(
+                      context,
+                      'Mining Range',
+                      settings.miningRange,
+                      spacing,
+                      min: 50,
+                      max: 600,
+                    ),
+                    GameText(
+                      'Performance',
+                      style: Theme.of(context).textTheme.titleMedium,
+                      maxLines: 1,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                    SizedBox(height: spacing),
+                    _buildSlider(
+                      context,
+                      'Starfield Tile',
+                      settings.starfieldTileSize,
+                      spacing,
+                      min: 256,
+                      max: 1024,
+                    ),
+                    SizedBox(height: spacing),
+                    ElevatedButton(
+                      onPressed: () {
+                        settings.reset();
+                        game.audioService.setMasterVolume(1);
+                      },
+                      child: const GameText(
+                        'Reset',
+                        maxLines: 1,
+                      ),
+                    ),
+                    SizedBox(height: spacing),
+                    ElevatedButton(
+                      onPressed: game.toggleSettings,
+                      child: const GameText(
+                        'Close',
+                        maxLines: 1,
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    SizedBox(height: spacing),
+                  ],
+                ),
               ),
             );
           },

--- a/lib/ui/settings_overlay.md
+++ b/lib/ui/settings_overlay.md
@@ -8,7 +8,9 @@ Overlay providing runtime audio, UI scaling and range controls.
 - Sections separate HUD scaling from range scaling for easier navigation.
 - Bordered layout limits width on large screens for clarity.
 - Opens from the HUD; closing returns to the game.
-- Overlay remains transparent so adjustments can be viewed immediately.
+- Semi-transparent grey background keeps gameplay visible while improving readability.
 - Reset button restores default values for all sliders.
+- Close button at the bottom exits the overlay without using shortcuts or HUD.
+- Scrollable content keeps controls accessible on smaller screens.
 
 See [../../PLAN.md](../../PLAN.md) for UI goals.


### PR DESCRIPTION
## Summary
- Give settings overlay a semi-transparent grey background for readability
- Make overlay scrollable so close button stays visible on small screens
- Document overlay's close button and scrolling for easier exit

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bed7fd21888330901c1a51f1df7d30