### PR TITLE
Add PoolManager lifecycle and responsive layout tests

### DIFF
--- a/test/pool_manager_test.dart
+++ b/test/pool_manager_test.dart
@@ -1,0 +1,90 @@
+import 'package:flame/components.dart';
+import 'package:flame/flame.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/components/asteroid.dart';
+import 'package:space_game/components/bullet.dart';
+import 'package:space_game/game/event_bus.dart';
+import 'package:space_game/game/pool_manager.dart';
+import 'package:space_game/assets.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PoolManager', () {
+    test('acquire, release via event and clear lifecycle', () {
+      final events = GameEventBus();
+      final pools = PoolManager(events: events);
+
+      final bullet = pools.acquire<BulletComponent>(
+          (b) => b.reset(Vector2.zero(), Vector2.zero()));
+      expect(pools.components<BulletComponent>(), contains(bullet));
+
+      events.emit(ComponentRemoveEvent<BulletComponent>(bullet));
+      expect(pools.components<BulletComponent>(), isEmpty);
+
+      final reused = pools.acquire<BulletComponent>(
+          (b) => b.reset(Vector2.zero(), Vector2.zero()));
+      expect(identical(reused, bullet), isTrue);
+
+      pools.clear();
+      expect(pools.components<BulletComponent>(), isEmpty);
+    });
+
+    test('asteroid grid queries and updates', () async {
+      final events = GameEventBus();
+      final pools = PoolManager(events: events);
+      await Flame.images.loadAll(Assets.asteroids);
+
+      final asteroid = pools.acquire<AsteroidComponent>(
+          (a) => a.reset(Vector2.zero(), Vector2.zero()));
+      expect(pools.nearbyAsteroids(Vector2.zero(), 100), contains(asteroid));
+
+      final previous = asteroid.position.clone();
+      asteroid.position = Vector2(400, 0);
+      pools.updateAsteroidPosition(asteroid, previous);
+
+      expect(pools.nearbyAsteroids(Vector2.zero(), 100), isEmpty);
+      expect(pools.nearbyAsteroids(Vector2(400, 0), 100), contains(asteroid));
+
+      pools.release(asteroid);
+      expect(pools.nearbyAsteroids(Vector2(400, 0), 100), isEmpty);
+
+      final second = pools.acquire<AsteroidComponent>(
+          (a) => a.reset(Vector2.zero(), Vector2.zero()));
+      expect(pools.nearbyAsteroids(Vector2.zero(), 100), contains(second));
+      pools.clear();
+      expect(pools.nearbyAsteroids(Vector2.zero(), 100), isEmpty);
+    });
+
+    test('applyDebugMode propagates to pooled components', () async {
+      final events = GameEventBus();
+      final pools = PoolManager(events: events);
+      await Flame.images.load(Assets.bullet);
+
+      final bullet = pools.acquire<BulletComponent>(
+          (b) => b.reset(Vector2.zero(), Vector2.zero()));
+      final child = Component();
+      await bullet.add(child);
+      bullet.updateTree(0);
+
+      pools.release(bullet);
+      expect(bullet.debugMode, isFalse);
+      expect(child.debugMode, isFalse);
+
+      pools.applyDebugMode(true);
+      expect(bullet.debugMode, isTrue);
+      expect(child.debugMode, isTrue);
+
+      final reused = pools.acquire<BulletComponent>(
+          (b) => b.reset(Vector2.zero(), Vector2.zero()));
+      expect(identical(reused, bullet), isTrue);
+      expect(reused.debugMode, isTrue);
+      expect(child.debugMode, isTrue);
+
+      pools.applyDebugMode(false);
+      expect(reused.debugMode, isFalse);
+      expect(child.debugMode, isFalse);
+    });
+  });
+}

--- a/test/responsive_icon_size_test.dart
+++ b/test/responsive_icon_size_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/ui/responsive.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('responsiveIconSize', () {
+    test('returns base size on phones', () {
+      final constraints = BoxConstraints.tight(const Size(500, 800));
+      expect(responsiveIconSize(constraints), 24);
+    });
+
+    test('doubles size on tablets', () {
+      final constraints = BoxConstraints.tight(const Size(600, 800));
+      expect(responsiveIconSize(constraints), 48);
+    });
+
+    test('triples size on desktops', () {
+      final constraints = BoxConstraints.tight(const Size(900, 1200));
+      expect(responsiveIconSize(constraints), 72);
+    });
+
+    test('honors custom base size', () {
+      final constraints = BoxConstraints.tight(const Size(900, 1200));
+      expect(responsiveIconSize(constraints, base: 30), 90);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add PoolManager unit tests for lifecycle, asteroid grid queries and debug flag propagation
- test responsiveIconSize breakpoints for phone, tablet and desktop sizes

## Testing
- `./scripts/flutterw test test/pool_manager_test.dart test/responsive_icon_size_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68c2a2ba6d4083308d0c2cae84c26975