### PR TITLE
docs: track SpaceGame refactor tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -133,3 +133,10 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [ ] Expose settings toggles and sliders for these overlays.
       - Changes should rebuild layers and persist via `SettingsService`.
       - Ensure overlays hide when debug mode is disabled.
+
+## Refactoring
+
+- [ ] Decouple starfield setup and rebuild logic into a dedicated starfield manager or service to reduce `SpaceGame` complexity.
+- [ ] Move joystick, fire button and scaling input code into a `ControlManager` so `SpaceGame` focuses on orchestration.
+- [ ] Extract debug-mode toggling into a reusable `DebugController` mixin or utility.
+- [ ] Shift asset loading plus pause/resume handlers to a lifecycle/asset loader service instead of keeping them in `SpaceGame`.


### PR DESCRIPTION
## Summary
- add refactoring TODOs for splitting SpaceGame responsibilities

## Testing
- `./scripts/dartw format lib test`
- `./scripts/dartw analyze` (4 warnings)
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c27c0dd2488330bf3b49998bcb320e