### PR TITLE
docs: plan nebula overlay layers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -199,6 +199,11 @@ tree spanning weapons and ship systems.
   adjustable via the settings overlay. The player flies over a static backdrop
   while circles draw faint-to-bright. A `debugDrawTiles` switch outlines tile
   boundaries when debug mode (`F1`) is active for troubleshooting.
+- Optional nebula or distant galaxy layers may overlay this starfield to add
+  ambience. Nebulae could be noise-generated sprites cached per tile, while a
+  far galaxy may draw as a single bitmap with slow parallax. Each overlay would
+  be toggleable in the settings and render behind gameplay but above the
+  starfield to keep existing tiles untouched.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -150,6 +150,10 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   `Picture` that sorts stars by radius so faint ones draw first for smoother
   blending. A weighted size/brightness distribution with subtle colour jitter
   adds variety, and layered parallax with gentle alpha twinkling adds depth.
+  - Optional nebula or distant galaxy overlays may render above this starfield to
+    enrich the backdrop without altering the tile-based generation. These
+    overlays could use noise-generated sprites or large bitmaps and expose
+    toggles in the settings overlay.
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple
   object pools to reduce garbage collection overhead

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ dedicated server or NAT traversal.
 - Optional backend for saves or analytics
 - Native builds (Play Store/TestFlight) if needed later
 - Inventory, mineral-based upgrades, menus, shop UI and save/load
+- Optional nebula or distant galaxy overlays to enrich the starfield without
+  altering its tile system
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -120,3 +120,10 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       - [x] Remove the old parallax starfield once the deterministic version is
             in place.
       - [x] Expose an optional `debugDrawTiles` flag to outline starfield tiles.
+
+## Background Enhancements
+
+- [ ] Add an optional noise-generated nebula layer rendered above the starfield.
+- [ ] Add an optional distant galaxy bitmap overlay with subtle parallax.
+- [ ] Expose settings toggles and density/brightness sliders for these
+      overlays.

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -51,6 +51,8 @@ Gameplay entities and reusable pieces.
 
 ## Planned Components
 
-None at this time.
+- [NebulaLayer](nebula_layer.md) – optional noise-generated nebula sprites or a
+  distant galaxy bitmap that overlays the starfield and exposes toggles for
+  visibility and density in the settings overlay.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/components/nebula_layer.md
+++ b/lib/components/nebula_layer.md
@@ -1,0 +1,24 @@
+# NebulaLayer
+
+Optional overlay component that enriches the background with nebulae or a distant
+sample galaxy image while keeping the deterministic starfield intact.
+
+## Goals
+
+- Render additional ambience above the starfield but below gameplay.
+- Allow toggling overlays via the settings overlay.
+- Support two sources:
+  - Noise-generated nebula sprites cached per tile.
+  - A large, low-resolution galaxy bitmap with subtle parallax.
+
+## Implementation Notes
+
+- Expose brightness and density controls alongside existing starfield settings.
+- Nebula tiles can reuse the starfield's caching system and background isolate
+  to avoid frame spikes.
+- Galaxy bitmap loads through `Assets` and draws with a fixed offset for a slow
+  parallax effect.
+- Component priority sits between the starfield and gameplay components so
+  overlays appear behind action but above stars.
+- All layers must respect debugging controls and hide when the game's debug mode
+  is disabled.

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -31,3 +31,10 @@ Deterministic parallax starfield rendered by `StarfieldComponent`.
   visuals.
 - Added to `SpaceGame` with a negative priority so it always renders beneath
   gameplay components.
+
+## Future Enhancements
+
+- Optional nebula or distant galaxy overlays may draw above the starfield to
+  add ambience while leaving the deterministic tiles untouched. These overlays
+  could use noise-generated sprites or a pre-rendered bitmap and expose
+  toggles and density controls in the settings overlay.


### PR DESCRIPTION
## Summary
- outline optional nebula/galaxy overlays to enrich the starfield
- add NebulaLayer design notes and reference in component docs
- track background overlay tasks in PLAN and TASKS

## Testing
- `npx --yes markdownlint-cli '**/*.md'`
- `scripts/dartw test` *(fails: loading test files)*

------
https://chatgpt.com/codex/tasks/task_e_68c009ab85cc8330850598f00f8013bc