### PR TITLE
Return success flag from StorageService setters

### DIFF
--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -49,23 +49,20 @@ class StorageService {
   ///
   /// Supported types are [int], [double], [bool], [String] and
   /// [List]<[String]>. Throws [UnsupportedError] for unsupported types.
-  Future<void> setValue<T>(String key, T value) async {
+  ///
+  /// Returns `true` when the value was written to storage.
+  Future<bool> setValue<T>(String key, T value) {
     switch (value) {
       case int v:
-        await _prefs.setInt(key, v);
-        break;
+        return _prefs.setInt(key, v);
       case double v:
-        await _prefs.setDouble(key, v);
-        break;
+        return _prefs.setDouble(key, v);
       case bool v:
-        await _prefs.setBool(key, v);
-        break;
+        return _prefs.setBool(key, v);
       case String v:
-        await _prefs.setString(key, v);
-        break;
+        return _prefs.setString(key, v);
       case List<String> v:
-        await _prefs.setStringList(key, v);
-        break;
+        return _prefs.setStringList(key, v);
       default:
         throw UnsupportedError('Type ${value.runtimeType} is not supported');
     }
@@ -75,7 +72,7 @@ class StorageService {
   int getHighScore() => getInt(_highScoreKey, 0);
 
   /// Persists a new high score value.
-  Future<void> setHighScore(int value) => setInt(_highScoreKey, value);
+  Future<bool> setHighScore(int value) => setInt(_highScoreKey, value);
 
   /// Clears the stored high score.
   ///
@@ -86,13 +83,13 @@ class StorageService {
   bool isMuted() => getBool(_mutedKey, false);
 
   /// Persists the mute flag.
-  Future<void> setMuted(bool value) => setBool(_mutedKey, value);
+  Future<bool> setMuted(bool value) => setBool(_mutedKey, value);
 
   /// Returns the selected player sprite index or `0` if unset.
   int getPlayerSpriteIndex() => getInt(_playerSpriteKey, 0);
 
   /// Persists the selected player sprite index.
-  Future<void> setPlayerSpriteIndex(int value) =>
+  Future<bool> setPlayerSpriteIndex(int value) =>
       setInt(_playerSpriteKey, value);
 
   /// Retrieves a double value for [key] or returns [defaultValue] if unset.
@@ -100,7 +97,7 @@ class StorageService {
       getValue<double>(key, defaultValue);
 
   /// Persists a double [value] for [key].
-  Future<void> setDouble(String key, double value) =>
+  Future<bool> setDouble(String key, double value) =>
       setValue<double>(key, value);
 
   /// Retrieves a boolean for [key] or returns [defaultValue] if unset.
@@ -108,20 +105,20 @@ class StorageService {
       getValue<bool>(key, defaultValue);
 
   /// Persists a boolean [value] for [key].
-  Future<void> setBool(String key, bool value) => setValue<bool>(key, value);
+  Future<bool> setBool(String key, bool value) => setValue<bool>(key, value);
 
   /// Retrieves an integer for [key] or returns [defaultValue] if unset.
   int getInt(String key, int defaultValue) => getValue<int>(key, defaultValue);
 
   /// Persists an integer [value] for [key].
-  Future<void> setInt(String key, int value) => setValue<int>(key, value);
+  Future<bool> setInt(String key, int value) => setValue<int>(key, value);
 
   /// Retrieves a string for [key] or returns [defaultValue] if unset.
   String getString(String key, String defaultValue) =>
       getValue<String>(key, defaultValue);
 
   /// Persists a string [value] for [key].
-  Future<void> setString(String key, String value) =>
+  Future<bool> setString(String key, String value) =>
       setValue<String>(key, value);
 
   /// Retrieves a list of strings for [key] or returns [defaultValue] if unset.
@@ -129,6 +126,6 @@ class StorageService {
       getValue<List<String>>(key, defaultValue);
 
   /// Persists a list of strings [value] for [key].
-  Future<void> setStringList(String key, List<String> value) =>
+  Future<bool> setStringList(String key, List<String> value) =>
       setValue<List<String>>(key, value);
 }

--- a/lib/services/storage_service.md
+++ b/lib/services/storage_service.md
@@ -16,7 +16,9 @@ Create the service with `await StorageService.create()` and call
 `getHighScore()`/`setHighScore()` or `isMuted()`/`setMuted()` to read or update
 values. Generic helpers `getValue`/`setValue` are also available for storing
 `int`, `double`, `bool`, `String` and `List<String>` values under custom keys.
-Call `resetHighScore()` to clear the stored high score. The method returns a
-`bool` indicating whether the value was successfully removed.
+All `set*` methods return a `Future<bool>` indicating whether the value was
+successfully written. Call `resetHighScore()` to clear the stored high score.
+The method returns a `bool` indicating whether the value was successfully
+removed.
 
 See [../../PLAN.md](../../PLAN.md) for polish goals.

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -11,7 +11,7 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       final storage = await StorageService.create();
       expect(storage.getHighScore(), 0);
-      await storage.setHighScore(42);
+      expect(await storage.setHighScore(42), isTrue);
       expect(storage.getHighScore(), 42);
     });
 
@@ -27,21 +27,21 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       final storage = await StorageService.create();
       expect(storage.getPlayerSpriteIndex(), 0);
-      await storage.setPlayerSpriteIndex(1);
+      expect(await storage.setPlayerSpriteIndex(1), isTrue);
       expect(storage.getPlayerSpriteIndex(), 1);
     });
 
     test('generic get/set handles strings', () async {
       SharedPreferences.setMockInitialValues({});
       final storage = await StorageService.create();
-      await storage.setValue<String>('greeting', 'hello');
+      expect(await storage.setValue<String>('greeting', 'hello'), isTrue);
       expect(storage.getValue<String>('greeting', ''), 'hello');
     });
 
     test('string helpers persist values', () async {
       SharedPreferences.setMockInitialValues({});
       final storage = await StorageService.create();
-      await storage.setString('name', 'Alice');
+      expect(await storage.setString('name', 'Alice'), isTrue);
       expect(storage.getString('name', ''), 'Alice');
     });
   });


### PR DESCRIPTION
## Summary
- Return `Future<bool>` from `StorageService` setter methods to expose persistence success
- Document new success flags in `StorageService` usage guide
- Update storage service tests to assert setters return `true`

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe3f30f908330a21c0857301ab2b8