### PR TITLE
refactor: simplify StorageService generics

### DIFF
--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -24,24 +24,23 @@ class StorageService {
   /// Supported types are [int], [double], [bool], [String] and
   /// [List]<[String]>. Throws [UnsupportedError] for unsupported types.
   T getValue<T>(String key, T defaultValue) {
-    switch (defaultValue) {
-      case int _:
-        final value = _prefs.getInt(key);
-        return (value is int ? value : defaultValue) as T;
-      case double _:
-        final value = _prefs.getDouble(key);
-        return (value is double ? value : defaultValue) as T;
-      case bool _:
-        final value = _prefs.getBool(key);
-        return (value is bool ? value : defaultValue) as T;
-      case String _:
-        final value = _prefs.getString(key);
-        return (value is String ? value : defaultValue) as T;
-      case List<String> _:
-        final value = _prefs.getStringList(key);
-        return (value is List<String> ? value : defaultValue) as T;
-      default:
-        throw UnsupportedError('Type $T is not supported');
+    if (T == int) {
+      final value = _prefs.getInt(key);
+      return (value ?? defaultValue) as T;
+    } else if (T == double) {
+      final value = _prefs.getDouble(key);
+      return (value ?? defaultValue) as T;
+    } else if (T == bool) {
+      final value = _prefs.getBool(key);
+      return (value ?? defaultValue) as T;
+    } else if (T == String) {
+      final value = _prefs.getString(key);
+      return (value ?? defaultValue) as T;
+    } else if (T == List<String>) {
+      final value = _prefs.getStringList(key);
+      return (value ?? defaultValue) as T;
+    } else {
+      throw UnsupportedError('Type $T is not supported');
     }
   }
 

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -45,6 +45,15 @@ void main() {
       expect(storage.getString('name', ''), 'Alice');
     });
 
+    test('generic get/set handles double and bool', () async {
+      SharedPreferences.setMockInitialValues({});
+      final storage = await StorageService.create();
+      expect(await storage.setValue<double>('volume', 0.5), isTrue);
+      expect(storage.getValue<double>('volume', 0), 0.5);
+      expect(await storage.setValue<bool>('muted', true), isTrue);
+      expect(storage.getValue<bool>('muted', false), isTrue);
+    });
+
     test('high score persists across instances', () async {
       SharedPreferences.setMockInitialValues({});
       var storage = await StorageService.create();


### PR DESCRIPTION
## Summary
- streamline StorageService.getValue with type-based checks
- test StorageService generic getters for bool and double values

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68c1374450d08330bd685950e7e8db98