### PR TITLE
docs: outline nebula and galaxy overlay layers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -201,12 +201,12 @@ tree spanning weapons and ship systems.
   boundaries when debug mode (`F1`) is active for troubleshooting.
 - Optional nebula or distant galaxy layers may overlay this starfield to add
   ambience.
-  - Nebulae reuse the starfield's tile worker to generate noise-based sprites
-    and expose brightness/density sliders.
-  - A far galaxy draws as a single bitmap with subtle parallax and optional
+  - `NebulaLayer` reuses the starfield's tile worker to generate noise-based
+    sprites and expose brightness/density sliders.
+  - `GalaxyLayer` draws a single bitmap with subtle parallax and optional
     tint.
-  - Settings toggles control visibility, and overlays hide when debug mode is
-    disabled so existing tiles stay untouched.
+  - Settings toggles control visibility, overlays hide when debug mode is
+    disabled, and each component can land independently.
 
 ## Assets
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -154,7 +154,9 @@ in sync, and tasks are broken down in the milestone docs and consolidated in
     enrich the backdrop without altering the tile-based generation.
     - `NebulaLayer` renders noise-generated sprites per tile using the existing
       cache worker and exposes brightness/density sliders.
-    - A distant galaxy overlay draws a low‑resolution bitmap with subtle parallax.
+    - `GalaxyLayer` draws a low-resolution bitmap with subtle parallax and
+      optional tint.
+    - Each layer is an independent component so work can land incrementally.
     - Both layers toggle via the settings menu and respect debug mode flags.
 - Aim for 60 FPS and avoid heavy per‑frame allocations
 - For frequently spawned objects, bullets, asteroids and enemies use simple

--- a/TASKS.md
+++ b/TASKS.md
@@ -123,11 +123,13 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 ## Background Enhancements
 
-- [ ] Add an optional noise-generated nebula layer rendered above the starfield.
-      - Generate nebula sprites per tile in a background isolate and cache them.
+- [ ] Implement `NebulaLayer` component rendered above the starfield.
+      - Generate nebula textures per tile in a background isolate and cache them.
       - Expose brightness and density controls.
-- [ ] Add an optional distant galaxy bitmap overlay with subtle parallax.
+      - Hide when debug mode is off.
+- [ ] Implement `GalaxyLayer` component with a distant bitmap and subtle parallax.
       - Load via the `Assets` registry and draw behind gameplay.
-      - Support tint/alpha adjustments.
-- [ ] Expose settings toggles and density/brightness sliders for these overlays.
+      - Support tint/alpha adjustments and randomised orientation.
+- [ ] Expose settings toggles and sliders for these overlays.
+      - Changes should rebuild layers and persist via `SettingsService`.
       - Ensure overlays hide when debug mode is disabled.

--- a/lib/components/README.md
+++ b/lib/components/README.md
@@ -51,8 +51,9 @@ Gameplay entities and reusable pieces.
 
 ## Planned Components
 
-- [NebulaLayer](nebula_layer.md) – optional noise-generated nebula sprites or a
-  distant galaxy bitmap that overlays the starfield and exposes toggles for
-  visibility and density in the settings overlay.
+- [NebulaLayer](nebula_layer.md) – noise-generated nebula sprites cached per
+  tile with brightness and density settings.
+- [GalaxyLayer](galaxy_layer.md) – distant galaxy bitmap with subtle parallax
+  and tint controls.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/components/galaxy_layer.md
+++ b/lib/components/galaxy_layer.md
@@ -1,0 +1,23 @@
+# GalaxyLayer
+
+Optional overlay that displays a distant galaxy bitmap to add depth beyond the starfield.
+
+## Goals
+
+- Draw a subtle parallax galaxy behind gameplay but above the starfield.
+- Allow toggling visibility from the settings overlay.
+- Support tint and opacity controls.
+
+## Implementation Notes
+
+- Load one or more low-resolution galaxy images through `Assets`.
+- Apply a slight parallax offset based on camera movement.
+- Component priority sits between the starfield and gameplay components so the overlay stays behind action but above stars.
+- Hide the layer when debug mode is disabled so starfield tiles remain clear.
+- If multiple images ship, select one at random on start.
+
+## Open Questions
+
+- What resolution keeps download size small without looking blurry?
+- Should multiple galaxy bitmaps be blended or animated?
+- How should the layer interact with nebula overlays if both are enabled?

--- a/lib/components/nebula_layer.md
+++ b/lib/components/nebula_layer.md
@@ -1,30 +1,25 @@
 # NebulaLayer
 
-Optional overlay component that enriches the background with nebulae or a distant
-sample galaxy image while keeping the deterministic starfield intact.
+Optional overlay component that enriches the background with noise-generated
+nebulae while keeping the deterministic starfield intact.
 
 ## Goals
 
 - Render additional ambience above the starfield but below gameplay.
-- Allow toggling overlays via the settings overlay.
-- Support two sources:
-  - Noise-generated nebula sprites cached per tile.
-  - A large, low-resolution galaxy bitmap with subtle parallax.
+- Allow enabling or disabling via the settings overlay.
+- Generate nebula sprites per tile in a background isolate and cache them.
 
 ## Implementation Notes
 
 - Expose brightness and density controls alongside existing starfield settings.
-- Nebula tiles reuse the starfield's caching system and background isolate to
-  avoid frame spikes. Sprites may be 512×512 noise textures tinted at load time.
-- Galaxy bitmap loads through `Assets` and draws with a fixed offset for a slow
-  parallax effect. Multiple bitmaps could randomise orientation.
-- Component priority sits between the starfield and gameplay components so
-  overlays appear behind action but above stars.
-- All layers must respect debugging controls and hide when the game's debug mode
-  is disabled.
+- Nebula tiles reuse the starfield's cache worker to avoid frame spikes. Sprites
+  may be 512×512 noise textures tinted at load time.
+- Component priority sits between the starfield and gameplay components so the
+  layer appears behind action but above stars.
+- Debug mode should hide the layer unless explicitly toggled for clarity.
 
 ## Open Questions
 
 - Which noise algorithm and parameters produce appealing nebula patterns?
-- How should colour palettes be chosen or themed?
-- Should the galaxy overlay support animation or multiple variants?
+- Should palettes match the starfield's `StarPalette` or provide independent themes?
+- How much memory does caching nebula tiles consume, and is an explicit LRU cap needed?

--- a/lib/components/starfield.md
+++ b/lib/components/starfield.md
@@ -38,5 +38,6 @@ Deterministic parallax starfield rendered by `StarfieldComponent`.
   add ambience while leaving the deterministic tiles untouched.
   - `NebulaLayer` generates noise-based sprites per tile with brightness and
     density sliders.
-  - A distant galaxy overlay draws a large bitmap with subtle parallax.
+  - `GalaxyLayer` draws a low-resolution bitmap with subtle parallax and
+    optional tint.
   - Settings menu controls toggle these layers and adjust their intensity.


### PR DESCRIPTION
## Summary
- document optional NebulaLayer and GalaxyLayer overlays above the starfield
- expand PLAN and TASKS with separate steps for nebula and galaxy components
- note independent delivery of overlays in design and starfield docs

## Testing
- `dart format lib/components/starfield.dart`
- `./scripts/dartw analyze`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68c137ffacf88330832132caacf2d32b