### PR TITLE
feat: add starfield palette options and gamma brightness control

### DIFF
--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -26,6 +26,7 @@ class StarfieldLayerConfig {
     ],
     this.minBrightness = 150,
     this.maxBrightness = 255,
+    this.gamma = 1,
   });
 
   /// Camera movement multiplier. Smaller values appear further away.
@@ -49,6 +50,13 @@ class StarfieldLayerConfig {
 
   /// Maximum star brightness (0-255).
   final int maxBrightness;
+
+  /// Exponent applied to the brightness randomiser.
+  ///
+  /// Values >1 bias towards darker stars while values <1 produce more bright
+  /// stars. A value of 1 yields linear scaling between [minBrightness] and
+  /// [maxBrightness].
+  final double gamma;
 }
 
 /// Deterministic world-space starfield rendered behind gameplay.
@@ -60,6 +68,7 @@ class StarfieldComponent extends Component with HasGameReference<FlameGame> {
     this.tileSize = Constants.starfieldTileSize,
     this.densityMultiplier = 1,
     this.brightnessMultiplier = 1,
+    this.gamma = 1,
   })  : _seed = seed,
         _layers =
             layers ?? const [StarfieldLayerConfig(parallax: 1, density: 1)],
@@ -78,6 +87,9 @@ class StarfieldComponent extends Component with HasGameReference<FlameGame> {
 
   /// Multiplier applied to star brightness (0-1).
   final double brightnessMultiplier;
+
+  /// Global multiplier applied to layer gamma values.
+  final double gamma;
 
   final Paint _starPaint = Paint();
 
@@ -285,6 +297,7 @@ class StarfieldComponent extends Component with HasGameReference<FlameGame> {
       layer.paletteValues,
       (layer.config.minBrightness * brightnessMultiplier).clamp(0, 255).round(),
       (layer.config.maxBrightness * brightnessMultiplier).clamp(0, 255).round(),
+      layer.config.gamma * gamma,
     );
     final future = _runTileData(params).then((data) {
       final stars =
@@ -377,6 +390,7 @@ class StarfieldComponent extends Component with HasGameReference<FlameGame> {
       cfg.palette.map((c) => c.toARGB32()).toList(growable: false),
       cfg.minBrightness,
       cfg.maxBrightness,
+      cfg.gamma * gamma,
     );
     return _generateTileStars(params, cfg.twinkleSpeed).map((s) => s.radius);
   }
@@ -452,7 +466,7 @@ class _StarData {
 class _TileParams {
   /// Parameters passed to tile generation isolate. Must remain sendable.
   const _TileParams(this.seed, this.tx, this.ty, this.minDist, this.tileSize,
-      this.palette, this.minBrightness, this.maxBrightness);
+      this.palette, this.minBrightness, this.maxBrightness, this.gamma);
 
   final int seed;
   final int tx;
@@ -462,6 +476,7 @@ class _TileParams {
   final List<int> palette;
   final int minBrightness;
   final int maxBrightness;
+  final double gamma;
 }
 
 class _TileWorker {
@@ -570,6 +585,7 @@ List<_StarData> _generateTileStarData(_TileParams params) {
             params.palette,
             params.minBrightness,
             params.maxBrightness,
+            params.gamma,
           ))
       .toList()
     ..sort((a, b) => (a.radius).compareTo(b.radius));
@@ -637,7 +653,7 @@ List<Offset> _poisson(double size, double minDist, math.Random rnd,
 }
 
 _StarData _randomStarData(Offset position, math.Random rnd, List<int> palette,
-    int minBrightness, int maxBrightness) {
+    int minBrightness, int maxBrightness, double gamma) {
   final roll = rnd.nextDouble();
   double radius;
   if (roll < 0.8) {
@@ -649,8 +665,9 @@ _StarData _randomStarData(Offset position, math.Random rnd, List<int> palette,
   }
 
   final baseColor = palette[rnd.nextInt(palette.length)];
+  final t = math.pow(rnd.nextDouble(), gamma).toDouble();
   final brightness =
-      minBrightness + rnd.nextInt(maxBrightness - minBrightness + 1);
+      (minBrightness + (maxBrightness - minBrightness) * t).round();
   final r = ((baseColor >> 16) & 0xFF) * brightness ~/ 255;
   final g = ((baseColor >> 8) & 0xFF) * brightness ~/ 255;
   final b = (baseColor & 0xFF) * brightness ~/ 255;

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -7,7 +7,8 @@ Deterministic parallax starfield rendered by `StarfieldComponent`.
 - Low-frequency Simplex noise modulates the minimum distance between stars to
   create subtle clusters and voids. A density multiplier on each layer allows
   the game to tune how busy the sky appears. Global density and brightness
-  multipliers expose accessibility controls.
+  multipliers expose accessibility controls. A gamma value modulates brightness
+  using a non-linear curve, enabling more nuanced contrast adjustments.
 - Star generation runs in a background isolate (`compute`) so tile creation
   doesn't stall the main thread.
 - Each layer owns a single `OpenSimplexNoise` instance reused for all tiles,
@@ -23,6 +24,7 @@ Deterministic parallax starfield rendered by `StarfieldComponent`.
 - Tiles are generated asynchronously and cached in an LRU map so camera movement
   never blocks the render loop. Cache size is bounded by each layer's
   `maxCacheTiles`.
+- Star colours come from a selectable palette, allowing theme-driven visuals.
 - A `debugDrawTiles` flag outlines each tile with a translucent stroke for
   development verification. `SpaceGame.toggleDebug` flips this on whenever the
   game's debug mode is enabled so tile borders appear alongside other debug

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -14,6 +14,9 @@ class Constants {
   /// Global multiplier applied to star brightness (0-1).
   static const double starfieldBrightness = 1;
 
+  /// Global gamma exponent applied to star brightness.
+  static const double starfieldGamma = 1;
+
   /// Player movement speed in pixels per second.
   static const double playerSpeed = 200;
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -27,6 +27,7 @@ import '../services/targeting_service.dart';
 import '../services/upgrade_service.dart';
 import '../services/settings_service.dart';
 import '../theme/game_theme.dart';
+import '../theme/star_palette.dart';
 import '../ui/help_overlay.dart';
 import '../ui/settings_overlay.dart';
 import 'event_bus.dart';
@@ -181,21 +182,28 @@ class SpaceGame extends FlameGame
     joystick = _buildJoystick();
     await add(joystick);
 
+    final palette = settingsService.starfieldPalette.value.colors;
     _starfield = await StarfieldComponent(
       debugDrawTiles: debugMode,
-      layers: const [
-        StarfieldLayerConfig(parallax: 0.2, density: 0.15, twinkleSpeed: 0.5),
-        StarfieldLayerConfig(parallax: 0.6, density: 0.3, twinkleSpeed: 0.8),
-        StarfieldLayerConfig(parallax: 1.0, density: 0.5, twinkleSpeed: 1),
+      layers: [
+        StarfieldLayerConfig(
+            parallax: 0.2, density: 0.15, twinkleSpeed: 0.5, palette: palette),
+        StarfieldLayerConfig(
+            parallax: 0.6, density: 0.3, twinkleSpeed: 0.8, palette: palette),
+        StarfieldLayerConfig(
+            parallax: 1.0, density: 0.5, twinkleSpeed: 1, palette: palette),
       ],
       tileSize: settingsService.starfieldTileSize.value,
       densityMultiplier: settingsService.starfieldDensity.value,
       brightnessMultiplier: settingsService.starfieldBrightness.value,
+      gamma: settingsService.starfieldGamma.value,
     );
     await add(_starfield!);
     settingsService.starfieldTileSize.addListener(_rebuildStarfield);
     settingsService.starfieldDensity.addListener(_rebuildStarfield);
     settingsService.starfieldBrightness.addListener(_rebuildStarfield);
+    settingsService.starfieldGamma.addListener(_rebuildStarfield);
+    settingsService.starfieldPalette.addListener(_rebuildStarfield);
 
     player = PlayerComponent(
       joystick: joystick,
@@ -479,20 +487,26 @@ class SpaceGame extends FlameGame
     final tileSize = settingsService.starfieldTileSize.value;
     final density = settingsService.starfieldDensity.value;
     final brightness = settingsService.starfieldBrightness.value;
+    final gamma = settingsService.starfieldGamma.value;
+    final palette = settingsService.starfieldPalette.value.colors;
     _starfield?.removeFromParent();
     _starfield = null;
     final buildId = ++_starfieldRebuildId;
     unawaited(() async {
       final sf = await StarfieldComponent(
         debugDrawTiles: debugMode,
-        layers: const [
-          StarfieldLayerConfig(parallax: 0.2, density: 0.3, twinkleSpeed: 0.5),
-          StarfieldLayerConfig(parallax: 0.6, density: 0.6, twinkleSpeed: 0.8),
-          StarfieldLayerConfig(parallax: 1.0, density: 1, twinkleSpeed: 1),
+        layers: [
+          StarfieldLayerConfig(
+              parallax: 0.2, density: 0.3, twinkleSpeed: 0.5, palette: palette),
+          StarfieldLayerConfig(
+              parallax: 0.6, density: 0.6, twinkleSpeed: 0.8, palette: palette),
+          StarfieldLayerConfig(
+              parallax: 1.0, density: 1, twinkleSpeed: 1, palette: palette),
         ],
         tileSize: tileSize,
         densityMultiplier: density,
         brightnessMultiplier: brightness,
+        gamma: gamma,
       );
       if (buildId != _starfieldRebuildId) {
         return;

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../constants.dart';
+import '../theme/star_palette.dart';
 import 'storage_service.dart';
 
 /// Holds tweakable UI scale values, gameplay ranges and performance tweaks for
@@ -20,6 +21,12 @@ class SettingsService {
     starfieldTileSize = _notifiers[_starfieldTileSizeKey]!;
     starfieldDensity = _notifiers[_starfieldDensityKey]!;
     starfieldBrightness = _notifiers[_starfieldBrightnessKey]!;
+    starfieldGamma = _notifiers[_starfieldGammaKey]!;
+    starfieldPalette = ValueNotifier<StarPalette>(
+      StarPalette.values[_storage?.getInt(_starfieldPaletteKey, 0) ?? 0],
+    );
+    starfieldPalette.addListener(() =>
+        _storage?.setInt(_starfieldPaletteKey, starfieldPalette.value.index));
   }
 
   static const double defaultHudButtonScale = 0.75;
@@ -57,6 +64,12 @@ class SettingsService {
   /// Global multiplier applied to star brightness.
   late final ValueNotifier<double> starfieldBrightness;
 
+  /// Exponent applied to star brightness.
+  late final ValueNotifier<double> starfieldGamma;
+
+  /// Currently selected star colour palette.
+  late final ValueNotifier<StarPalette> starfieldPalette;
+
   StorageService? _storage;
   late final Map<String, ValueNotifier<double>> _notifiers;
 
@@ -72,6 +85,8 @@ class SettingsService {
       (key, notifier) =>
           notifier.value = storage.getDouble(key, notifier.value),
     );
+    starfieldPalette.value =
+        StarPalette.values[storage.getInt(_starfieldPaletteKey, 0)];
   }
 
   /// Restores all values to their defaults.
@@ -79,6 +94,7 @@ class SettingsService {
     _settingDefaults.forEach(
       (key, defaultValue) => _notifiers[key]!.value = defaultValue,
     );
+    starfieldPalette.value = StarPalette.classic;
   }
 
   static const _hudScaleKey = 'hudButtonScale';
@@ -91,6 +107,8 @@ class SettingsService {
   static const _starfieldTileSizeKey = 'starfieldTileSize';
   static const _starfieldDensityKey = 'starfieldDensity';
   static const _starfieldBrightnessKey = 'starfieldBrightness';
+  static const _starfieldGammaKey = 'starfieldGamma';
+  static const _starfieldPaletteKey = 'starfieldPalette';
 
   static const _settingDefaults = <String, double>{
     _hudScaleKey: defaultHudButtonScale,
@@ -103,6 +121,7 @@ class SettingsService {
     _starfieldTileSizeKey: Constants.starfieldTileSize,
     _starfieldDensityKey: Constants.starfieldDensity,
     _starfieldBrightnessKey: Constants.starfieldBrightness,
+    _starfieldGammaKey: Constants.starfieldGamma,
   };
 
   ValueNotifier<double> _initNotifier(String key, double defaultValue) {
@@ -117,6 +136,7 @@ class SettingsService {
     for (final notifier in _notifiers.values) {
       notifier.dispose();
     }
+    starfieldPalette.dispose();
     _notifiers.clear();
   }
 }

--- a/lib/theme/star_palette.dart
+++ b/lib/theme/star_palette.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/painting.dart';
+
+/// Available colour palettes for the starfield.
+///
+/// These palettes tint the procedurally generated stars and can be swapped at
+/// runtime for accessibility or stylistic variety.
+enum StarPalette {
+  /// Original multicolour palette.
+  classic,
+
+  /// Cooler blues and purples for a dusk-like tone.
+  dusk,
+
+  /// Single white tone for high contrast.
+  monochrome,
+}
+
+extension StarPaletteColors on StarPalette {
+  /// Returns the list of colours associated with this palette.
+  List<Color> get colors {
+    switch (this) {
+      case StarPalette.classic:
+        return const [
+          Color(0xFFFFFFFF),
+          Color(0xFFFFAAAA),
+          Color(0xFFFFFFAA),
+          Color(0xFFAAAFFF),
+        ];
+      case StarPalette.dusk:
+        return const [
+          Color(0xFFB0E0FF),
+          Color(0xFF8090FF),
+          Color(0xFF4050A0),
+          Color(0xFFE0A0FF),
+        ];
+      case StarPalette.monochrome:
+        return const [Color(0xFFFFFFFF)];
+    }
+  }
+
+  /// Human-readable label for UI selection.
+  String get label {
+    switch (this) {
+      case StarPalette.classic:
+        return 'Classic';
+      case StarPalette.dusk:
+        return 'Dusk';
+      case StarPalette.monochrome:
+        return 'Monochrome';
+    }
+  }
+}

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../game/space_game.dart';
+import '../theme/star_palette.dart';
 import 'game_text.dart';
 import 'overlay_widgets.dart';
 
@@ -158,6 +159,20 @@ class SettingsOverlay extends StatelessWidget {
                       min: 0,
                       max: 1,
                     ),
+                    _buildSlider(
+                      context,
+                      'Star Gamma',
+                      settings.starfieldGamma,
+                      spacing,
+                      min: 0.5,
+                      max: 2.5,
+                    ),
+                    _buildPaletteDropdown(
+                      context,
+                      'Star Palette',
+                      settings.starfieldPalette,
+                      spacing,
+                    ),
                     SizedBox(height: spacing),
                     ElevatedButton(
                       onPressed: () {
@@ -208,6 +223,37 @@ class SettingsOverlay extends StatelessWidget {
             min: min,
             max: max,
             onChanged: (v) => notifier.value = v,
+          ),
+          SizedBox(height: spacing),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPaletteDropdown(
+    BuildContext context,
+    String label,
+    ValueNotifier<StarPalette> notifier,
+    double spacing,
+  ) {
+    return ValueListenableBuilder<StarPalette>(
+      valueListenable: notifier,
+      builder: (context, value, _) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GameText(label),
+          DropdownButton<StarPalette>(
+            value: value,
+            items: [
+              for (final p in StarPalette.values)
+                DropdownMenuItem(
+                  value: p,
+                  child: GameText(p.label),
+                )
+            ],
+            onChanged: (p) {
+              if (p != null) notifier.value = p;
+            },
           ),
           SizedBox(height: spacing),
         ],


### PR DESCRIPTION
## Summary
- add gamma exponent to starfield brightness for non-linear curves
- allow selecting star palettes and gamma via settings UI
- rebuild starfield when palette or gamma changes

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bffdda24e08330acefe4b2fdfbbf41