### PR TITLE
test: add utility and storage persistence tests

### DIFF
--- a/test/angle_utils_test.dart
+++ b/test/angle_utils_test.dart
@@ -1,0 +1,27 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/util/angle_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('normalizeAngle wraps angles greater than pi', () {
+    final angle = 3 * math.pi / 2;
+    final normalized = normalizeAngle(angle);
+    expect(normalized, closeTo(-math.pi / 2, 1e-10));
+  });
+
+  test('normalizeAngle wraps angles less than -pi', () {
+    final angle = -3 * math.pi / 2;
+    final normalized = normalizeAngle(angle);
+    expect(normalized, closeTo(math.pi / 2, 1e-10));
+  });
+
+  test('normalizeAngle handles multiples of 2π', () {
+    final angle = 5 * 2 * math.pi + math.pi / 4;
+    final normalized = normalizeAngle(angle);
+    expect(normalized, closeTo(math.pi / 4, 1e-10));
+  });
+}

--- a/test/interaction_test.dart
+++ b/test/interaction_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/util/interaction.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('onFirstUserInteraction invokes callback immediately on non-web', () {
+    var called = false;
+    onFirstUserInteraction(() {
+      called = true;
+    });
+    expect(called, isTrue);
+  });
+}

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -44,5 +44,26 @@ void main() {
       expect(await storage.setString('name', 'Alice'), isTrue);
       expect(storage.getString('name', ''), 'Alice');
     });
+
+    test('high score persists across instances', () async {
+      SharedPreferences.setMockInitialValues({});
+      var storage = await StorageService.create();
+      await storage.setHighScore(77);
+
+      storage = await StorageService.create();
+      expect(storage.getHighScore(), 77);
+    });
+
+    test('string list persists across instances', () async {
+      SharedPreferences.setMockInitialValues({});
+      var storage = await StorageService.create();
+      await storage.setStringList('upgrades', ['speed1', 'fireRate1']);
+
+      storage = await StorageService.create();
+      expect(
+        storage.getStringList('upgrades', []),
+        ['speed1', 'fireRate1'],
+      );
+    });
   });
 }

--- a/test/upgrade_service_test.dart
+++ b/test/upgrade_service_test.dart
@@ -45,22 +45,23 @@ void main() {
 
   test('purchased upgrades persist to storage', () async {
     SharedPreferences.setMockInitialValues({});
-    final storage = await StorageService.create();
-    final score = ScoreService(storageService: storage);
+    final storage1 = await StorageService.create();
+    final score = ScoreService(storageService: storage1);
     final settings = SettingsService();
     final service = UpgradeService(
       scoreService: score,
-      storageService: storage,
+      storageService: storage1,
       settingsService: settings,
     );
     final upgrade = service.upgrades.first;
     score.addMinerals(upgrade.cost);
     service.buy(upgrade);
 
-    final score2 = ScoreService(storageService: storage);
+    final storage2 = await StorageService.create();
+    final score2 = ScoreService(storageService: storage2);
     final service2 = UpgradeService(
       scoreService: score2,
-      storageService: storage,
+      storageService: storage2,
       settingsService: settings,
     );
     expect(service2.isPurchased(upgrade.id), isTrue);


### PR DESCRIPTION
## Summary
- add `angle_utils` unit tests for angle normalization
- cover interaction stub to ensure callback firing
- test storage for high score and upgrade persistence across instances
- verify upgrade service reloads purchases with fresh storage

## Testing
- `./scripts/dartw format test/angle_utils_test.dart test/interaction_test.dart test/storage_service_test.dart test/upgrade_service_test.dart`
- `./scripts/flutterw test test/angle_utils_test.dart test/interaction_test.dart test/storage_service_test.dart test/upgrade_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68bfe7dd3b148330ba1d3d0e931bcbbf