### PR TITLE
Refactor debug mode handling into reusable mixin

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -140,9 +140,9 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 - [x] Move joystick, fire button and scaling input code into a `ControlManager` so `SpaceGame` focuses on orchestration.
   - [x] Extract joystick and fire button construction into `ControlManager`.
   - [x] Update references and tests for `ControlManager`.
-- [ ] Extract debug-mode toggling into a reusable `DebugController` mixin or utility.
-  - [ ] Implement `DebugController` mixin.
-  - [ ] Apply mixin to `SpaceGame` and related components.
+- [x] Extract debug-mode toggling into a reusable `DebugController` mixin or utility.
+  - [x] Implement `DebugController` mixin.
+  - [x] Apply mixin to `SpaceGame` and related components.
 - [ ] Shift asset loading plus pause/resume handlers to a lifecycle/asset loader service instead of keeping them in `SpaceGame`.
   - [ ] Create `AssetLifecycleService` handling asset loading and pause/resume.
   - [ ] Refactor `SpaceGame` to use the service.

--- a/lib/game/debug_controller.dart
+++ b/lib/game/debug_controller.dart
@@ -1,0 +1,38 @@
+import 'package:flame/components.dart';
+import 'package:flame/game.dart';
+
+/// Mixin providing debug-mode toggling and propagation to all components.
+///
+/// When mixed into a [FlameGame], calling [toggleDebug] will update the game's
+/// [debugMode] flag and apply the change to all current descendants. Subclasses
+/// can override [onDebugModeChanged] to respond to debug mode updates.
+///
+/// This reduces duplication across game classes that need consistent debug
+/// handling.
+mixin DebugController on FlameGame {
+  /// Toggles the game's debug rendering state.
+  void toggleDebug() => _setDebug(!debugMode);
+
+  /// Sets the game's debug flag and propagates to existing components.
+  void _setDebug(bool enabled) {
+    debugMode = enabled;
+
+    // Propagate the new debug mode to all existing components so built-in
+    // debug visuals like hitboxes update immediately.
+    for (final child in children) {
+      _applyDebugMode(child, enabled);
+    }
+
+    onDebugModeChanged(enabled);
+  }
+
+  /// Hook for subclasses to respond to debug mode changes.
+  void onDebugModeChanged(bool enabled) {}
+
+  void _applyDebugMode(Component component, bool enabled) {
+    component.debugMode = enabled;
+    for (final child in component.children) {
+      _applyDebugMode(child, enabled);
+    }
+  }
+}

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -31,6 +31,7 @@ import 'lifecycle_manager.dart';
 import 'shortcut_manager.dart' as game_shortcuts;
 import 'starfield_manager.dart';
 import 'control_manager.dart';
+import 'debug_controller.dart';
 
 /// Root Flame game handling the core loop.
 ///
@@ -39,7 +40,7 @@ import 'control_manager.dart';
 /// standalone [KeyboardEvents] here would prevent that propagation, so it is
 /// intentionally omitted.
 class SpaceGame extends FlameGame
-    with HasKeyboardHandlerComponents, HasCollisionDetection {
+    with HasKeyboardHandlerComponents, HasCollisionDetection, DebugController {
   SpaceGame({
     required this.storageService,
     required this.audioService,
@@ -343,36 +344,21 @@ class SpaceGame extends FlameGame
   /// Transitions to the game over state.
   void gameOver() => stateMachine.gameOver();
 
-  /// Toggles debug rendering and FPS overlay.
-  void toggleDebug() {
-    debugMode = !debugMode;
-
-    // Propagate the new debug mode to all existing components so built-in
-    // debug visuals like hitboxes update immediately.
-    for (final child in children) {
-      _applyDebugMode(child, debugMode);
-    }
-
+  @override
+  void onDebugModeChanged(bool enabled) {
     // Ensure pooled components also reflect the new debug mode so reused
     // instances don't retain stale debug flags.
-    pools.applyDebugMode(debugMode);
+    pools.applyDebugMode(enabled);
 
     // Outline starfield tiles when debug visuals are enabled.
-    starfieldManager.updateDebug(debugMode);
+    starfieldManager.updateDebug(enabled);
 
-    if (debugMode) {
+    if (enabled) {
       if (_fpsText != null && !_fpsText!.isMounted) {
         add(_fpsText!);
       }
     } else {
       _fpsText?.removeFromParent();
-    }
-  }
-
-  void _applyDebugMode(Component component, bool enabled) {
-    component.debugMode = enabled;
-    for (final child in component.children) {
-      _applyDebugMode(child, enabled);
     }
   }
 


### PR DESCRIPTION
## Summary
- add `DebugController` mixin to centralize debug mode toggling
- apply mixin to `SpaceGame` and update task tracker

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test --reporter compact`


------
https://chatgpt.com/codex/tasks/task_e_68c2aea193748330a45abfab63464d3d