### PR TITLE
Refactor asset path generation and logging; instrument object pool

### DIFF
--- a/lib/log.dart
+++ b/lib/log.dart
@@ -1,7 +1,23 @@
+import 'dart:developer' as developer;
 import 'package:flutter/foundation.dart';
 
-/// Simple wrapper around [debugPrint] to allow easy silencing in release builds.
-void log(String message) {
+/// Logs [message] using [developer.log] so that output is available in all
+/// builds. In debug/profile modes, the message is also printed using
+/// [debugPrint] for convenience.
+void log(
+  String message, {
+  String name = 'space_game',
+  int level = 0,
+  Object? error,
+  StackTrace? stackTrace,
+}) {
+  developer.log(
+    message,
+    name: name,
+    level: level,
+    error: error,
+    stackTrace: stackTrace,
+  );
   if (!kReleaseMode) {
     debugPrint(message);
   }

--- a/test/object_pool_max_size_test.dart
+++ b/test/object_pool_max_size_test.dart
@@ -12,4 +12,18 @@ void main() {
     // Ensure the stored instance is the first one released.
     expect(pool.acquire(), 1);
   });
+
+  test('onDiscard callback fires when pool is full', () {
+    var discarded = 0;
+    final pool = ObjectPool<int>(
+      () => 0,
+      maxSize: 1,
+      onDiscard: (_) => discarded++,
+    );
+
+    pool.release(1);
+    pool.release(2); // Triggers discard.
+
+    expect(discarded, 1);
+  });
 }


### PR DESCRIPTION
## Summary
- derive enemy faction asset paths from enum names to remove duplication
- simplify asset loading with shared helper and progress reporting
- upgrade logging to use `dart:developer` with optional levels and errors
- add object pool discard callback and log when capacity exceeded

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68bffd9256788330ad9c86b9dabb217c