### PR TITLE
chore: remove unused import from StarfieldManager

### DIFF
--- a/lib/game/starfield_manager.dart
+++ b/lib/game/starfield_manager.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 
 import '../components/starfield.dart';


### PR DESCRIPTION
## Summary
- remove unused Flame components import in StarfieldManager

## Testing
- `scripts/flutterw analyze --no-pub`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2aaf15e3c8330be2c08403a6bf7b8