### PR TITLE
refactor: expose async event bus disposal

### DIFF
--- a/lib/game/event_bus.dart
+++ b/lib/game/event_bus.dart
@@ -8,8 +8,8 @@ sealed class GameEvent {}
 
 /// Simple event bus for broadcasting game lifecycle events.
 ///
-/// Uses a single broadcast stream and [whereType] filtering so listeners can
-/// subscribe to specific event classes without managing per-type controllers.
+/// Uses a single broadcast stream; listeners filter for specific event types
+/// using [on].
 class GameEventBus {
   GameEventBus()
       : _controller = StreamController<GameEvent>.broadcast(sync: true);
@@ -31,9 +31,7 @@ class GameEventBus {
       _controller.stream.where((event) => event is T).cast<T>();
 
   /// Closes the underlying stream controller.
-  void dispose() {
-    _controller.close();
-  }
+  Future<void> dispose() => _controller.close();
 }
 
 /// Event fired when a component is spawned.

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -419,7 +419,7 @@ class SpaceGame extends FlameGame
     super.onRemove();
     // Dispose the event bus after children are removed so they can emit
     // removal events without errors.
-    eventBus.dispose();
+    unawaited(eventBus.dispose());
   }
 
   /// Requests keyboard focus for the surrounding [GameWidget].


### PR DESCRIPTION
## Summary
- make `GameEventBus.dispose` return a `Future` so callers can await controller closure
- use `unawaited` when disposing the bus in `SpaceGame` teardown

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2ba36517c83308616d4b3cd3f8c94