### PR TITLE
Refactor on-screen controls into ControlManager

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -137,9 +137,9 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 ## Refactoring
 
 - [x] Decouple starfield setup and rebuild logic into a dedicated starfield manager or service to reduce `SpaceGame` complexity.
-- [ ] Move joystick, fire button and scaling input code into a `ControlManager` so `SpaceGame` focuses on orchestration.
-  - [ ] Extract joystick and fire button construction into `ControlManager`.
-  - [ ] Update references and tests for `ControlManager`.
+- [x] Move joystick, fire button and scaling input code into a `ControlManager` so `SpaceGame` focuses on orchestration.
+  - [x] Extract joystick and fire button construction into `ControlManager`.
+  - [x] Update references and tests for `ControlManager`.
 - [ ] Extract debug-mode toggling into a reusable `DebugController` mixin or utility.
   - [ ] Implement `DebugController` mixin.
   - [ ] Apply mixin to `SpaceGame` and related components.

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -9,7 +9,8 @@ Core game class and shared systems.
 - Uses the default camera viewport so the game fills the available
   browser window.
 - Timer-based spawners generate enemies and asteroids.
-  - Input uses Flame's `JoystickComponent`, `ButtonComponent` and a
+  - On-screen controls are handled by `ControlManager`, which builds and
+    scales Flame's `JoystickComponent` and `ButtonComponent` alongside a
     custom `KeyDispatcher` (via `KeyboardHandler`) that supports helpers like
     `isAnyPressed` for grouped key queries.
 - Broadcasts component spawn and remove events through a lightweight
@@ -37,5 +38,7 @@ Core game class and shared systems.
 - [game_state.dart](game_state.md) – enum describing the game's phases.
 - [event_bus.dart](event_bus.md) – typed hub for spawn/remove events.
 - [pool_manager.dart](pool_manager.md) – central object pools and spatial grid.
+- [control_manager.dart](control_manager.dart) – manages joystick and fire
+  button controls.
 
 See [../../PLAN.md](../../PLAN.md) for the broader roadmap.

