### PR TITLE
Clamp health at zero in ScoreService

### DIFF
--- a/lib/services/score_service.dart
+++ b/lib/services/score_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 
 import '../constants.dart';
@@ -30,8 +32,8 @@ class ScoreService {
 
   /// Returns `true` when health reaches zero.
   bool hitPlayer() {
-    health.value -= 1;
-    return health.value <= 0;
+    health.value = math.max(0, health.value - 1);
+    return health.value == 0;
   }
 
   /// Clears the high score both in memory and persistent storage.

--- a/test/score_service_test.dart
+++ b/test/score_service_test.dart
@@ -26,6 +26,20 @@ void main() {
     expect(score.health.value, Constants.playerMaxHealth);
   });
 
+  test('hitPlayer clamps health at zero', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+
+    for (var i = 0; i < Constants.playerMaxHealth; i++) {
+      score.hitPlayer();
+    }
+
+    expect(score.health.value, 0);
+    expect(score.hitPlayer(), isTrue);
+    expect(score.health.value, 0);
+  });
+
   test('updates and resets high score', () async {
     SharedPreferences.setMockInitialValues({'highScore': 10});
     final storage = await StorageService.create();


### PR DESCRIPTION
## Summary
- Avoid negative health values by clamping to zero when the player is hit
- Add regression test ensuring health remains at zero and reports game over

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe1b964f8833094362b18c2f35dad