### PR TITLE
refactor: simplify icon button color handling

### DIFF
--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -75,10 +75,8 @@ class GameIconButton extends StatelessWidget {
     return IconButton(
       iconSize: iconSize,
       onPressed: onPressed,
-      icon: IconTheme.merge(
-        data: IconThemeData(color: iconColor),
-        child: icon,
-      ),
+      color: iconColor,
+      icon: icon,
     );
   }
 }


### PR DESCRIPTION
## Summary
- streamline GameIconButton by using IconButton's built-in color support

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe7d79cf88330b6aee0111b8d50fd