### PR TITLE
Ensure master volume setter stores double

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -79,7 +79,7 @@ class AudioService {
 
   /// Sets the global volume multiplier (0-1).
   void setMasterVolume(double value) {
-    volume.value = value.clamp(0, 1);
+    volume.value = value.clamp(0, 1).toDouble();
   }
 
   /// Toggles the mute flag and persists the new value.


### PR DESCRIPTION
## Summary
- cast clamped master volume to double before assigning to notifier

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3c26763e88330921369d5da3c1fe0