### PR TITLE
Expand utility tests for angles and interaction callbacks

### DIFF
--- a/test/angle_utils_test.dart
+++ b/test/angle_utils_test.dart
@@ -58,4 +58,35 @@ void main() {
       );
     }
   });
+
+  test('normalizeAngle is odd except at π', () {
+    for (var angle = -10 * math.pi;
+        angle <= 10 * math.pi;
+        angle += math.pi / 7) {
+      final normalized = normalizeAngle(angle);
+      if ((normalized - math.pi).abs() < 1e-10 ||
+          (normalized + math.pi).abs() < 1e-10) {
+        continue;
+      }
+      final mirrored = normalizeAngle(-angle);
+      expect(
+        mirrored,
+        closeTo(-normalized, 1e-10),
+        reason: 'angle $angle produced $normalized and $mirrored',
+      );
+    }
+  });
+
+  test('normalizeAngle ignores 2π multiples', () {
+    const base = math.pi / 3;
+    final expected = normalizeAngle(base);
+    for (var k = -5; k <= 5; k++) {
+      final shifted = base + k * 2 * math.pi;
+      expect(normalizeAngle(shifted), closeTo(expected, 1e-10));
+    }
+  });
+
+  test('normalizeAngle treats -0 as 0', () {
+    expect(normalizeAngle(-0.0), isZero);
+  });
 }

--- a/test/interaction_test.dart
+++ b/test/interaction_test.dart
@@ -12,4 +12,22 @@ void main() {
     });
     expect(called, isTrue);
   });
+
+  test('onFirstUserInteraction executes each callback separately', () {
+    var count = 0;
+    onFirstUserInteraction(() {
+      count++;
+    });
+    onFirstUserInteraction(() {
+      count++;
+    });
+    expect(count, 2);
+  });
+
+  test('onFirstUserInteraction forwards exceptions', () {
+    expect(
+      () => onFirstUserInteraction(() => throw Exception('boom')),
+      throwsException,
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- broaden angle normalization coverage with additional property tests
- verify non-web interaction callbacks fire individually and propagate errors

## Testing
- `scripts/flutterw test test/angle_utils_test.dart test/interaction_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68c00971e4748330b23c0256603e8505