### PR TITLE
refactor: centralize vector angle conversion

### DIFF
--- a/lib/components/auto_aim_behavior.dart
+++ b/lib/components/auto_aim_behavior.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:flame/components.dart';
 
 import '../game/space_game.dart';
@@ -24,11 +22,7 @@ class AutoAimBehavior extends Component
     );
     if (target != null) {
       parent.targetAngle = normalizeAngle(
-        math.atan2(
-              target.position.y - parent.position.y,
-              target.position.x - parent.position.x,
-            ) +
-            math.pi / 2,
+        vectorToFlameAngle(target.position - parent.position),
       );
       parent.updateRotation(dt);
     }

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
@@ -10,6 +8,7 @@ import 'asteroid.dart';
 import 'damageable.dart';
 import 'offscreen_cleanup.dart';
 import 'spawn_remove_emitter.dart';
+import '../util/angle_utils.dart';
 
 /// Short-lived projectile fired by the player.
 ///
@@ -32,7 +31,7 @@ class BulletComponent extends SpriteComponent
     _direction
       ..setFrom(direction)
       ..normalize();
-    angle = math.atan2(_direction.y, _direction.x) + math.pi / 2;
+    angle = vectorToFlameAngle(_direction);
   }
 
   @override

--- a/lib/components/enemy.dart
+++ b/lib/components/enemy.dart
@@ -1,5 +1,4 @@
 import 'dart:ui';
-import 'dart:math' as math;
 
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
@@ -10,6 +9,7 @@ import '../enemy_faction.dart';
 import '../game/space_game.dart';
 import 'debug_health_text.dart';
 import '../util/collision_utils.dart';
+import '../util/angle_utils.dart';
 import 'damageable.dart';
 import 'explosion.dart';
 import 'offscreen_cleanup.dart';
@@ -72,7 +72,7 @@ class EnemyComponent extends SpriteComponent
     final playerPos = game.targetingService.playerPosition;
     if (playerPos != null) {
       final direction = (playerPos - position).normalized();
-      angle = math.atan2(direction.y, direction.x) + math.pi / 2;
+      angle = vectorToFlameAngle(direction);
       position += direction * Constants.enemySpeed * dt;
     }
     super.update(dt);

--- a/lib/components/player_input_behavior.dart
+++ b/lib/components/player_input_behavior.dart
@@ -8,6 +8,7 @@ import '../game/key_dispatcher.dart';
 import '../game/space_game.dart';
 import 'bullet.dart';
 import 'player.dart';
+import '../util/angle_utils.dart';
 
 /// Handles keyboard/joystick input, movement and shooting for the player.
 class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
@@ -82,7 +83,7 @@ class PlayerInputBehavior extends Component with HasGameReference<SpaceGame> {
     if (!input.isZero()) {
       input = input.normalized();
       player.position += input * game.upgradeService.playerSpeed * dt;
-      player.targetAngle = math.atan2(input.y, input.x) + math.pi / 2;
+      player.targetAngle = vectorToFlameAngle(input);
       player.isMoving = true;
       return true;
     }

--- a/lib/util/angle_utils.dart
+++ b/lib/util/angle_utils.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'package:flame/components.dart';
+
 /// Utilities for working with angles.
 ///
 /// Normalises angles to the `[-π, π]` range to avoid discontinuities when
@@ -14,3 +16,11 @@ double normalizeAngle(double angle) {
   }
   return angle;
 }
+
+/// Converts a directional [vector] into a Flame angle.
+///
+/// In Flame, an angle of `0` points upwards. This helper maps a vector using
+/// [`atan2`] and applies the required offset so sprites face the vector's
+/// heading.
+double vectorToFlameAngle(Vector2 vector) =>
+    math.atan2(vector.y, vector.x) + math.pi / 2;

--- a/test/angle_utils_test.dart
+++ b/test/angle_utils_test.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flame/components.dart';
 
 import 'package:space_game/util/angle_utils.dart';
 
@@ -77,5 +78,11 @@ void main() {
 
   test('normalizeAngle treats -0 as 0', () {
     expect(normalizeAngle(-0.0), isZero);
+  });
+
+  test('vectorToFlameAngle converts vectors to Flame angles', () {
+    expect(vectorToFlameAngle(Vector2(0, -1)), closeTo(0, 1e-10));
+    expect(vectorToFlameAngle(Vector2(1, 0)), closeTo(math.pi / 2, 1e-10));
+    expect(vectorToFlameAngle(Vector2(0, 1)), closeTo(math.pi, 1e-10));
   });
 }


### PR DESCRIPTION
## Summary
- add `vectorToFlameAngle` utility for consistent angle calculation
- refactor components to use shared helper instead of ad hoc atan2 logic
- test angle helper and align components with it

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2ba36517c83308616d4b3cd3f8c94