### PR TITLE
Expand coverage for angle and storage helpers

### DIFF
--- a/test/angle_utils_test.dart
+++ b/test/angle_utils_test.dart
@@ -24,4 +24,20 @@ void main() {
     final normalized = normalizeAngle(angle);
     expect(normalized, closeTo(math.pi / 4, 1e-10));
   });
+
+  test('normalizeAngle leaves in-range angles unchanged', () {
+    expect(normalizeAngle(math.pi), closeTo(math.pi, 1e-10));
+    expect(normalizeAngle(0), closeTo(0, 1e-10));
+    expect(normalizeAngle(math.pi / 2), closeTo(math.pi / 2, 1e-10));
+  });
+
+  test('normalizeAngle wraps -π to π', () {
+    expect(normalizeAngle(-math.pi), closeTo(math.pi, 1e-10));
+  });
+
+  test('normalizeAngle handles negative multiples of 2π', () {
+    final angle = -7 * 2 * math.pi - math.pi / 3;
+    final normalized = normalizeAngle(angle);
+    expect(normalized, closeTo(-math.pi / 3, 1e-10));
+  });
 }

--- a/test/interaction_web_test.dart
+++ b/test/interaction_web_test.dart
@@ -1,0 +1,24 @@
+@TestOn('browser')
+import 'dart:html' as html; // ignore: deprecated_member_use
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/util/interaction_web.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('onFirstUserInteraction waits for browser event', () async {
+    var called = false;
+    onFirstUserInteraction(() {
+      called = true;
+    });
+
+    expect(called, isFalse);
+
+    html.window.dispatchEvent(html.KeyboardEvent('keydown'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(called, isTrue);
+  });
+}

--- a/test/score_service_test.dart
+++ b/test/score_service_test.dart
@@ -56,4 +56,18 @@ void main() {
     expect(score.highScore.value, 0);
     expect(storage.getHighScore(), 0);
   });
+
+  test('high score persists across instances', () async {
+    SharedPreferences.setMockInitialValues({});
+    var storage = await StorageService.create();
+    var score1 = ScoreService(storageService: storage);
+
+    score1.addScore(10);
+    await score1.updateHighScoreIfNeeded();
+    score1.dispose();
+
+    storage = await StorageService.create();
+    final score2 = ScoreService(storageService: storage);
+    expect(score2.highScore.value, 10);
+  });
 }


### PR DESCRIPTION
## Summary
- add boundary and negative angle cases to `normalizeAngle` tests
- add browser-only test for `onFirstUserInteraction`
- verify high score persists across `ScoreService` instances

## Testing
- `./scripts/flutterw test`
- ⚠️ `./scripts/flutterw test --platform chrome test/interaction_web_test.dart` (compile error)


------
https://chatgpt.com/codex/tasks/task_e_68bff42420248330a56ca6aa6a6c8e39