### PR TITLE
Refactor SpaceGame UI controller and health regen

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -136,10 +136,11 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 ## Refactoring
 
-- [ ] Extract `SpaceGame` overlay toggles and UI state helpers into a dedicated
+- [x] Extract `SpaceGame` overlay toggles and UI state helpers into a dedicated
       controller module.
-- [ ] Move health regeneration logic out of `SpaceGame.update` into a separate
+- [x] Move health regeneration logic out of `SpaceGame.update` into a separate
       component or system.
 - [ ] Break `SpaceGame` constructor and `onLoad` setup into modular builders or
       helpers to reduce class size.
+  - [ ] Split `onLoad` into `_initWorld` and `_initOverlays` helpers.
 

--- a/lib/game/health_regen_system.dart
+++ b/lib/game/health_regen_system.dart
@@ -1,0 +1,35 @@
+import '../constants.dart';
+import '../services/score_service.dart';
+import '../services/upgrade_service.dart';
+
+/// Handles passive player health regeneration when the relevant upgrade is active.
+class HealthRegenSystem {
+  HealthRegenSystem({
+    required this.scoreService,
+    required this.upgradeService,
+  });
+
+  final ScoreService scoreService;
+  final UpgradeService upgradeService;
+
+  double _timer = 0;
+
+  /// Resets the regeneration timer, typically when the player is damaged.
+  void reset() => _timer = 0;
+
+  /// Updates the regeneration timer and applies healing when appropriate.
+  void update(double dt, bool isPlaying) {
+    if (isPlaying &&
+        upgradeService.hasShieldRegen &&
+        scoreService.health.value < Constants.playerMaxHealth) {
+      _timer += dt;
+      if (_timer >= Constants.playerHealthRegenInterval) {
+        _timer = 0;
+        scoreService.health.value =
+            (scoreService.health.value + 1).clamp(0, Constants.playerMaxHealth);
+      }
+    } else {
+      _timer = 0;
+    }
+  }
+}

--- a/lib/game/ui_controller.dart
+++ b/lib/game/ui_controller.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+
+import '../components/mining_laser.dart';
+import '../components/player.dart';
+import '../services/overlay_service.dart';
+import '../ui/help_overlay.dart';
+import '../ui/settings_overlay.dart';
+import 'game_state_machine.dart';
+
+/// Handles overlay toggles and UI state such as the minimap visibility.
+class UiController {
+  UiController({
+    required this.overlayService,
+    required this.stateMachine,
+    required this.player,
+    required this.miningLaser,
+    required this.pauseEngine,
+    required this.resumeEngine,
+    required this.focusGame,
+  });
+
+  final OverlayService overlayService;
+  final GameStateMachine stateMachine;
+  final PlayerComponent player;
+  final MiningLaserComponent? miningLaser;
+  final VoidCallback pauseEngine;
+  final VoidCallback resumeEngine;
+  final VoidCallback focusGame;
+
+  /// Whether the minimap should be shown in the HUD.
+  final ValueNotifier<bool> showMinimap = ValueNotifier<bool>(true);
+
+  bool _helpWasPlaying = false;
+
+  /// Toggles the upgrades overlay and pauses/resumes the game.
+  void toggleUpgrades() => stateMachine.toggleUpgrades();
+
+  /// Toggles the help overlay and pauses/resumes if entering from gameplay.
+  void toggleHelp() {
+    if (overlayService.game.overlays.isActive(HelpOverlay.id)) {
+      overlayService.hideHelp();
+      if (_helpWasPlaying) {
+        resumeEngine();
+        focusGame();
+      }
+    } else {
+      _helpWasPlaying = stateMachine.isPlaying;
+      overlayService.showHelp();
+      if (_helpWasPlaying) {
+        pauseEngine();
+        miningLaser?.stopSound();
+      }
+    }
+  }
+
+  /// Toggles rendering of the player's range rings.
+  void toggleRangeRings() {
+    player.toggleRangeRings();
+  }
+
+  /// Shows or hides the runtime settings overlay.
+  void toggleSettings() {
+    if (overlayService.game.overlays.isActive(SettingsOverlay.id)) {
+      overlayService.hideSettings();
+    } else {
+      overlayService.showSettings();
+    }
+  }
+
+  /// Toggles the minimap visibility in the HUD.
+  void toggleMinimap() {
+    showMinimap.value = !showMinimap.value;
+  }
+}

