### PR TITLE
Seal GameEvent hierarchy

### DIFF
--- a/lib/game/event_bus.dart
+++ b/lib/game/event_bus.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 
 /// Marker base class for all game events.
-abstract class GameEvent {}
+///
+/// Declared as `sealed` so that all valid game events are defined within this
+/// library, enabling the event bus to enforce exhaustiveness when needed.
+sealed class GameEvent {}
 
 /// Simple event bus for broadcasting game lifecycle events.
 class GameEventBus {

--- a/test/event_bus_test.dart
+++ b/test/event_bus_test.dart
@@ -1,31 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/game/event_bus.dart';
 
-class _IntEvent implements GameEvent {
-  _IntEvent(this.value);
-  final int value;
-}
-
-class _OtherEvent implements GameEvent {}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('emit delivers events to listeners', () {
     final bus = GameEventBus();
-    var received = 0;
-    bus.on<_IntEvent>().listen((e) => received = e.value);
-    bus.emit(_IntEvent(5));
-    expect(received, 5);
+    ComponentSpawnEvent<int>? received;
+    bus.on<ComponentSpawnEvent<int>>().listen((e) => received = e);
+    bus.emit(ComponentSpawnEvent<int>(5));
+    expect(received?.component, 5);
   });
 
   test('listeners only receive matching types', () {
     final bus = GameEventBus();
     final events = <int>[];
-    bus.on<_IntEvent>().listen((e) => events.add(e.value));
-    bus.emit(_IntEvent(1));
-    bus.emit(_OtherEvent());
-    bus.emit(_IntEvent(2));
+    bus.on<ComponentSpawnEvent<int>>().listen((e) => events.add(e.component));
+    bus.emit(ComponentSpawnEvent<int>(1));
+    bus.emit(ComponentSpawnEvent<String>('skip'));
+    bus.emit(ComponentSpawnEvent<int>(2));
     expect(events, [1, 2]);
   });
 }


### PR DESCRIPTION
## Summary
- restrict GameEvent to a sealed hierarchy for type-safe event bus usage
- update event bus tests to rely on existing component event types

## Testing
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe19e65788330a073d095c3c55e6b