### PR TITLE
Ensure object pools discard items on clear

### DIFF
--- a/lib/game/pool_manager.dart
+++ b/lib/game/pool_manager.dart
@@ -140,5 +140,12 @@ class PoolManager {
       sub.cancel();
     }
     _subscriptions.clear();
+    for (final pool in _pools.values) {
+      pool.clear();
+    }
+    _pools.clear();
+    _active.clear();
+    _onRemove.clear();
+    _onSpawn.clear();
   }
 }

--- a/lib/util/object_pool.dart
+++ b/lib/util/object_pool.dart
@@ -48,6 +48,18 @@ class ObjectPool<T> {
     }
   }
 
-  /// Clears all cached instances.
-  void clear() => _items.clear();
+  /// Clears all cached instances and calls [onDiscard] for each.
+  ///
+  /// This ensures pooled objects can release any resources before being
+  /// dropped permanently, mirroring the behaviour when the pool reaches its
+  /// [maxSize] in [release].
+  void clear() {
+    final discard = onDiscard;
+    if (discard != null) {
+      for (final item in _items) {
+        discard(item);
+      }
+    }
+    _items.clear();
+  }
 }

--- a/test/object_pool_clear_test.dart
+++ b/test/object_pool_clear_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/util/object_pool.dart';
+
+void main() {
+  test('clear discards cached instances', () {
+    final discarded = <int>[];
+    final pool = ObjectPool<int>(
+      () => 0,
+      onDiscard: discarded.add,
+    );
+
+    pool.release(1);
+    pool.release(2);
+
+    pool.clear();
+
+    expect(discarded, [1, 2]);
+    expect(pool.items, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- call onDiscard for every cached instance when clearing an ObjectPool
- release pooled components and bookkeeping when disposing PoolManager
- test that clearing a pool triggers discard callbacks

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c0107a97788330844ad4f52285b895