### PR TITLE
Refactor upgrade overlay handling into state machine

### DIFF
--- a/lib/game/game_state_machine.dart
+++ b/lib/game/game_state_machine.dart
@@ -12,6 +12,8 @@ class GameStateMachine {
     required this.onResume,
     required this.onGameOver,
     required this.onMenu,
+    required this.onEnterUpgrades,
+    required this.onExitUpgrades,
   });
 
   final OverlayService overlays;
@@ -20,6 +22,8 @@ class GameStateMachine {
   final void Function() onResume;
   final void Function() onGameOver;
   final void Function() onMenu;
+  final void Function() onEnterUpgrades;
+  final void Function() onExitUpgrades;
 
   final ValueNotifier<GameState> stateNotifier =
       ValueNotifier<GameState>(GameState.menu);
@@ -60,6 +64,19 @@ class GameStateMachine {
     state = GameState.menu;
     overlays.showMenu();
     onMenu();
+  }
+
+  /// Toggles the upgrades overlay and pauses/resumes the game.
+  void toggleUpgrades() {
+    if (state == GameState.upgrades) {
+      state = GameState.playing;
+      overlays.hideUpgrades();
+      onExitUpgrades();
+    } else if (state == GameState.playing) {
+      state = GameState.upgrades;
+      overlays.showUpgrades();
+      onEnterUpgrades();
+    }
   }
 
   /// Releases resources held by the state machine.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -28,7 +28,6 @@ import '../services/upgrade_service.dart';
 import '../services/settings_service.dart';
 import '../theme/game_theme.dart';
 import '../ui/help_overlay.dart';
-import '../ui/upgrades_overlay.dart';
 import '../ui/settings_overlay.dart';
 import 'event_bus.dart';
 import 'game_state.dart';
@@ -228,6 +227,14 @@ class SpaceGame extends FlameGame
       onResume: () {},
       onGameOver: lifecycle.onGameOver,
       onMenu: lifecycle.onMenu,
+      onEnterUpgrades: () {
+        pauseEngine();
+        miningLaser?.stopSound();
+      },
+      onExitUpgrades: () {
+        resumeEngine();
+        focusGame();
+      },
     );
 
     shortcuts = game_shortcuts.ShortcutManager(
@@ -256,22 +263,7 @@ class SpaceGame extends FlameGame
   PoolManager createPoolManager() => PoolManager(events: eventBus);
 
   /// Toggles the upgrades overlay and pauses/resumes the game.
-  void toggleUpgrades() {
-    if (overlays.isActive(UpgradesOverlay.id)) {
-      overlayService.hideUpgrades();
-      stateMachine.state = GameState.playing;
-      resumeEngine();
-      focusGame();
-    } else {
-      if (stateMachine.state != GameState.playing) {
-        return;
-      }
-      stateMachine.state = GameState.upgrades;
-      overlayService.showUpgrades();
-      pauseEngine();
-      miningLaser?.stopSound();
-    }
-  }
+  void toggleUpgrades() => stateMachine.toggleUpgrades();
 
   /// Toggles the help overlay and pauses/resumes if entering from gameplay.
   void toggleHelp() {

--- a/test/game_state_machine_test.dart
+++ b/test/game_state_machine_test.dart
@@ -13,6 +13,8 @@ class _FakeOverlayService implements OverlayService {
   bool showPauseCalled = false;
   bool showGameOverCalled = false;
   bool showMenuCalled = false;
+  bool showUpgradesCalled = false;
+  bool hideUpgradesCalled = false;
 
   @override
   void showHud() => showHudCalled = true;
@@ -28,9 +30,9 @@ class _FakeOverlayService implements OverlayService {
   @override
   void hideHelp() {}
   @override
-  void showUpgrades() {}
+  void showUpgrades() => showUpgradesCalled = true;
   @override
-  void hideUpgrades() {}
+  void hideUpgrades() => hideUpgradesCalled = true;
   @override
   void showSettings() {}
   @override
@@ -51,6 +53,8 @@ void main() {
         onResume: () {},
         onGameOver: () {},
         onMenu: () {},
+        onEnterUpgrades: () {},
+        onExitUpgrades: () {},
       );
 
       stateMachine.startGame();
@@ -70,6 +74,8 @@ void main() {
         onResume: () {},
         onGameOver: () {},
         onMenu: () {},
+        onEnterUpgrades: () {},
+        onExitUpgrades: () {},
       )..startGame();
 
       stateMachine.pauseGame();
@@ -89,6 +95,8 @@ void main() {
         onResume: () => resumeCalled = true,
         onGameOver: () {},
         onMenu: () {},
+        onEnterUpgrades: () {},
+        onExitUpgrades: () {},
       )
         ..startGame()
         ..pauseGame();
@@ -111,6 +119,8 @@ void main() {
         onResume: () {},
         onGameOver: () => gameOverCalled = true,
         onMenu: () {},
+        onEnterUpgrades: () {},
+        onExitUpgrades: () {},
       )..startGame();
 
       stateMachine.gameOver();
@@ -130,6 +140,8 @@ void main() {
         onResume: () {},
         onGameOver: () {},
         onMenu: () => menuCalled = true,
+        onEnterUpgrades: () {},
+        onExitUpgrades: () {},
       )..startGame();
 
       stateMachine.returnToMenu();
@@ -149,6 +161,8 @@ void main() {
         onResume: () {},
         onGameOver: () {},
         onMenu: () {},
+        onEnterUpgrades: () {},
+        onExitUpgrades: () {},
       );
 
       stateMachine.pauseGame();
@@ -168,6 +182,8 @@ void main() {
         onResume: () => resumeCalled = true,
         onGameOver: () {},
         onMenu: () {},
+        onEnterUpgrades: () {},
+        onExitUpgrades: () {},
       )..startGame();
 
       overlays.showHudCalled = false;
@@ -176,6 +192,50 @@ void main() {
       expect(stateMachine.state, GameState.playing);
       expect(overlays.showHudCalled, isFalse);
       expect(resumeCalled, isFalse);
+    });
+
+    test('toggleUpgrades shows upgrades overlay and calls onEnterUpgrades', () {
+      final overlays = _FakeOverlayService();
+      var enterCalled = false;
+      final stateMachine = GameStateMachine(
+        overlays: overlays,
+        onStart: () {},
+        onPause: () {},
+        onResume: () {},
+        onGameOver: () {},
+        onMenu: () {},
+        onEnterUpgrades: () => enterCalled = true,
+        onExitUpgrades: () {},
+      )..startGame();
+
+      stateMachine.toggleUpgrades();
+
+      expect(stateMachine.state, GameState.upgrades);
+      expect(overlays.showUpgradesCalled, isTrue);
+      expect(enterCalled, isTrue);
+    });
+
+    test('toggleUpgrades hides upgrades overlay and calls onExitUpgrades', () {
+      final overlays = _FakeOverlayService();
+      var exitCalled = false;
+      final stateMachine = GameStateMachine(
+        overlays: overlays,
+        onStart: () {},
+        onPause: () {},
+        onResume: () {},
+        onGameOver: () {},
+        onMenu: () {},
+        onEnterUpgrades: () {},
+        onExitUpgrades: () => exitCalled = true,
+      )..startGame();
+
+      stateMachine.toggleUpgrades();
+      overlays.showUpgradesCalled = false;
+      stateMachine.toggleUpgrades();
+
+      expect(stateMachine.state, GameState.playing);
+      expect(overlays.hideUpgradesCalled, isTrue);
+      expect(exitCalled, isTrue);
     });
   });
 }