--- a/lib/ui/help_overlay.dart
+++ b/lib/ui/help_overlay.dart
@@ -46,7 +46,7 @@ class HelpOverlay extends StatelessWidget {
             ),
             SizedBox(height: spacing),
             ElevatedButton(
-              onPressed: game.toggleHelp,
+              onPressed: () => game.ui.toggleHelp(),
               child: const GameText(
                 'Close',
                 maxLines: 1,

--- a/lib/ui/hud_overlay.dart
+++ b/lib/ui/hud_overlay.dart
@@ -34,7 +34,7 @@ class HudOverlay extends StatelessWidget {
                   Align(
                     alignment: Alignment.topLeft,
                     child: ValueListenableBuilder<bool>(
-                      valueListenable: game.showMinimap,
+                      valueListenable: game.ui.showMinimap,
                       builder: (context, show, _) {
                         if (!show) {
                           return const SizedBox.shrink();
@@ -88,7 +88,7 @@ class HudOverlay extends StatelessWidget {
                             Icons.gps_fixed,
                             color: Theme.of(context).colorScheme.onSurface,
                           ),
-                          onPressed: game.toggleRangeRings,
+                          onPressed: () => game.ui.toggleRangeRings(),
                         ),
                         MinimapButton(game: game, iconSize: iconSize),
                         UpgradeButton(game: game, iconSize: iconSize),

--- a/lib/ui/overlay_widgets.dart
+++ b/lib/ui/overlay_widgets.dart
@@ -119,11 +119,11 @@ class HelpButton extends StatelessWidget {
       return GameIconButton(
         icon: const Icon(Icons.help_outline),
         iconSize: iconSize!,
-        onPressed: game.toggleHelp,
+        onPressed: () => game.ui.toggleHelp(),
       );
     }
     return ElevatedButton(
-      onPressed: game.toggleHelp,
+      onPressed: () => game.ui.toggleHelp(),
       child: const GameText(
         'Help',
         maxLines: 1,
@@ -145,7 +145,7 @@ class UpgradeButton extends StatelessWidget {
     return GameIconButton(
       icon: const Icon(Icons.upgrade),
       iconSize: iconSize,
-      onPressed: game.toggleUpgrades,
+      onPressed: () => game.ui.toggleUpgrades(),
     );
   }
 }
@@ -164,7 +164,7 @@ class SettingsButton extends StatelessWidget {
         AssetImage('assets/images/${Assets.settingsIcon}'),
       ),
       iconSize: iconSize,
-      onPressed: game.toggleSettings,
+      onPressed: () => game.ui.toggleSettings(),
     );
   }
 }
@@ -182,7 +182,7 @@ class MinimapButton extends StatelessWidget {
       icon: const Icon(Icons.map),
       iconSize: iconSize,
       color: Theme.of(context).colorScheme.onSurface,
-      onPressed: game.toggleMinimap,
+      onPressed: () => game.ui.toggleMinimap(),
     );
   }
 }

--- a/lib/ui/settings_overlay.dart
+++ b/lib/ui/settings_overlay.dart
@@ -186,7 +186,7 @@ class SettingsOverlay extends StatelessWidget {
                     ),
                     SizedBox(height: spacing),
                     ElevatedButton(
-                      onPressed: game.toggleSettings,
+                      onPressed: () => game.ui.toggleSettings(),
                       child: const GameText(
                         'Close',
                         maxLines: 1,

--- a/lib/ui/upgrades_overlay.dart
+++ b/lib/ui/upgrades_overlay.dart
@@ -48,7 +48,7 @@ class _UpgradesOverlayState extends State<UpgradesOverlay> {
             ),
             SizedBox(height: spacing),
             ElevatedButton(
-              onPressed: widget.game.toggleUpgrades,
+              onPressed: () => widget.game.ui.toggleUpgrades(),
               child: const GameText(
                 'Resume',
                 maxLines: 1,

--- a/test/help_overlay_test.dart
+++ b/test/help_overlay_test.dart
@@ -29,11 +29,11 @@ void main() {
     expect(game.overlays.isActive(HelpOverlay.id), isFalse);
     expect(game.paused, isFalse);
 
-    game.toggleHelp();
+    game.ui.toggleHelp();
     expect(game.overlays.isActive(HelpOverlay.id), isTrue);
     expect(game.paused, isTrue);
 
-    game.toggleHelp();
+    game.ui.toggleHelp();
     expect(game.overlays.isActive(HelpOverlay.id), isFalse);
     expect(game.paused, isFalse);
   });

--- a/test/upgrades_overlay_test.dart
+++ b/test/upgrades_overlay_test.dart
@@ -30,11 +30,11 @@ void main() {
     expect(game.overlays.isActive(UpgradesOverlay.id), isFalse);
     expect(game.paused, isFalse);
 
-    game.toggleUpgrades();
+    game.ui.toggleUpgrades();
     expect(game.overlays.isActive(UpgradesOverlay.id), isTrue);
     expect(game.paused, isTrue);
 
-    game.toggleUpgrades();
+    game.ui.toggleUpgrades();
     expect(game.overlays.isActive(UpgradesOverlay.id), isFalse);
     expect(game.paused, isFalse);
   });


### PR DESCRIPTION
## Summary
- extract SpaceGame overlay toggles and minimap state into a UiController
- move health regeneration logic into a dedicated HealthRegenSystem
- update overlays, tests, and tasks to use new controller

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test --concurrency 1`


------
https://chatgpt.com/codex/tasks/task_e_68c344bfe1088330ad988f2cf8b420ab