### PR TITLE
Allow multiple key callbacks in KeyDispatcher

### DIFF
--- a/test/key_dispatcher_test.dart
+++ b/test/key_dispatcher_test.dart
@@ -167,5 +167,27 @@ void main() {
       );
       expect(handled, isFalse);
     });
+
+    test('multiple callbacks for a key all fire', () {
+      final dispatcher = KeyDispatcher();
+      var count = 0;
+      dispatcher.register(
+        LogicalKeyboardKey.space,
+        onDown: () => count++,
+      );
+      dispatcher.register(
+        LogicalKeyboardKey.space,
+        onDown: () => count++,
+      );
+      dispatcher.onKeyEvent(
+        const KeyDownEvent(
+          logicalKey: LogicalKeyboardKey.space,
+          physicalKey: PhysicalKeyboardKey.space,
+          timeStamp: Duration.zero,
+        ),
+        {LogicalKeyboardKey.space},
+      );
+      expect(count, 2);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- allow registering multiple callbacks per key in `KeyDispatcher`
- test that multiple callbacks fire when the key is pressed

## Testing
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c2bf038a488330a2847633f46116cc