--- a/test/player_collision_test.dart
+++ b/test/player_collision_test.dart
@@ -124,6 +124,8 @@ class _TestGame extends SpaceGame {
       onResume: () {},
       onGameOver: () {},
       onMenu: () {},
+      onEnterUpgrades: () {},
+      onExitUpgrades: () {},
     );
     stateMachine.state = GameState.playing;
     final dispatcher = KeyDispatcher();

--- a/test/player_damage_flash_test.dart
+++ b/test/player_damage_flash_test.dart
@@ -38,6 +38,8 @@ class _TestGame extends SpaceGame {
       onResume: () {},
       onGameOver: () {},
       onMenu: () {},
+      onEnterUpgrades: () {},
+      onExitUpgrades: () {},
     )..state = GameState.playing;
     final keyDispatcher = KeyDispatcher();
     add(keyDispatcher);

--- a/test/player_input_behavior_test.dart
+++ b/test/player_input_behavior_test.dart
@@ -110,6 +110,8 @@ class _TestGame extends SpaceGame {
       onResume: resumeEngine,
       onGameOver: () {},
       onMenu: () {},
+      onEnterUpgrades: () {},
+      onExitUpgrades: () {},
     );
     player.inputBehavior.game = this;
   }

--- a/test/shortcut_manager_test.dart
+++ b/test/shortcut_manager_test.dart
@@ -91,6 +91,8 @@ class _Harness {
       onResume: () {},
       onGameOver: () {},
       onMenu: () {},
+      onEnterUpgrades: () {},
+      onExitUpgrades: () {},
     );
     ShortcutManager(
       keyDispatcher: dispatcher,


### PR DESCRIPTION
## Summary
- centralize upgrade overlay transitions in `GameStateMachine`
- delegate upgrade toggling in `SpaceGame` to the state machine
- cover upgrade toggling with new tests

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68bff7074bd88330b85304bcd38eeac9