### PR TITLE
Improve resource cleanup and event typing

### DIFF
--- a/lib/game/event_bus.dart
+++ b/lib/game/event_bus.dart
@@ -1,28 +1,32 @@
 import 'dart:async';
 
+/// Marker base class for all game events.
+abstract class GameEvent {}
+
 /// Simple event bus for broadcasting game lifecycle events.
 class GameEventBus {
-  final StreamController<Object> _controller =
-      StreamController<Object>.broadcast(sync: true);
+  final StreamController<GameEvent> _controller =
+      StreamController<GameEvent>.broadcast(sync: true);
 
   /// Emits an [event] to all listeners.
-  void emit(Object event) => _controller.add(event);
+  void emit(GameEvent event) => _controller.add(event);
 
   /// Returns a stream of events of type [T].
-  Stream<T> on<T>() => _controller.stream.where((e) => e is T).cast<T>();
+  Stream<T> on<T extends GameEvent>() =>
+      _controller.stream.where((e) => e is T).cast<T>();
 
   /// Closes the underlying stream controller.
   void dispose() => _controller.close();
 }
 
 /// Event fired when a component is spawned.
-class ComponentSpawnEvent<T> {
+class ComponentSpawnEvent<T> implements GameEvent {
   ComponentSpawnEvent(this.component);
   final T component;
 }
 
 /// Event fired when a component is removed.
-class ComponentRemoveEvent<T> {
+class ComponentRemoveEvent<T> implements GameEvent {
   ComponentRemoveEvent(this.component);
   final T component;
 }

--- a/lib/game/event_bus.md
+++ b/lib/game/event_bus.md
@@ -2,6 +2,7 @@
 
 Lightweight synchronous event hub used by core game systems.
 
+- All events extend the `GameEvent` base class.
 - `GameEventBus` exposes `emit` and typed `on<T>()` helpers for broadcasting
   events.
 - Components mix in `SpawnRemoveEmitter` so `ComponentSpawnEvent` and

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -540,6 +540,7 @@ class SpaceGame extends FlameGame
     targetingService.dispose();
     stateMachine.dispose();
     audioService.dispose();
+    pools.dispose();
     super.onRemove();
     // Dispose the event bus after children are removed so they can emit
     // removal events without errors.

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -138,6 +138,7 @@ class AudioService {
   void dispose() {
     stopAll();
     muted.dispose();
+    volume.dispose();
     _shootPool?.dispose();
   }
 }

--- a/test/event_bus_test.dart
+++ b/test/event_bus_test.dart
@@ -1,24 +1,31 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/game/event_bus.dart';
 
+class _IntEvent implements GameEvent {
+  _IntEvent(this.value);
+  final int value;
+}
+
+class _OtherEvent implements GameEvent {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('emit delivers events to listeners', () {
     final bus = GameEventBus();
     var received = 0;
-    bus.on<int>().listen((e) => received = e);
-    bus.emit(5);
+    bus.on<_IntEvent>().listen((e) => received = e.value);
+    bus.emit(_IntEvent(5));
     expect(received, 5);
   });
 
   test('listeners only receive matching types', () {
     final bus = GameEventBus();
     final events = <int>[];
-    bus.on<int>().listen(events.add);
-    bus.emit(1);
-    bus.emit('not int');
-    bus.emit(2);
+    bus.on<_IntEvent>().listen((e) => events.add(e.value));
+    bus.emit(_IntEvent(1));
+    bus.emit(_OtherEvent());
+    bus.emit(_IntEvent(2));
     expect(events, [1, 2]);
   });
 }

--- a/test/flutter_test_config.dart
+++ b/test/flutter_test_config.dart
@@ -1,0 +1,11 @@
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  @override
+  Future<String?> getTemporaryPath() async => '.';
+}
+
+Future<void> testExecutable(Future<void> Function() testMain) async {
+  PathProviderPlatform.instance = _FakePathProviderPlatform();
+  await testMain();
+}


### PR DESCRIPTION
## Summary
- dispose AudioService volume notifier
- cancel PoolManager event bus subscriptions and dispose pools on game removal
- add GameEvent base and typed GameEventBus
- stub path provider plugin in tests to silence audio warnings

## Testing
- `scripts/dartw analyze`
- `scripts/markdownlint.sh lib/game/event_bus.md`
- `scripts/flutterw test --reporter expanded`


------
https://chatgpt.com/codex/tasks/task_e_68bedb448cec8330ab4e19a20ddd9bb4