### PR TITLE
refactor: streamline event bus filtering

### DIFF
--- a/lib/game/event_bus.dart
+++ b/lib/game/event_bus.dart
@@ -20,8 +20,7 @@ class GameEventBus {
   void emit(GameEvent event) => _controller.add(event);
 
   /// Returns a stream of events of type [T].
-  Stream<T> on<T extends GameEvent>() =>
-      _controller.stream.where((event) => event is T).cast<T>();
+  Stream<T> on<T extends GameEvent>() => _controller.stream.whereType<T>();
 
   /// Closes the underlying stream controller.
   void dispose() {
@@ -39,4 +38,10 @@ class ComponentSpawnEvent<T> implements GameEvent {
 class ComponentRemoveEvent<T> implements GameEvent {
   ComponentRemoveEvent(this.component);
   final T component;
+}
+
+extension GameEventStreamX on Stream<GameEvent> {
+  /// Returns a stream of events of type [T].
+  Stream<T> whereType<T extends GameEvent>() =>
+      where((event) => event is T).cast<T>();
 }


### PR DESCRIPTION
## Summary
- simplify GameEventBus type filtering with a stream extension
- tidy the event bus API to better match documented whereType usage

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c1374450d08330bd685950e7e8db98