### PR TITLE
Fix event listener types for package:web

### DIFF
--- a/lib/util/interaction_web.dart
+++ b/lib/util/interaction_web.dart
@@ -15,11 +15,11 @@ void onFirstUserInteraction(void Function() callback) {
       return;
     }
     handled = true;
-    web.window.removeEventListener('pointerdown', listener);
-    web.window.removeEventListener('keydown', listener);
+    web.window.removeEventListener('pointerdown'.toJS as String, listener);
+    web.window.removeEventListener('keydown'.toJS as String, listener);
     callback();
   }).toJS;
 
-  web.window.addEventListener('pointerdown', listener);
-  web.window.addEventListener('keydown', listener);
+  web.window.addEventListener('pointerdown'.toJS as String, listener);
+  web.window.addEventListener('keydown'.toJS as String, listener);
 }


### PR DESCRIPTION
## Summary
- use JSString for web event listener names

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test --platform=chrome` *(fails: value of type '({void Function() entryPoint, Future<void> Function(Future<void> Function()) entryPointRunner, Uri goldensUri})' can't be assigned to a variable of type '({FutureOr<void> Function() entryPoint, Future<void> Function(FutureOr<void> Function())? entryPointRunner, Uri goldensUri})')*


------
https://chatgpt.com/codex/tasks/task_e_68c006dab1748330a139d05e341ccb2b