### PR TITLE
docs: expand plan for nebula and galaxy overlays

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -200,10 +200,13 @@ tree spanning weapons and ship systems.
   while circles draw faint-to-bright. A `debugDrawTiles` switch outlines tile
   boundaries when debug mode (`F1`) is active for troubleshooting.
 - Optional nebula or distant galaxy layers may overlay this starfield to add
-  ambience. Nebulae could be noise-generated sprites cached per tile, while a
-  far galaxy may draw as a single bitmap with slow parallax. Each overlay would
-  be toggleable in the settings and render behind gameplay but above the
-  starfield to keep existing tiles untouched.
+  ambience.
+  - Nebulae reuse the starfield's tile worker to generate noise-based sprites
+    and expose brightness/density sliders.
+  - A far galaxy draws as a single bitmap with subtle parallax and optional
+    tint.
+  - Settings toggles control visibility, and overlays hide when debug mode is
+    disabled so existing tiles stay untouched.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,9 +151,11 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
   blending. A weighted size/brightness distribution with subtle colour jitter
   adds variety, and layered parallax with gentle alpha twinkling adds depth.
   - Optional nebula or distant galaxy overlays may render above this starfield to
-    enrich the backdrop without altering the tile-based generation. These
-    overlays could use noise-generated sprites or large bitmaps and expose
-    toggles in the settings overlay.
+    enrich the backdrop without altering the tile-based generation.
+    - `NebulaLayer` renders noise-generated sprites per tile using the existing
+      cache worker and exposes brightness/density sliders.
+    - A distant galaxy overlay draws a low‑resolution bitmap with subtle parallax.
+    - Both layers toggle via the settings menu and respect debug mode flags.
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple
   object pools to reduce garbage collection overhead

--- a/TASKS.md
+++ b/TASKS.md
@@ -124,6 +124,10 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 ## Background Enhancements
 
 - [ ] Add an optional noise-generated nebula layer rendered above the starfield.
+      - Generate nebula sprites per tile in a background isolate and cache them.
+      - Expose brightness and density controls.
 - [ ] Add an optional distant galaxy bitmap overlay with subtle parallax.
-- [ ] Expose settings toggles and density/brightness sliders for these
-      overlays.
+      - Load via the `Assets` registry and draw behind gameplay.
+      - Support tint/alpha adjustments.
+- [ ] Expose settings toggles and density/brightness sliders for these overlays.
+      - Ensure overlays hide when debug mode is disabled.

--- a/lib/components/nebula_layer.md
+++ b/lib/components/nebula_layer.md
@@ -14,11 +14,17 @@ sample galaxy image while keeping the deterministic starfield intact.
 ## Implementation Notes
 
 - Expose brightness and density controls alongside existing starfield settings.
-- Nebula tiles can reuse the starfield's caching system and background isolate
-  to avoid frame spikes.
+- Nebula tiles reuse the starfield's caching system and background isolate to
+  avoid frame spikes. Sprites may be 512×512 noise textures tinted at load time.
 - Galaxy bitmap loads through `Assets` and draws with a fixed offset for a slow
-  parallax effect.
+  parallax effect. Multiple bitmaps could randomise orientation.
 - Component priority sits between the starfield and gameplay components so
   overlays appear behind action but above stars.
 - All layers must respect debugging controls and hide when the game's debug mode
   is disabled.
+
+## Open Questions
+
+- Which noise algorithm and parameters produce appealing nebula patterns?
+- How should colour palettes be chosen or themed?
+- Should the galaxy overlay support animation or multiple variants?

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -35,6 +35,8 @@ Deterministic parallax starfield rendered by `StarfieldComponent`.
 ## Future Enhancements
 
 - Optional nebula or distant galaxy overlays may draw above the starfield to
-  add ambience while leaving the deterministic tiles untouched. These overlays
-  could use noise-generated sprites or a pre-rendered bitmap and expose
-  toggles and density controls in the settings overlay.
+  add ambience while leaving the deterministic tiles untouched.
+  - `NebulaLayer` generates noise-based sprites per tile with brightness and
+    density sliders.
+  - A distant galaxy overlay draws a large bitmap with subtle parallax.
+  - Settings menu controls toggle these layers and adjust their intensity.


### PR DESCRIPTION
## Summary
- expand roadmap for optional nebula and galaxy background overlays
- outline background enhancement tasks with implementation notes
- document open questions around noise generation, palettes and galaxy assets

## Testing
- `./scripts/dartw format lib/components/starfield.dart`
- `./scripts/dartw analyze`
- `./scripts/dartw test` *(fails: invalid-type patterns in Flutter packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c00ff5ed7c83309f1531d171b093e4