### PR TITLE
Align non-web interaction callback timing

### DIFF
--- a/lib/util/interaction_stub.dart
+++ b/lib/util/interaction_stub.dart
@@ -1,3 +1,10 @@
+import 'dart:async';
+
+/// Immediately schedules [callback] to run asynchronously.
+///
+/// Matches the web implementation's behaviour by invoking the callback in a
+/// microtask, ensuring consistent ordering and allowing exceptions to surface
+/// through the event loop rather than synchronously.
 void onFirstUserInteraction(void Function() callback) {
-  callback();
+  Future.microtask(callback);
 }

--- a/test/interaction_test.dart
+++ b/test/interaction_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:space_game/util/interaction.dart';
@@ -5,15 +7,18 @@ import 'package:space_game/util/interaction.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('onFirstUserInteraction invokes callback immediately on non-web', () {
+  test('onFirstUserInteraction schedules callback asynchronously on non-web',
+      () async {
     var called = false;
     onFirstUserInteraction(() {
       called = true;
     });
+    expect(called, isFalse);
+    await Future<void>.delayed(Duration.zero);
     expect(called, isTrue);
   });
 
-  test('onFirstUserInteraction executes each callback separately', () {
+  test('onFirstUserInteraction executes each callback separately', () async {
     var count = 0;
     onFirstUserInteraction(() {
       count++;
@@ -21,13 +26,23 @@ void main() {
     onFirstUserInteraction(() {
       count++;
     });
+    await Future<void>.delayed(Duration.zero);
     expect(count, 2);
   });
 
-  test('onFirstUserInteraction forwards exceptions', () {
-    expect(
-      () => onFirstUserInteraction(() => throw Exception('boom')),
-      throwsException,
-    );
+  test('onFirstUserInteraction forwards exceptions', () async {
+    final errors = <Object>[];
+    final completer = Completer<void>();
+    runZonedGuarded(() {
+      onFirstUserInteraction(() {
+        throw Exception('boom');
+      });
+      Future<void>.delayed(Duration.zero).then((_) => completer.complete());
+    }, (error, _) {
+      errors.add(error);
+    });
+    await completer.future;
+    expect(errors, hasLength(1));
+    expect(errors.first, isException);
   });
 }


### PR DESCRIPTION
## Summary
- invoke non-web `onFirstUserInteraction` via microtask to match web behaviour
- adjust interaction tests for async callback scheduling and error propagation

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c344b947608330b8fee75dcf0f2743