### PR TITLE
Add tests for utilities and overlay flows

### DIFF
--- a/test/angle_utils_test.dart
+++ b/test/angle_utils_test.dart
@@ -25,6 +25,11 @@ void main() {
     expect(normalized, closeTo(math.pi / 4, 1e-10));
   });
 
+  test('normalizeAngle maps ±2π to zero', () {
+    expect(normalizeAngle(2 * math.pi), closeTo(0, 1e-10));
+    expect(normalizeAngle(-2 * math.pi), closeTo(0, 1e-10));
+  });
+
   test('normalizeAngle leaves in-range angles unchanged', () {
     expect(normalizeAngle(math.pi), closeTo(math.pi, 1e-10));
     expect(normalizeAngle(0), closeTo(0, 1e-10));

--- a/test/interaction_web_test.dart
+++ b/test/interaction_web_test.dart
@@ -37,4 +37,22 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     expect(calls, 1);
   });
+
+  test('listeners removed even if callback throws', () async {
+    var calls = 0;
+    onFirstUserInteraction(() {
+      calls++;
+      throw Exception('boom');
+    });
+
+    expect(
+      () => web.window.dispatchEvent(web.KeyboardEvent('keydown')),
+      throwsException,
+    );
+
+    // Subsequent events should not trigger the callback again.
+    web.window.dispatchEvent(web.PointerEvent('pointerdown'));
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 1);
+  });
 }

--- a/test/overlay_service_test.dart
+++ b/test/overlay_service_test.dart
@@ -99,6 +99,23 @@ void main() {
     expect(game.overlays.isActive(HudOverlay.id), isTrue);
   });
 
+  test('opening settings while paused retains pause and hides HUD', () {
+    final game = _createGame();
+    final service = OverlayService(game);
+
+    service.showHud();
+    service.showPause();
+
+    expect(game.overlays.isActive(PauseOverlay.id), isTrue);
+    expect(game.overlays.isActive(HudOverlay.id), isTrue);
+
+    service.showSettings();
+
+    expect(game.overlays.isActive(SettingsOverlay.id), isTrue);
+    expect(game.overlays.isActive(PauseOverlay.id), isTrue);
+    expect(game.overlays.isActive(HudOverlay.id), isTrue);
+  });
+
   test('rapid overlay toggles leave only HUD active', () {
     final game = _createGame();
     final service = OverlayService(game);

--- a/test/upgrades_high_score_persistence_test.dart
+++ b/test/upgrades_high_score_persistence_test.dart
@@ -39,5 +39,18 @@ void main() {
 
     expect(score.highScore.value, 100);
     expect(upgradeService.isPurchased(upgrade.id), isTrue);
+
+    // Simulate another restart to ensure persistence across multiple sessions.
+    storage = await StorageService.create();
+    score = ScoreService(storageService: storage);
+    settings = SettingsService();
+    upgradeService = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+      settingsService: settings,
+    );
+
+    expect(score.highScore.value, 100);
+    expect(upgradeService.isPurchased(upgrade.id), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- test angle normalization when normalizing ±2π
- ensure browser interaction listeners are removed after callback
- cover showing settings during pause
- verify upgrade and high score data persists across multiple restarts

## Testing
- `scripts/flutterw test --concurrency 1`

------
https://chatgpt.com/codex/tasks/task_e_68c0010a3d308330a56399c6772ef5fd