### PR TITLE
refactor: use enum for upgrade ids

### DIFF
--- a/test/player_input_behavior_test.dart
+++ b/test/player_input_behavior_test.dart
@@ -17,6 +17,7 @@ import 'package:space_game/game/game_state.dart';
 import 'package:space_game/services/overlay_service.dart';
 import 'package:space_game/services/storage_service.dart';
 import 'package:space_game/services/audio_service.dart';
+import 'package:space_game/services/upgrade_service.dart';
 
 import 'test_joystick.dart';
 import 'test_images.dart';
@@ -235,8 +236,8 @@ void main() {
     final normalX = game.player.position.x;
 
     game.player.position.setZero();
-    final upgrade =
-        game.upgradeService.upgrades.firstWhere((u) => u.id == 'speed1');
+    final upgrade = game.upgradeService.upgrades
+        .firstWhere((u) => u.id == UpgradeId.speed1);
     game.scoreService.addMinerals(upgrade.cost);
     game.upgradeService.buy(upgrade);
     game.controlManager.joystick.delta.setValues(1, 0);

--- a/test/tractor_aura_test.dart
+++ b/test/tractor_aura_test.dart
@@ -11,6 +11,7 @@ import 'package:space_game/game/key_dispatcher.dart';
 import 'package:space_game/game/space_game.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/services/upgrade_service.dart';
 
 class _TestGame extends SpaceGame {
   _TestGame({required StorageService storage, required AudioService audio})
@@ -114,8 +115,8 @@ void main() {
     game.update(0);
     game.update(0);
 
-    final upgrade =
-        game.upgradeService.upgrades.firstWhere((u) => u.id == 'tractorRange1');
+    final upgrade = game.upgradeService.upgrades
+        .firstWhere((u) => u.id == UpgradeId.tractorRange1);
     game.scoreService.addMinerals(upgrade.cost);
     game.upgradeService.buy(upgrade);
 

--- a/test/upgrade_effects_test.dart
+++ b/test/upgrade_effects_test.dart
@@ -20,7 +20,8 @@ void main() {
       storageService: storage,
       settingsService: settings,
     );
-    final upgrade = service.upgrades.firstWhere((u) => u.id == 'fireRate1');
+    final upgrade =
+        service.upgrades.firstWhere((u) => u.id == UpgradeId.fireRate1);
     expect(service.bulletCooldown, Constants.bulletCooldown);
     score.addMinerals(upgrade.cost);
     service.buy(upgrade);
@@ -37,7 +38,8 @@ void main() {
       storageService: storage,
       settingsService: settings,
     );
-    final upgrade = service.upgrades.firstWhere((u) => u.id == 'miningSpeed1');
+    final upgrade =
+        service.upgrades.firstWhere((u) => u.id == UpgradeId.miningSpeed1);
     expect(service.miningPulseInterval, Constants.miningPulseInterval);
     score.addMinerals(upgrade.cost);
     service.buy(upgrade);
@@ -56,7 +58,7 @@ void main() {
       settingsService: settings,
     );
     final upgrade =
-        service.upgrades.firstWhere((u) => u.id == 'targetingRange1');
+        service.upgrades.firstWhere((u) => u.id == UpgradeId.targetingRange1);
     expect(service.targetingRange, Constants.playerAutoAimRange);
     score.addMinerals(upgrade.cost);
     service.buy(upgrade);
@@ -73,7 +75,8 @@ void main() {
       storageService: storage,
       settingsService: settings,
     );
-    final upgrade = service.upgrades.firstWhere((u) => u.id == 'tractorRange1');
+    final upgrade =
+        service.upgrades.firstWhere((u) => u.id == UpgradeId.tractorRange1);
     expect(service.tractorRange, Constants.playerTractorAuraRadius);
     score.addMinerals(upgrade.cost);
     service.buy(upgrade);
@@ -91,7 +94,8 @@ void main() {
       storageService: storage,
       settingsService: settings,
     );
-    final upgrade = service.upgrades.firstWhere((u) => u.id == 'speed1');
+    final upgrade =
+        service.upgrades.firstWhere((u) => u.id == UpgradeId.speed1);
     expect(service.playerSpeed, Constants.playerSpeed);
     score.addMinerals(upgrade.cost);
     service.buy(upgrade);

--- a/test/upgrade_service_test.dart
+++ b/test/upgrade_service_test.dart
@@ -103,7 +103,7 @@ void main() {
       settingsService: settings,
     );
     final shieldUpgrade =
-        service.upgrades.firstWhere((u) => u.id == 'shieldRegen1');
+        service.upgrades.firstWhere((u) => u.id == UpgradeId.shieldRegen1);
 
     // Shield regen flag should be false until the upgrade is purchased.
     expect(service.hasShieldRegen, isFalse);


### PR DESCRIPTION
## Summary
- introduce `UpgradeId` enum for compile-time safe upgrade references
- refactor `UpgradeService` and tests to use `UpgradeId`

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3c2769b94833082ad4b41a7649859