### PR TITLE
refactor: simplify component tracker subscriptions

### DIFF
--- a/lib/util/component_tracker.dart
+++ b/lib/util/component_tracker.dart
@@ -10,22 +10,19 @@ import '../game/event_bus.dart';
 /// provided [GameEventBus] and exposes the current instance via [component].
 /// Call [dispose] to cancel internal subscriptions when no longer needed.
 class ComponentTracker<T extends Component> {
-  ComponentTracker(GameEventBus events)
-      : _component = null,
-        _spawnSub = events.on<ComponentSpawnEvent<T>>().listen(null),
-        _removeSub = events.on<ComponentRemoveEvent<T>>().listen(null) {
-    _spawnSub.onData((event) {
+  ComponentTracker(GameEventBus events) {
+    _spawnSub = events.on<ComponentSpawnEvent<T>>().listen((event) {
       _component = event.component;
     });
-    _removeSub.onData((event) {
+    _removeSub = events.on<ComponentRemoveEvent<T>>().listen((event) {
       if (identical(_component, event.component)) {
         _component = null;
       }
     });
   }
 
-  final StreamSubscription<ComponentSpawnEvent<T>> _spawnSub;
-  final StreamSubscription<ComponentRemoveEvent<T>> _removeSub;
+  late final StreamSubscription<ComponentSpawnEvent<T>> _spawnSub;
+  late final StreamSubscription<ComponentRemoveEvent<T>> _removeSub;
 
   T? _component;
 


### PR DESCRIPTION
## Summary
- simplify ComponentTracker by registering spawn and remove event listeners directly

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test` *(fails: process hangs while loading tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bff3bd1e3883309f8a036946aa03b8