### PR TITLE
Ensure exclusive overlays remove upgrades

### DIFF
--- a/lib/services/overlay_service.dart
+++ b/lib/services/overlay_service.dart
@@ -27,21 +27,27 @@ class OverlayService {
       PauseOverlay.id,
       GameOverOverlay.id,
       SettingsOverlay.id,
+      UpgradesOverlay.id,
     },
     HudOverlay.id: {
       MenuOverlay.id,
       PauseOverlay.id,
       GameOverOverlay.id,
       SettingsOverlay.id,
+      UpgradesOverlay.id,
     },
     GameOverOverlay.id: {
       HudOverlay.id,
       PauseOverlay.id,
       SettingsOverlay.id,
+      UpgradesOverlay.id,
     },
     UpgradesOverlay.id: {
       HudOverlay.id,
       SettingsOverlay.id,
+      MenuOverlay.id,
+      PauseOverlay.id,
+      GameOverOverlay.id,
     },
   };
 
@@ -63,10 +69,7 @@ class OverlayService {
 
   void showUpgrades() => _showExclusive(UpgradesOverlay.id);
 
-  void hideUpgrades() => _showExclusive(
-        HudOverlay.id,
-        remove: {UpgradesOverlay.id, SettingsOverlay.id},
-      );
+  void hideUpgrades() => showHud();
 
   void showSettings() => game.overlays.add(SettingsOverlay.id);
 


### PR DESCRIPTION
## Summary
- Include `UpgradesOverlay` in the exclusivity map so other overlays automatically hide it
- Make `hideUpgrades` simply delegate to `showHud`

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe7d79cf88330b6aee0111b8d50fd