### PR TITLE
refactor: reduce vector allocations in control manager

### DIFF
--- a/lib/game/control_manager.dart
+++ b/lib/game/control_manager.dart
@@ -92,7 +92,7 @@ class ControlManager {
       onPressed: player.startShooting,
       onReleased: player.stopShooting,
       onCancelled: player.stopShooting,
-    )..size = Vector2.all((radius * 2));
+    )..size = Vector2.all(radius * 2);
   }
 
   void _updateJoystickScale() {
@@ -101,15 +101,18 @@ class ControlManager {
     final knob = _joystick.knob as CircleComponent;
     bg
       ..radius = _joystickBackgroundRadius * scale
-      ..position = Vector2.zero();
+      ..position.setZero();
     knob
       ..radius = _joystickKnobRadius * scale
-      ..position = Vector2.zero();
+      ..position.setZero();
     _joystick
       ..size = Vector2.all((_joystickBackgroundRadius * 2) * scale)
       ..knobRadius = _joystickKnobRadius * scale
       ..anchor = Anchor.bottomLeft
-      ..position = Vector2(_controlMargin, game.size.y - _controlMargin);
+      ..position.setValues(
+        _controlMargin,
+        game.size.y - _controlMargin,
+      );
     _joystick.onGameResize(game.size);
 
     final fb = fireButton;


### PR DESCRIPTION
## Summary
- optimize joystick scaling by reusing vectors instead of allocating new ones

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c34970e9208330a9f69878b24a2285