--- a/lib/game/control_manager.dart
+++ b/lib/game/control_manager.dart
@@ -1,0 +1,120 @@
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+import 'package:flame/input.dart';
+import 'package:flutter/painting.dart' show EdgeInsets;
+import 'package:flutter/material.dart' show ColorScheme;
+
+import '../components/player.dart';
+import '../services/settings_service.dart';
+
+/// Manages on-screen controls like the joystick and fire button.
+///
+/// Listens for [SettingsService.joystickScale] updates to resize controls
+/// without recreating them.
+class ControlManager {
+  ControlManager({
+    required this.game,
+    required this.settings,
+    required this.colorScheme,
+  });
+
+  /// Host game used to mount control components.
+  final FlameGame game;
+
+  /// Provides runtime-adjustable control scale.
+  final SettingsService settings;
+
+  /// Colours used to style the joystick and fire button.
+  final ColorScheme colorScheme;
+
+  late JoystickComponent _joystick;
+  JoystickComponent get joystick => _joystick;
+  set joystick(JoystickComponent value) => _joystick = value;
+
+  HudButtonComponent? fireButton;
+
+  /// Builds and adds the joystick to the game.
+  Future<void> init() async {
+    _joystick = _buildJoystick();
+    await game.add(_joystick);
+    settings.joystickScale.addListener(_updateJoystickScale);
+  }
+
+  /// Builds and adds the fire button once the [player] is ready.
+  Future<void> attachPlayer(PlayerComponent player) async {
+    fireButton = _buildFireButton(settings.joystickScale.value, player);
+    await game.add(fireButton!);
+  }
+
+  JoystickComponent _buildJoystick() {
+    final scale = settings.joystickScale.value;
+    final scheme = colorScheme;
+    return JoystickComponent(
+      knob: CircleComponent(
+        radius: 20 * scale,
+        paint: Paint()..color = scheme.primary,
+      ),
+      background: CircleComponent(
+        radius: 50 * scale,
+        paint: Paint()..color = scheme.primary.withValues(alpha: 0.4),
+      ),
+      margin: const EdgeInsets.only(left: 40, bottom: 40),
+    )..anchor = Anchor.bottomLeft;
+  }
+
+  HudButtonComponent _buildFireButton(double scale, PlayerComponent player) {
+    final scheme = colorScheme;
+    return HudButtonComponent(
+      button: CircleComponent(
+        radius: 30 * scale,
+        paint: Paint()..color = scheme.primary.withValues(alpha: 0.4),
+      ),
+      buttonDown: CircleComponent(
+        radius: 30 * scale,
+        paint: Paint()..color = scheme.primary,
+      ),
+      anchor: Anchor.bottomRight,
+      margin: const EdgeInsets.only(right: 40, bottom: 40),
+      onPressed: player.startShooting,
+      onReleased: player.stopShooting,
+      onCancelled: player.stopShooting,
+    )..size = Vector2.all(60 * scale);
+  }
+
+  void _updateJoystickScale() {
+    final scale = settings.joystickScale.value;
+    final bg = _joystick.background as CircleComponent;
+    final knob = _joystick.knob as CircleComponent;
+    bg
+      ..radius = 50 * scale
+      ..position = Vector2.zero();
+    knob
+      ..radius = 20 * scale
+      ..position = Vector2.zero();
+    _joystick
+      ..size = Vector2.all(100 * scale)
+      ..knobRadius = 20 * scale
+      ..anchor = Anchor.bottomLeft
+      ..position = Vector2(40, game.size.y - 40);
+    _joystick.onGameResize(game.size);
+
+    final fb = fireButton;
+    if (fb != null) {
+      (fb.button as CircleComponent).radius = 30 * scale;
+      (fb.buttonDown as CircleComponent).radius = 30 * scale;
+      fb
+        ..size = Vector2.all(60 * scale)
+        ..anchor = Anchor.bottomRight;
+      fb.onGameResize(game.size);
+    }
+  }
+
+  /// Cleans up listeners and removes controls from the game.
+  void dispose() {
+    settings.joystickScale.removeListener(_updateJoystickScale);
+    _joystick.removeFromParent();
+    fireButton?.removeFromParent();
+  }
+}

