### PR TITLE
Refactor UiController to fetch current player and mining laser

### DIFF
--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -218,8 +218,8 @@ class SpaceGame extends FlameGame
     ui = UiController(
       overlayService: overlayService,
       stateMachine: stateMachine,
-      player: player,
-      miningLaser: miningLaser,
+      player: () => player,
+      miningLaser: () => miningLaser,
       pauseEngine: pauseEngine,
       resumeEngine: resumeEngine,
       focusGame: focusGame,

--- a/lib/game/ui_controller.dart
+++ b/lib/game/ui_controller.dart
@@ -12,17 +12,23 @@ class UiController {
   UiController({
     required this.overlayService,
     required this.stateMachine,
-    required this.player,
-    required this.miningLaser,
+    required PlayerComponent Function() player,
+    required MiningLaserComponent? Function() miningLaser,
     required this.pauseEngine,
     required this.resumeEngine,
     required this.focusGame,
-  });
+  })  : _player = player,
+        _miningLaser = miningLaser;
 
   final OverlayService overlayService;
   final GameStateMachine stateMachine;
-  final PlayerComponent player;
-  final MiningLaserComponent? miningLaser;
+
+  /// Suppliers used to fetch the current player and mining laser components.
+  ///
+  /// The lifecycle manager replaces these components on each new run, so the
+  /// UI controller avoids caching stale instances by retrieving them on demand.
+  final PlayerComponent Function() _player;
+  final MiningLaserComponent? Function() _miningLaser;
   final VoidCallback pauseEngine;
   final VoidCallback resumeEngine;
   final VoidCallback focusGame;
@@ -48,14 +54,14 @@ class UiController {
       overlayService.showHelp();
       if (_helpWasPlaying) {
         pauseEngine();
-        miningLaser?.stopSound();
+        _miningLaser()?.stopSound();
       }
     }
   }
 
   /// Toggles rendering of the player's range rings.
   void toggleRangeRings() {
-    player.toggleRangeRings();
+    _player().toggleRangeRings();
   }
 
   /// Shows or hides the runtime settings overlay.


### PR DESCRIPTION
## Summary
- avoid caching player and mining laser in UiController by storing suppliers to fetch current components
- update SpaceGame to provide closures returning latest player and mining laser

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3c1e7a9108330ab599cef05f9e08c