### PR TITLE
Handle cache misses individually in service worker

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -28,11 +28,13 @@ const RARELY_CHANGED_EXTENSIONS = new Set([
 
 async function cacheAll(cache, assets) {
   const urls = [...new Set(assets)];
-  try {
-    await cache.addAll(urls);
-  } catch (err) {
-    console.warn("Failed to cache assets", err);
-  }
+  await Promise.all(
+    urls.map((url) =>
+      cache.add(url).catch((err) => {
+        console.warn(`Failed to cache ${url}`, err);
+      }),
+    ),
+  );
 }
 
 async function cacheOptionalAssets(cache) {


### PR DESCRIPTION
## Summary
- Cache assets one by one so a single failure doesn't abort service worker install

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bedc8cd3c083308f86ddbc5f586cbd