### PR TITLE
refactor: inject Random into AsteroidSpawner for testability

### DIFF
--- a/lib/components/asteroid_spawner.dart
+++ b/lib/components/asteroid_spawner.dart
@@ -9,9 +9,10 @@ import 'asteroid.dart';
 
 /// Spawns asteroids at timed intervals when started.
 class AsteroidSpawner extends Component with HasGameReference<SpaceGame> {
-  AsteroidSpawner();
+  AsteroidSpawner({math.Random? random}) : _random = random ?? math.Random();
 
-  final math.Random _random = math.Random();
+  /// Source of randomness for spawn positions. Injected for testability.
+  final math.Random _random;
   final Timer _timer = Timer(Constants.asteroidSpawnInterval, repeat: true);
 
   void start() => _timer.start();

--- a/test/asteroid_spawner_test.dart
+++ b/test/asteroid_spawner_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -35,7 +37,7 @@ class _TestGame extends SpaceGame {
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);
-    asteroidSpawner = AsteroidSpawner();
+    asteroidSpawner = AsteroidSpawner(random: math.Random(0));
     await add(asteroidSpawner);
   }
 }


### PR DESCRIPTION
## Summary
- allow injecting a `Random` into `AsteroidSpawner` for predictable spawning
- update asteroid spawner tests to pass a seeded random generator

## Testing
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2ba36517c83308616d4b3cd3f8c94