### PR TITLE
Handle invalid saved settings data

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -22,9 +22,11 @@ class SettingsService {
     starfieldDensity = _notifiers[_starfieldDensityKey]!;
     starfieldBrightness = _notifiers[_starfieldBrightnessKey]!;
     starfieldGamma = _notifiers[_starfieldGammaKey]!;
-    starfieldPalette = ValueNotifier<StarPalette>(
-      StarPalette.values[_storage?.getInt(_starfieldPaletteKey, 0) ?? 0],
+    final paletteIndex = _safePaletteIndex(
+      _storage?.getInt(_starfieldPaletteKey, 0) ?? 0,
     );
+    starfieldPalette =
+        ValueNotifier<StarPalette>(StarPalette.values[paletteIndex]);
     starfieldPalette.addListener(() =>
         _storage?.setInt(_starfieldPaletteKey, starfieldPalette.value.index));
   }
@@ -85,8 +87,9 @@ class SettingsService {
       (key, notifier) =>
           notifier.value = storage.getDouble(key, notifier.value),
     );
-    starfieldPalette.value =
-        StarPalette.values[storage.getInt(_starfieldPaletteKey, 0)];
+    final paletteIndex =
+        _safePaletteIndex(storage.getInt(_starfieldPaletteKey, 0));
+    starfieldPalette.value = StarPalette.values[paletteIndex];
   }
 
   /// Restores all values to their defaults.
@@ -125,10 +128,18 @@ class SettingsService {
   };
 
   ValueNotifier<double> _initNotifier(String key, double defaultValue) {
-    final notifier = ValueNotifier<double>(
-        _storage?.getDouble(key, defaultValue) ?? defaultValue);
+    final value = _storage?.getDouble(key, defaultValue) ?? defaultValue;
+    final notifier =
+        ValueNotifier<double>(value.isFinite ? value : defaultValue);
     notifier.addListener(() => _storage?.setDouble(key, notifier.value));
     return notifier;
+  }
+
+  int _safePaletteIndex(int index) {
+    if (index < 0 || index >= StarPalette.values.length) {
+      return 0;
+    }
+    return index;
   }
 
   /// Releases resources held by the service.

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -23,7 +23,9 @@ class StorageService {
   ///
   /// Supported types are [int], [double], [bool], [String] and
   /// [List]<[String]>. Throws [UnsupportedError] for unsupported types.
-  T getValue<T>(String key, T defaultValue) => switch (defaultValue) {
+  T getValue<T>(String key, T defaultValue) {
+    try {
+      return switch (defaultValue) {
         int _ => (_prefs.getInt(key) ?? defaultValue) as T,
         double _ => (_prefs.getDouble(key) ?? defaultValue) as T,
         bool _ => (_prefs.getBool(key) ?? defaultValue) as T,
@@ -32,6 +34,12 @@ class StorageService {
           (_prefs.getStringList(key) ?? defaultValue as List<String>) as T,
         _ => throw UnsupportedError('Type $T is not supported'),
       };
+    } on UnsupportedError {
+      rethrow;
+    } catch (_) {
+      return defaultValue;
+    }
+  }
 
   /// Persists [value] for [key].
   ///

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:space_game/constants.dart';
 import 'package:space_game/services/settings_service.dart';
 import 'package:space_game/services/storage_service.dart';
+import 'package:space_game/theme/star_palette.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -120,6 +121,21 @@ void main() {
     final reloaded = SettingsService(storage: storage);
     expect(reloaded.hudButtonScale.value, 1.4);
     expect(reloaded.minimapScale.value, 1.2);
+  });
+
+  test('invalid palette index falls back to classic', () async {
+    SharedPreferences.setMockInitialValues({'starfieldPalette': 999});
+    final storage = await StorageService.create();
+    final settings = SettingsService(storage: storage);
+    expect(settings.starfieldPalette.value, StarPalette.classic);
+  });
+
+  test('negative palette index falls back to classic during attach', () async {
+    SharedPreferences.setMockInitialValues({'starfieldPalette': -1});
+    final storage = await StorageService.create();
+    final settings = SettingsService();
+    settings.attachStorage(storage);
+    expect(settings.starfieldPalette.value, StarPalette.classic);
   });
 
   test('dispose releases all notifiers', () {


### PR DESCRIPTION
## Summary
- Guard shared preferences reads to fall back to defaults when data can't be parsed
- Validate stored starfield palette and numeric settings to prevent crashes
- Test that out-of-range palette indices reset to classic

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68c3c315d1408330b9c4d3713baf39e0