### PR TITLE
docs: add SpaceGame refactoring tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -134,3 +134,12 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       - Changes should rebuild layers and persist via `SettingsService`.
       - Ensure overlays hide when debug mode is disabled.
 
+## Refactoring
+
+- [ ] Extract `SpaceGame` overlay toggles and UI state helpers into a dedicated
+      controller module.
+- [ ] Move health regeneration logic out of `SpaceGame.update` into a separate
+      component or system.
+- [ ] Break `SpaceGame` constructor and `onLoad` setup into modular builders or
+      helpers to reduce class size.
+


### PR DESCRIPTION
## Summary
- document planned SpaceGame refactor: move UI helpers and health regen into dedicated modules and modularize constructor/onLoad

## Testing
- `scripts/dartw format lib test`
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2bf7c5054833097868442fb921f0b