### PR TITLE
chore: remove redundant viewport meta tag

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta name="description" content="Space Miner PWA">
     <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Space Miner</title>
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="icons/Icon-192.png">


### PR DESCRIPTION
## Summary
- remove hard-coded `<meta name="viewport">` so Flutter Web can manage the viewport without warnings

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test` *(fails: terminated early by SIGINT)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ad4beb2c8330ae0a72e992ac0ad2