### PR TITLE
Remove unused imports for clean analyze run

### DIFF
--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -5,7 +5,6 @@ import 'package:flutter/services.dart';
 
 import '../constants.dart';
 import '../game/key_dispatcher.dart';
-import '../game/game_state.dart';
 import '../game/space_game.dart';
 import 'bullet.dart';
 import 'player.dart';

--- a/lib/game/shortcut_manager.dart
+++ b/lib/game/shortcut_manager.dart
@@ -2,7 +2,6 @@ import 'package:flutter/services.dart';
 
 import '../services/audio_service.dart';
 import 'game_state_machine.dart';
-import 'game_state.dart';
 import 'key_dispatcher.dart';
 
 /// Registers global keyboard shortcuts and wires them to actions.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -31,7 +31,6 @@ import '../theme/star_palette.dart';
 import '../ui/help_overlay.dart';
 import '../ui/settings_overlay.dart';
 import 'event_bus.dart';
-import 'game_state.dart';
 import 'pool_manager.dart';
 import 'lifecycle_manager.dart';
 import 'shortcut_manager.dart' as game_shortcuts;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 import 'assets.dart';
 import 'game/space_game.dart';
-import 'game/game_state.dart';
 import 'theme/game_theme.dart';
 import 'ui/game_over_overlay.dart';
 import 'ui/hud_overlay.dart';


### PR DESCRIPTION
## Summary
- remove unused `game_state.dart` imports from player input, shortcut manager, space game, and main

## Testing
- `scripts/flutterw analyze --no-pub`
- `scripts/flutterw test --no-pub`


------
https://chatgpt.com/codex/tasks/task_e_68c283eea8b4833090deb9c85468a9ae