### PR TITLE
test: cover UpgradeService affordance and shield flag

### DIFF
--- a/test/upgrade_service_test.dart
+++ b/test/upgrade_service_test.dart
@@ -66,4 +66,52 @@ void main() {
     );
     expect(service2.isPurchased(upgrade.id), isTrue);
   });
+
+  test('canAfford returns true only when upgrade is affordable and unpurchased',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+      settingsService: settings,
+    );
+    final upgrade = service.upgrades.first;
+
+    // Cannot afford without minerals.
+    expect(service.canAfford(upgrade), isFalse);
+
+    // With sufficient minerals, upgrade becomes affordable.
+    score.addMinerals(upgrade.cost);
+    expect(service.canAfford(upgrade), isTrue);
+
+    // Once purchased, upgrade is no longer considered affordable.
+    service.buy(upgrade);
+    expect(service.canAfford(upgrade), isFalse);
+  });
+
+  test('hasShieldRegen reflects purchase state', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = await StorageService.create();
+    final score = ScoreService(storageService: storage);
+    final settings = SettingsService();
+    final service = UpgradeService(
+      scoreService: score,
+      storageService: storage,
+      settingsService: settings,
+    );
+    final shieldUpgrade =
+        service.upgrades.firstWhere((u) => u.id == 'shieldRegen1');
+
+    // Shield regen flag should be false until the upgrade is purchased.
+    expect(service.hasShieldRegen, isFalse);
+
+    score.addMinerals(shieldUpgrade.cost);
+    service.buy(shieldUpgrade);
+
+    // After purchase, shield regen flag should be true.
+    expect(service.hasShieldRegen, isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- add unit test for `canAfford` to validate mineral and purchase requirements
- add unit test for `hasShieldRegen` flag after shield upgrade purchase

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b927475c8330b3d6620c6cf33a70