### PR TITLE
Restore viewport meta tag for responsive mobile layout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="description" content="Space Miner PWA">
     <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Space Miner</title>
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="icons/Icon-192.png">


### PR DESCRIPTION
## Summary
- reintroduce `<meta name="viewport" content="width=device-width, initial-scale=1.0">` in `web/index.html` to ensure proper mobile scaling

## Testing
- `./scripts/dartw format web/index.html` *(fails: source could not be parsed)*
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b869889883308dd937a97061854f