### PR TITLE
Avoid disposing shared tile worker during starfield removal

### DIFF
--- a/lib/components/starfield.dart
+++ b/lib/components/starfield.dart
@@ -138,7 +138,10 @@ class StarfieldComponent extends Component with HasGameReference<FlameGame> {
       layer.cache.clear();
       layer.lru.clear();
     }
-    _TileWorker.instance.dispose();
+    // Do not dispose the global tile worker here. When the starfield is
+    // rebuilt, Flame processes additions before removals, so disposing the
+    // worker during removal can interfere with the new component that is
+    // already using it.
     super.onRemove();
   }
 


### PR DESCRIPTION
## Summary
- Prevent starfield rebuild from blanking by keeping the shared tile worker alive during component removal

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c003bc31988330aa0b7fece7d34925