### PR TITLE
Refactor SettingsService disposal

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -114,15 +114,9 @@ class SettingsService {
 
   /// Releases resources held by the service.
   void dispose() {
-    hudButtonScale.dispose();
-    textScale.dispose();
-    joystickScale.dispose();
-    minimapScale.dispose();
-    targetingRange.dispose();
-    tractorRange.dispose();
-    miningRange.dispose();
-    starfieldTileSize.dispose();
-    starfieldDensity.dispose();
-    starfieldBrightness.dispose();
+    for (final notifier in _notifiers.values) {
+      notifier.dispose();
+    }
+    _notifiers.clear();
   }
 }

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -121,4 +121,14 @@ void main() {
     expect(reloaded.hudButtonScale.value, 1.4);
     expect(reloaded.minimapScale.value, 1.2);
   });
+
+  test('dispose releases all notifiers', () {
+    final settings = SettingsService();
+    settings.dispose();
+
+    expect(
+      () => settings.hudButtonScale.addListener(() {}),
+      throwsFlutterError,
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- dispose SettingsService notifiers via map iteration and clear map
- test that disposed SettingsService notifiers throw on further use

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bff7074bd88330b85304bcd38eeac9