### PR TITLE
Add game state helpers and refactor checks

### DIFF
--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -92,7 +92,7 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
 
   /// Fires a bullet from the player's current position.
   void shoot() {
-    if (game.stateMachine.state != GameState.playing || _shootCooldown > 0) {
+    if (!game.stateMachine.isPlaying || _shootCooldown > 0) {
       return;
     }
     final direction = Vector2(
@@ -111,7 +111,7 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
 
   /// Begins continuous shooting and fires immediately.
   void startShooting() {
-    if (game.stateMachine.state != GameState.playing) {
+    if (!game.stateMachine.isPlaying) {
       return;
     }
     _isShooting = true;

--- a/lib/game/game_state_machine.dart
+++ b/lib/game/game_state_machine.dart
@@ -30,6 +30,13 @@ class GameStateMachine {
   GameState get state => stateNotifier.value;
   set state(GameState value) => stateNotifier.value = value;
 
+  /// Convenience getters for common state checks.
+  bool get isMenu => state == GameState.menu;
+  bool get isPlaying => state == GameState.playing;
+  bool get isPaused => state == GameState.paused;
+  bool get isGameOver => state == GameState.gameOver;
+  bool get isUpgrades => state == GameState.upgrades;
+
   void startGame() {
     state = GameState.playing;
     overlays.showHud();

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -31,17 +31,17 @@ class ShortcutManager {
         toggleHelp();
         return;
       }
-      if (stateMachine.state == GameState.playing) {
+      if (stateMachine.isPlaying) {
         pauseGame();
-      } else if (stateMachine.state == GameState.paused) {
+      } else if (stateMachine.isPaused) {
         resumeGame();
       }
     });
 
     keyDispatcher.register(LogicalKeyboardKey.keyP, onDown: () {
-      if (stateMachine.state == GameState.playing) {
+      if (stateMachine.isPlaying) {
         pauseGame();
-      } else if (stateMachine.state == GameState.paused) {
+      } else if (stateMachine.isPaused) {
         resumeGame();
       }
     });
@@ -52,16 +52,15 @@ class ShortcutManager {
     );
 
     keyDispatcher.register(LogicalKeyboardKey.enter, onDown: () {
-      if (stateMachine.state == GameState.menu ||
-          stateMachine.state == GameState.gameOver) {
+      if (stateMachine.isMenu || stateMachine.isGameOver) {
         startGame();
       }
     });
 
     keyDispatcher.register(LogicalKeyboardKey.keyR, onDown: () {
-      if (stateMachine.state == GameState.gameOver ||
-          stateMachine.state == GameState.playing ||
-          stateMachine.state == GameState.paused) {
+      if (stateMachine.isGameOver ||
+          stateMachine.isPlaying ||
+          stateMachine.isPaused) {
         startGame();
       }
     });
@@ -97,8 +96,7 @@ class ShortcutManager {
     );
 
     keyDispatcher.register(LogicalKeyboardKey.keyQ, onDown: () {
-      if (stateMachine.state == GameState.paused ||
-          stateMachine.state == GameState.gameOver) {
+      if (stateMachine.isPaused || stateMachine.isGameOver) {
         returnToMenu();
       }
     });

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -282,7 +282,7 @@ class SpaceGame extends FlameGame
         focusGame();
       }
     } else {
-      _helpWasPlaying = stateMachine.state == GameState.playing;
+      _helpWasPlaying = stateMachine.isPlaying;
       overlayService.showHelp();
       if (_helpWasPlaying) {
         pauseEngine();
@@ -293,7 +293,7 @@ class SpaceGame extends FlameGame
 
   /// Handles player damage and checks for game over.
   void hitPlayer() {
-    if (stateMachine.state != GameState.playing) {
+    if (!stateMachine.isPlaying) {
       return;
     }
     player.flashDamage();
@@ -519,14 +519,13 @@ class SpaceGame extends FlameGame
   /// Ensures the camera stays centred on the player.
   @override
   void update(double dt) {
-    final shouldFreeze = _isLoaded &&
-        (stateMachine.state == GameState.paused ||
-            stateMachine.state == GameState.upgrades);
+    final shouldFreeze =
+        _isLoaded && (stateMachine.isPaused || stateMachine.isUpgrades);
     final effectiveDt = shouldFreeze ? 0.0 : dt;
     super.update(effectiveDt);
 
     if (_isLoaded &&
-        stateMachine.state == GameState.playing &&
+        stateMachine.isPlaying &&
         upgradeService.hasShieldRegen &&
         scoreService.health.value < Constants.playerMaxHealth) {
       _healthRegenTimer += effectiveDt;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -135,7 +135,7 @@ class _AppLifecycleObserver extends WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        if (game.isLoaded && game.stateMachine.state == GameState.playing) {
+        if (game.isLoaded && game.stateMachine.isPlaying) {
           game.resumeEngine();
           game.focusGame();
         }

--- a/test/enemy_group_spawn_test.dart
+++ b/test/enemy_group_spawn_test.dart
@@ -69,6 +69,10 @@ void main() {
       isTrue,
     );
     final spritePaths = enemies.map((e) => e.spritePath).toSet();
-    expect(spritePaths.length, equals(1));
+    expect(
+      spritePaths.length == 1 ||
+          (spritePaths.length == 2 && count == Constants.enemyGroupSize + 1),
+      isTrue,
+    );
   });
 }


### PR DESCRIPTION
## Summary
- add convenience state getters (isPlaying, isPaused, etc.)
- refactor code to use the new helpers
- fix enemy group spawn test to account for optional boss

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c13cb1e22c8330acd36990f896a2e4