### PR TITLE
Fix service worker response cloning before caching

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -119,14 +119,14 @@ self.addEventListener("fetch", (event) => {
   }
   event.respondWith(
     fetch(event.request)
-      .then((response) => {
+      .then(async (response) => {
         if (
           response.status === 200 &&
           !event.request.url.startsWith("chrome-extension")
         ) {
-          caches
-            .open(CACHE_NAME)
-            .then((cache) => cache.put(event.request, response.clone()));
+          const responseClone = response.clone();
+          const cache = await caches.open(CACHE_NAME);
+          cache.put(event.request, responseClone);
         }
         return response;
       })


### PR DESCRIPTION
## Summary
- clone fetched responses before opening caches to avoid using consumed bodies

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe87413d48330a5a62117afa7b76f