### PR TITLE
Schedule first user interaction callbacks on a microtask

### DIFF
--- a/lib/util/interaction_stub.dart
+++ b/lib/util/interaction_stub.dart
@@ -1,3 +1,10 @@
+import 'dart:async';
+
+/// Invokes [callback] asynchronously on the next microtask.
+///
+/// This mirrors the web implementation where callbacks are triggered by event
+/// listeners, ensuring consistent error handling and invocation order across
+/// platforms.
 void onFirstUserInteraction(void Function() callback) {
-  callback();
+  scheduleMicrotask(callback);
 }

--- a/test/interaction_test.dart
+++ b/test/interaction_test.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:space_game/util/interaction.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('onFirstUserInteraction invokes callback asynchronously', () async {
+    var invoked = false;
+    onFirstUserInteraction(() {
+      invoked = true;
+    });
+    expect(invoked, isFalse);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(invoked, isTrue);
+  });
+
+  test('onFirstUserInteraction surfaces callback errors asynchronously',
+      () async {
+    final errors = <Object>[];
+
+    runZonedGuarded(() {
+      onFirstUserInteraction(() {
+        throw StateError('boom');
+      });
+    }, (error, stack) {
+      errors.add(error);
+    });
+
+    expect(errors, isEmpty);
+
+    await Future<void>.delayed(Duration.zero);
+
+    expect(errors.single, isA<StateError>());
+  });
+}


### PR DESCRIPTION
## Summary
- Run non-web first user interaction callbacks on a microtask for consistent async behavior
- Test interaction callback execution order and error surfacing

## Testing
- `scripts/dartw analyze lib/util/interaction_stub.dart test/interaction_test.dart`
- `scripts/flutterw test test/interaction_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68c3499240f88330a0a35efb1b72c0f4