### PR TITLE
refactor: replace static text scale with inherited notifier

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -63,7 +63,7 @@ tree spanning weapons and ship systems.
 - preloads assets through `Assets.load()` before play.
 - It initialises `StorageService`, `AudioService` and `SettingsService`, applies
   a static dark `ColorScheme` with extra hues from the `GameColors` theme
-  extension, and attaches global text scaling via `GameText.attachTextScale`.
+  extension, and provides global text scaling via `GameTextScale`.
 - An app lifecycle observer pauses the engine and audio when the window loses
   focus.
 - Run all development commands through FVM (`fvm flutter`, `fvm dart`) to keep

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,16 +46,18 @@ Future<void> main() async {
   // ready. The game itself will await completion before starting.
   game.startLoadingAssets();
 
-  GameText.attachTextScale(settings.textScale);
   final lifecycleObserver = _AppLifecycleObserver(game);
 
   runApp(
-    GameApp(
-      game: game,
-      focusNode: focusNode,
-      lifecycleObserver: lifecycleObserver,
-      colorScheme: colorScheme,
-      gameColors: gameColors,
+    GameTextScale(
+      textScale: settings.textScale,
+      child: GameApp(
+        game: game,
+        focusNode: focusNode,
+        lifecycleObserver: lifecycleObserver,
+        colorScheme: colorScheme,
+        gameColors: gameColors,
+      ),
     ),
   );
 }

--- a/lib/main.md
+++ b/lib/main.md
@@ -9,7 +9,7 @@ Entry point launching the Flutter app and `SpaceGame`.
   kicks off `Assets.loadRemaining()` after the first user interaction.
 - Creates core services (`StorageService`, `AudioService`, `SettingsService`).
 - Configures a dark `ColorScheme` for the app.
-- Attaches global text scaling via `GameText.attachTextScale`.
+- Provides global text scaling via `GameTextScale`.
 - Wraps `SpaceGame` in a `GameWidget` so overlays can render Flutter UI and
   registers overlay builders for menus, HUD and dialogs.
 - Observes app lifecycle changes to pause the engine and audio when unfocused.

--- a/lib/ui/game_text.dart
+++ b/lib/ui/game_text.dart
@@ -2,6 +2,23 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 
+/// Provides global text scaling for [GameText] widgets.
+class GameTextScale extends InheritedNotifier<ValueListenable<double>> {
+  const GameTextScale({
+    required ValueListenable<double> textScale,
+    required super.child,
+    super.key,
+  }) : super(notifier: textScale);
+
+  /// Returns the current scale factor from context, defaulting to `1` when
+  /// no [GameTextScale] ancestor is found.
+  static double of(BuildContext context) {
+    final inherited =
+        context.dependOnInheritedWidgetOfExactType<GameTextScale>();
+    return inherited?.notifier?.value ?? 1;
+  }
+}
+
 /// Displays text using a consistent style across game overlays.
 ///
 /// Text is rendered without decoration and uses the game's primary colour by
@@ -33,41 +50,22 @@ class GameText extends StatelessWidget {
 
   static const _baseStyle = TextStyle(fontSize: 18);
 
-  /// Globally applied text scale factor. When attached, all [GameText]
-  /// instances rebuild in response to changes.
-  static ValueListenable<double>? textScale;
-
-  /// Registers a [ValueListenable] that controls text scaling.
-  static void attachTextScale(ValueListenable<double> notifier) {
-    textScale = notifier;
-  }
-
   @override
   Widget build(BuildContext context) {
-    Widget buildText(double scale) {
-      final scheme = Theme.of(context).colorScheme;
-      final mergedStyle = _baseStyle.merge(style);
-      final effectiveColor = color ?? mergedStyle.color ?? scheme.primary;
-      final textStyle = mergedStyle.copyWith(
-        color: effectiveColor,
-        decoration: TextDecoration.none,
-      );
-      final baseSize = textStyle.fontSize ?? _baseStyle.fontSize!;
-      return AutoSizeText(
-        data,
-        maxLines: maxLines,
-        textAlign: textAlign,
-        style: textStyle.copyWith(fontSize: baseSize * scale),
-      );
-    }
-
-    final notifier = textScale;
-    if (notifier != null) {
-      return ValueListenableBuilder<double>(
-        valueListenable: notifier,
-        builder: (context, scale, _) => buildText(scale),
-      );
-    }
-    return buildText(1);
+    final scheme = Theme.of(context).colorScheme;
+    final mergedStyle = _baseStyle.merge(style);
+    final effectiveColor = color ?? mergedStyle.color ?? scheme.primary;
+    final textStyle = mergedStyle.copyWith(
+      color: effectiveColor,
+      decoration: TextDecoration.none,
+    );
+    final baseSize = textStyle.fontSize ?? _baseStyle.fontSize!;
+    final scale = GameTextScale.of(context);
+    return AutoSizeText(
+      data,
+      maxLines: maxLines,
+      textAlign: textAlign,
+      style: textStyle.copyWith(fontSize: baseSize * scale),
+    );
   }
 }

--- a/lib/ui/hud_value_display.dart
+++ b/lib/ui/hud_value_display.dart
@@ -44,19 +44,12 @@ class HudValueDisplay extends StatelessWidget {
       );
     }
 
-    final textScale = GameText.textScale;
-    if (textScale != null) {
-      final merged = Listenable.merge([textScale, valueListenable]);
-      return AnimatedBuilder(
-        animation: merged,
-        builder: (context, _) =>
-            buildDisplay(valueListenable.value, textScale.value),
-      );
-    }
-
     return ValueListenableBuilder<int>(
       valueListenable: valueListenable,
-      builder: (context, value, _) => buildDisplay(value, 1),
+      builder: (context, value, _) {
+        final scale = GameTextScale.of(context);
+        return buildDisplay(value, scale);
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace static GameText text scale with GameTextScale inherited notifier
- wire GameTextScale into main app and HUD value displays
- document new pattern for global text scaling

## Testing
- `./scripts/dartw format lib/ui/game_text.dart lib/main.dart`
- `./scripts/dartw analyze`
- `npx markdownlint-cli DESIGN.md lib/main.md`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bfea6ef6348330bb95a6085a13372e