### PR TITLE
Refactor responsive icon sizing into extensions

### DIFF
--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -24,7 +24,7 @@ class HudOverlay extends StatelessWidget {
     return ValueListenableBuilder<double>(
       valueListenable: game.settingsService.hudButtonScale,
       builder: (context, scale, _) {
-        final iconSize = responsiveIconSizeFromContext(context) * scale;
+        final iconSize = context.responsiveIconSize() * scale;
         return SafeArea(
           child: SizedBox.expand(
             child: Padding(

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -32,7 +32,7 @@ class OverlayLayout extends StatelessWidget {
       builder: (context, constraints) {
         final shortestSide = constraints.biggest.shortestSide;
         final spacing = shortestSide * 0.02;
-        final iconSize = responsiveIconSize(constraints);
+        final iconSize = constraints.responsiveIconSize();
 
         Widget child = Center(child: builder(context, spacing, iconSize));
         // Ensure overlays have a Material ancestor so widgets like ListTile

--- a/lib/ui/responsive.dart
+++ b/lib/ui/responsive.dart
@@ -7,26 +7,33 @@ import 'package:flutter/widgets.dart';
 const double _desktopBreakpoint = 900;
 const double _tabletBreakpoint = 600;
 
-/// Calculates an icon size that scales with the shortest side of [constraints].
-///
-/// Returns a `24` point icon on small phones, `48` on tablets and `72` on
-/// larger desktop displays. Breakpoints roughly match Material layout
-/// guidelines.
-///
-/// The returned size can be passed directly to [IconButton.iconSize].
-double responsiveIconSize(BoxConstraints constraints, {double base = 24}) {
-  final shortestSide = constraints.biggest.shortestSide;
-  if (shortestSide >= _desktopBreakpoint) {
-    return base * 3; // Desktop.
+/// Extension on [BoxConstraints] providing responsive sizing helpers.
+extension ResponsiveConstraints on BoxConstraints {
+  /// Calculates an icon size that scales with the shortest side of this
+  /// constraint.
+  ///
+  /// Returns a `24` point icon on small phones, `48` on tablets and `72` on
+  /// larger desktop displays. Breakpoints roughly match Material layout
+  /// guidelines.
+  ///
+  /// The returned size can be passed directly to [IconButton.iconSize].
+  double responsiveIconSize({double base = 24}) {
+    final shortestSide = biggest.shortestSide;
+    if (shortestSide >= _desktopBreakpoint) {
+      return base * 3; // Desktop.
+    }
+    if (shortestSide >= _tabletBreakpoint) {
+      return base * 2; // Tablet.
+    }
+    return base; // Phone.
   }
-  if (shortestSide >= _tabletBreakpoint) {
-    return base * 2; // Tablet.
-  }
-  return base; // Phone.
 }
 
-/// Variant that takes a [BuildContext] instead of [BoxConstraints].
-double responsiveIconSizeFromContext(BuildContext context, {double base = 24}) {
-  return responsiveIconSize(BoxConstraints.tight(MediaQuery.of(context).size),
-      base: base);
+/// Variant that operates on a [BuildContext].
+extension ResponsiveContext on BuildContext {
+  /// Calculates an icon size based on the current [MediaQuery] size.
+  double responsiveIconSize({double base = 24}) {
+    final constraints = BoxConstraints.tight(MediaQuery.of(this).size);
+    return constraints.responsiveIconSize(base: base);
+  }
 }

--- a/test/responsive_icon_size_test.dart
+++ b/test/responsive_icon_size_test.dart
@@ -6,25 +6,25 @@ import 'package:space_game/ui/responsive.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('responsiveIconSize', () {
+  group('ResponsiveConstraints', () {
     test('returns base size on phones', () {
       final constraints = BoxConstraints.tight(const Size(500, 800));
-      expect(responsiveIconSize(constraints), 24);
+      expect(constraints.responsiveIconSize(), 24);
     });
 
     test('doubles size on tablets', () {
       final constraints = BoxConstraints.tight(const Size(600, 800));
-      expect(responsiveIconSize(constraints), 48);
+      expect(constraints.responsiveIconSize(), 48);
     });
 
     test('triples size on desktops', () {
       final constraints = BoxConstraints.tight(const Size(900, 1200));
-      expect(responsiveIconSize(constraints), 72);
+      expect(constraints.responsiveIconSize(), 72);
     });
 
     test('honors custom base size', () {
       final constraints = BoxConstraints.tight(const Size(900, 1200));
-      expect(responsiveIconSize(constraints, base: 30), 90);
+      expect(constraints.responsiveIconSize(base: 30), 90);
     });
   });
 }


### PR DESCRIPTION
## Summary
- refactor responsive icon helpers into BoxConstraints and BuildContext extensions
- update overlays and tests to use extension methods

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68c2b6dda514833090d58c9d7bb2f4d5