### PR TITLE
Guard user interaction callback and streamline component tracker

### DIFF
--- a/lib/util/component_tracker.dart
+++ b/lib/util/component_tracker.dart
@@ -10,19 +10,22 @@ import '../game/event_bus.dart';
 /// provided [GameEventBus] and exposes the current instance via [component].
 /// Call [dispose] to cancel internal subscriptions when no longer needed.
 class ComponentTracker<T extends Component> {
-  ComponentTracker(GameEventBus events) {
-    _spawnSub = events.on<ComponentSpawnEvent<T>>().listen((event) {
+  ComponentTracker(GameEventBus events)
+      : _component = null,
+        _spawnSub = events.on<ComponentSpawnEvent<T>>().listen(null),
+        _removeSub = events.on<ComponentRemoveEvent<T>>().listen(null) {
+    _spawnSub.onData((event) {
       _component = event.component;
     });
-    _removeSub = events.on<ComponentRemoveEvent<T>>().listen((event) {
+    _removeSub.onData((event) {
       if (identical(_component, event.component)) {
         _component = null;
       }
     });
   }
 
-  late final StreamSubscription<ComponentSpawnEvent<T>> _spawnSub;
-  late final StreamSubscription<ComponentRemoveEvent<T>> _removeSub;
+  final StreamSubscription<ComponentSpawnEvent<T>> _spawnSub;
+  final StreamSubscription<ComponentRemoveEvent<T>> _removeSub;
 
   T? _component;
 

--- a/lib/util/interaction_web.dart
+++ b/lib/util/interaction_web.dart
@@ -1,10 +1,20 @@
 import 'dart:html' as html; // ignore: deprecated_member_use
 
+/// Invokes [callback] on the first user interaction and ensures it runs once.
+///
+/// The event listeners are removed before calling [callback] so a thrown
+/// exception won't keep them around and accidentally fire the handler again.
 void onFirstUserInteraction(void Function() callback) {
+  var handled = false;
+
   void handler(html.Event _) {
-    callback();
+    if (handled) {
+      return;
+    }
+    handled = true;
     html.window.removeEventListener('pointerdown', handler);
     html.window.removeEventListener('keydown', handler);
+    callback();
   }
 
   html.window.addEventListener('pointerdown', handler);


### PR DESCRIPTION
## Summary
- Ensure web interaction callback fires only once and remove listeners before executing
- Simplify `ComponentTracker` by attaching stream handlers after construction

## Testing
- `./scripts/flutterw test --reporter=compact`


------
https://chatgpt.com/codex/tasks/task_e_68bfea6ef6348330bb95a6085a13372e