### PR TITLE
Fix service worker asset path prefix

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -60,7 +60,12 @@ async function cacheOptionalAssets(cache) {
       ...(cachedManifest.images || []),
       ...(cachedManifest.audio || []),
       ...(cachedManifest.fonts || []),
-    ].map((asset) => (asset.startsWith("assets/") ? asset : `assets/${asset}`));
+      // Flutter compiles assets under a top-level `assets/` directory for web
+      // builds. Prefix manifest entries so cache.add fetches the actual files.
+    ].map((asset) => {
+      const normalized = asset.startsWith("/") ? asset.slice(1) : asset;
+      return `assets/${normalized}`;
+    });
     await cacheAll(cache, assetList);
   } catch (err) {
     console.error("Asset manifest fetch failed", err);


### PR DESCRIPTION
## Summary
- ensure service worker adds the `assets/` prefix when caching optional assets so that Flutter web asset URLs resolve correctly
- document why manifest entries need this prefix

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2adf0497483308c71277760781c28