### PR TITLE
fix: avoid JSString cast in event listeners

### DIFF
--- a/lib/util/interaction_web.dart
+++ b/lib/util/interaction_web.dart
@@ -15,11 +15,11 @@ void onFirstUserInteraction(void Function() callback) {
       return;
     }
     handled = true;
-    web.window.removeEventListener('pointerdown'.toJS as String, listener);
-    web.window.removeEventListener('keydown'.toJS as String, listener);
+    web.window.removeEventListener('pointerdown', listener);
+    web.window.removeEventListener('keydown', listener);
     callback();
   }).toJS;
 
-  web.window.addEventListener('pointerdown'.toJS as String, listener);
-  web.window.addEventListener('keydown'.toJS as String, listener);
+  web.window.addEventListener('pointerdown', listener);
+  web.window.addEventListener('keydown', listener);
 }


### PR DESCRIPTION
## Summary
- avoid casting `JSString` to `String` for event listener names

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c00d5aef188330abfa6d098870a181