### PR TITLE
Add persistence and input interaction tests

### DIFF
--- a/test/angle_utils_test.dart
+++ b/test/angle_utils_test.dart
@@ -40,4 +40,17 @@ void main() {
     final normalized = normalizeAngle(angle);
     expect(normalized, closeTo(-math.pi / 3, 1e-10));
   });
+
+  test('normalizeAngle keeps result within [-π, π]', () {
+    for (var angle = -20 * math.pi;
+        angle <= 20 * math.pi;
+        angle += math.pi / 5) {
+      final normalized = normalizeAngle(angle);
+      expect(
+        normalized >= -math.pi && normalized <= math.pi,
+        isTrue,
+        reason: 'angle $angle normalized to $normalized outside range',
+      );
+    }
+  });
 }

--- a/test/interaction_web_test.dart
+++ b/test/interaction_web_test.dart
@@ -21,4 +21,20 @@ void main() {
 
     expect(called, isTrue);
   });
+
+  test('onFirstUserInteraction triggers only once', () async {
+    var calls = 0;
+    onFirstUserInteraction(() {
+      calls++;
+    });
+
+    web.window.dispatchEvent(web.PointerEvent('pointerdown'));
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 1);
+
+    web.window.dispatchEvent(web.KeyboardEvent('keydown'));
+    web.window.dispatchEvent(web.PointerEvent('pointerdown'));
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 1);
+  });
 }

--- a/test/upgrades_high_score_persistence_test.dart
+++ b/test/upgrades_high_score_persistence_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:space_game/services/score_service.dart';
+import 'package:space_game/services/settings_service.dart';
+import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/upgrade_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('high score and upgrades persist across sessions', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    var storage = await StorageService.create();
+    var score = ScoreService(storageService: storage);
+    var settings = SettingsService();
+    var upgradeService = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+      settingsService: settings,
+    );
+
+    score.addScore(100);
+    await score.updateHighScoreIfNeeded();
+    final upgrade = upgradeService.upgrades.first;
+    score.addMinerals(upgrade.cost);
+    upgradeService.buy(upgrade);
+
+    // Simulate a restart by recreating services with the same underlying storage.
+    storage = await StorageService.create();
+    score = ScoreService(storageService: storage);
+    settings = SettingsService();
+    upgradeService = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+      settingsService: settings,
+    );
+
+    expect(score.highScore.value, 100);
+    expect(upgradeService.isPurchased(upgrade.id), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- expand angle normalization tests to ensure results stay within [-π, π]
- verify `onFirstUserInteraction` only fires once on the web
- ensure high scores and upgrades persist after service restart

## Testing
- `./scripts/flutterw test test/angle_utils_test.dart test/interaction_web_test.dart test/upgrades_high_score_persistence_test.dart`
- `./scripts/flutterw test -d chrome test/interaction_web_test.dart` *(no tests ran: browser not available)*
- `./scripts/dartw test -p chrome test/interaction_web_test.dart` *(failed: missing package `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68bffd9f923883308cc2ba6871a9613d