--- a/lib/game/lifecycle_manager.dart
+++ b/lib/game/lifecycle_manager.dart
@@ -34,7 +34,7 @@ class LifecycleManager {
     if (game.player.isRemoving || !game.player.isMounted) {
       // Previous player is pending removal; create a fresh instance.
       final player = PlayerComponent(
-        joystick: game.joystick,
+        joystick: game.controlManager.joystick,
         keyDispatcher: game.keyDispatcher,
         spritePath: game.selectedPlayerSprite,
       )..reset();
@@ -51,7 +51,7 @@ class LifecycleManager {
       game.miningLaser = laser;
       game.add(laser);
       // Update fire button callbacks.
-      game.fireButton
+      game.controlManager.fireButton!
         ..onPressed = player.startShooting
         ..onReleased = player.stopShooting;
     } else {

--- a/lib/game/space_game.md
+++ b/lib/game/space_game.md
@@ -12,7 +12,8 @@ Main FlameGame subclass managing world setup, state transitions and the update l
 - Provide small bullet, asteroid, enemy and mineral pickup pools to limit allocations.
 - Maintain `GameState` values (`menu`, `playing`, `paused`, `gameOver`)
    and toggle overlays.
-- Route joystick, button and keyboard input to the player component.
+- Delegate joystick and fire button handling to `ControlManager` and route
+  keyboard input to the player component.
 - Handle keyboard shortcuts such as `Escape` or `P` for pause, `M` for mute,
    `Enter` to start or restart from the menu or game over, `R` to restart at any
    time, `Q` to return to the menu from pause or game over, `Esc` to return to the

--- a/lib/game/starfield_manager.dart
+++ b/lib/game/starfield_manager.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 
 import '../components/starfield.dart';

--- a/test/camera_behavior_test.dart
+++ b/test/camera_behavior_test.dart
@@ -41,7 +41,7 @@ void main() {
     final game = await _createGame();
     await game.ready();
     game.onGameResize(Vector2.all(100));
-    game.joystick.removeFromParent();
+    game.controlManager.joystick.removeFromParent();
     await game.ready();
     game.player.position.add(Vector2(10, 20));
     game.update(0);

--- a/test/joystick_fire_button_scale_test.dart
+++ b/test/joystick_fire_button_scale_test.dart
@@ -37,14 +37,14 @@ void main() {
     game.settingsService.joystickScale.value = 1.2;
     await Future<void>.delayed(Duration.zero);
 
-    final bg = game.joystick.background as CircleComponent;
-    final knob = game.joystick.knob as CircleComponent;
-    final fire = game.fireButton.button as CircleComponent;
+    final bg = game.controlManager.joystick.background as CircleComponent;
+    final knob = game.controlManager.joystick.knob as CircleComponent;
+    final fire = game.controlManager.fireButton!.button as CircleComponent;
     expect(bg.radius, 50 * 1.2);
     expect(knob.radius, 20 * 1.2);
     expect(fire.radius, 30 * 1.2);
-    expect(game.joystick.position.x, 40);
-    expect(game.joystick.position.y, game.size.y - 40);
-    expect(game.fireButton.anchor, Anchor.bottomRight);
+    expect(game.controlManager.joystick.position.x, 40);
+    expect(game.controlManager.joystick.position.y, game.size.y - 40);
+    expect(game.controlManager.fireButton!.anchor, Anchor.bottomRight);
   });
 }

--- a/test/player_input_behavior_test.dart
+++ b/test/player_input_behavior_test.dart
@@ -98,9 +98,14 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
-    await add(joystick);
-    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await controlManager.init();
+    controlManager.joystick.removeFromParent();
+    controlManager.joystick = TestJoystick();
+    await add(controlManager.joystick);
+    player = _TestPlayer(
+      joystick: controlManager.joystick,
+      keyDispatcher: keyDispatcher,
+    );
     await add(player);
     overlayService = OverlayService(this);
     stateMachine = GameStateMachine(
@@ -160,8 +165,8 @@ void main() {
       ),
       {LogicalKeyboardKey.keyW},
     );
-    game.joystick.delta.setValues(1, 0);
-    game.joystick.relativeDelta.setValues(1, 0);
+    game.controlManager.joystick.delta.setValues(1, 0);
+    game.controlManager.joystick.relativeDelta.setValues(1, 0);
     game.player.inputBehavior.update(1);
     expect(game.player.position.x, greaterThan(0));
     expect(game.player.position.y, closeTo(0, 0.001));
@@ -196,8 +201,8 @@ void main() {
     game.onGameResize(Vector2.all(500));
     await game.ready();
 
-    game.joystick.delta.setValues(1, 0);
-    game.joystick.relativeDelta.setValues(1, 0);
+    game.controlManager.joystick.delta.setValues(1, 0);
+    game.controlManager.joystick.relativeDelta.setValues(1, 0);
     game.player.inputBehavior.update(1);
     final normalX = game.player.position.x;
 
@@ -206,8 +211,8 @@ void main() {
         game.upgradeService.upgrades.firstWhere((u) => u.id == 'speed1');
     game.scoreService.addMinerals(upgrade.cost);
     game.upgradeService.buy(upgrade);
-    game.joystick.delta.setValues(1, 0);
-    game.joystick.relativeDelta.setValues(1, 0);
+    game.controlManager.joystick.delta.setValues(1, 0);
+    game.controlManager.joystick.relativeDelta.setValues(1, 0);
     game.player.inputBehavior.update(1);
     expect(game.player.position.x, greaterThan(normalX));
   });

--- a/test/player_reset_orientation_test.dart
+++ b/test/player_reset_orientation_test.dart
@@ -31,11 +31,11 @@ void main() {
     game.onGameResize(Vector2.all(100));
     await game.ready();
     game.resumeEngine();
-    game.joystick.removeFromParent();
-    game.joystick = TestJoystick();
-    await game.add(game.joystick);
+    game.controlManager.joystick.removeFromParent();
+    game.controlManager.joystick = TestJoystick();
+    await game.add(game.controlManager.joystick);
     game.player
-      ..setJoystick(game.joystick)
+      ..setJoystick(game.controlManager.joystick)
       ..resetInput();
     game.update(0);
     game.update(0);
@@ -46,8 +46,8 @@ void main() {
       ..position.setValues(20, 20);
 
     // Clear input before restarting.
-    game.joystick.delta.setZero();
-    game.joystick.relativeDelta.setZero();
+    game.controlManager.joystick.delta.setZero();
+    game.controlManager.joystick.relativeDelta.setZero();
 
     // Starting a new game should reset orientation and position.
     await game.startGame();

--- a/test/player_rotation_test.dart
+++ b/test/player_rotation_test.dart
@@ -60,9 +60,14 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
-    await add(joystick);
-    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await controlManager.init();
+    controlManager.joystick.removeFromParent();
+    controlManager.joystick = TestJoystick();
+    await add(controlManager.joystick);
+    player = _TestPlayer(
+      joystick: controlManager.joystick,
+      keyDispatcher: keyDispatcher,
+    );
     await add(player);
     player.inputBehavior.game = this;
   }
@@ -89,8 +94,8 @@ void main() {
     game.update(0);
 
     // Move down; target angle is pi.
-    game.joystick.delta.setValues(0, 1);
-    game.joystick.relativeDelta.setValues(0, 1);
+    game.controlManager.joystick.delta.setValues(0, 1);
+    game.controlManager.joystick.relativeDelta.setValues(0, 1);
     final input = game.player.inputBehavior;
     input.update(0.05);
     final angleAfterFirstUpdate = game.player.angle;
@@ -100,8 +105,8 @@ void main() {
     expect(angleAfterFirstUpdate, lessThan(math.pi));
 
     // Change direction upward before rotation completes.
-    game.joystick.delta.setValues(0, -1);
-    game.joystick.relativeDelta.setValues(0, -1);
+    game.controlManager.joystick.delta.setValues(0, -1);
+    game.controlManager.joystick.relativeDelta.setValues(0, -1);
     input.update(0.05);
     expect(game.player.angle, lessThan(angleAfterFirstUpdate));
 

--- a/test/player_shoot_cooldown_test.dart
+++ b/test/player_shoot_cooldown_test.dart
@@ -84,9 +84,14 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
-    await add(joystick);
-    player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
+    await controlManager.init();
+    controlManager.joystick.removeFromParent();
+    controlManager.joystick = TestJoystick();
+    await add(controlManager.joystick);
+    player = _TestPlayer(
+      joystick: controlManager.joystick,
+      keyDispatcher: keyDispatcher,
+    );
     await add(player);
   }
 }
@@ -108,7 +113,7 @@ void main() {
       ),
     );
     await game.ready();
-    game.joystick.onGameResize(game.size);
+    game.controlManager.joystick.onGameResize(game.size);
     game.update(0);
     game.update(0);
 

--- a/test/player_space_key_reregister_test.dart
+++ b/test/player_space_key_reregister_test.dart
@@ -37,8 +37,10 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
-    await add(joystick);
+    await controlManager.init();
+    controlManager.joystick.removeFromParent();
+    controlManager.joystick = TestJoystick();
+    await add(controlManager.joystick);
   }
 }
 
@@ -58,12 +60,12 @@ void main() {
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
     await game.ready();
-    game.joystick.onGameResize(game.size);
+    game.controlManager.joystick.onGameResize(game.size);
     game.update(0);
     game.update(0);
 
     final player = _TestPlayer(
-      joystick: game.joystick,
+      joystick: game.controlManager.joystick,
       keyDispatcher: game.keyDispatcher,
     );
     await game.add(player);


### PR DESCRIPTION
## Summary
- Extract on-screen joystick and fire button into a dedicated `ControlManager` that listens to settings changes and scales controls.
- Integrate `ControlManager` with `SpaceGame`, exposing getters for compatibility and simplifying lifecycle logic.
- Update lifecycle manager, documentation, and tests to use the new control manager, marking tasks as complete.

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2aa82f43c8330b93e63dae346a2b3