### PR TITLE
chore: encapsulate joystick in control manager

### DIFF
--- a/lib/game/control_manager.dart
+++ b/lib/game/control_manager.dart
@@ -34,9 +34,8 @@ class ControlManager {
   /// Colours used to style the joystick and fire button.
   final ColorScheme colorScheme;
 
-  late JoystickComponent _joystick;
+  late final JoystickComponent _joystick;
   JoystickComponent get joystick => _joystick;
-  set joystick(JoystickComponent value) => _joystick = value;
 
   HudButtonComponent? fireButton;
 

--- a/lib/game/space_game.dart
+++ b/lib/game/space_game.dart
@@ -124,7 +124,6 @@ class SpaceGame extends FlameGame
   MiningLaserComponent? miningLaser;
   late final ControlManager controlManager;
   JoystickComponent get joystick => controlManager.joystick;
-  set joystick(JoystickComponent value) => controlManager.joystick = value;
   HudButtonComponent get fireButton => controlManager.fireButton!;
   late final EnemySpawner enemySpawner;
   late final AsteroidSpawner asteroidSpawner;

--- a/test/asteroid_damage_limit_test.dart
+++ b/test/asteroid_damage_limit_test.dart
@@ -35,7 +35,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/asteroid_spawner_test.dart
+++ b/test/asteroid_spawner_test.dart
@@ -33,7 +33,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/bullet_asteroid_destroy_test.dart
+++ b/test/bullet_asteroid_destroy_test.dart
@@ -76,7 +76,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/enemy_boss_spacing_test.dart
+++ b/test/enemy_boss_spacing_test.dart
@@ -33,7 +33,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     add(keyDispatcher);
-    joystick = JoystickComponent(
+    final joystick = JoystickComponent(
       knob: CircleComponent(radius: 1),
       background: CircleComponent(radius: 2),
     );

--- a/test/enemy_damage_flash_test.dart
+++ b/test/enemy_damage_flash_test.dart
@@ -71,7 +71,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/enemy_damage_test.dart
+++ b/test/enemy_damage_test.dart
@@ -77,7 +77,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/enemy_direction_test.dart
+++ b/test/enemy_direction_test.dart
@@ -34,7 +34,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     add(keyDispatcher);
-    joystick = JoystickComponent(
+    final joystick = JoystickComponent(
       knob: CircleComponent(radius: 1),
       background: CircleComponent(radius: 2),
     );

--- a/test/enemy_group_spawn_test.dart
+++ b/test/enemy_group_spawn_test.dart
@@ -31,7 +31,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     add(keyDispatcher);
-    joystick = JoystickComponent(
+    final joystick = JoystickComponent(
       knob: CircleComponent(radius: 1),
       background: CircleComponent(radius: 2),
     );

--- a/test/mineral_pickup_test.dart
+++ b/test/mineral_pickup_test.dart
@@ -34,7 +34,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/offscreen_cleanup_test.dart
+++ b/test/offscreen_cleanup_test.dart
@@ -43,7 +43,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/player_auto_aim_test.dart
+++ b/test/player_auto_aim_test.dart
@@ -34,7 +34,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/player_bullet_direction_test.dart
+++ b/test/player_bullet_direction_test.dart
@@ -71,7 +71,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: keyDispatcher);
     await add(player);

--- a/test/player_collision_test.dart
+++ b/test/player_collision_test.dart
@@ -130,7 +130,7 @@ class _TestGame extends SpaceGame {
     stateMachine.state = GameState.playing;
     final dispatcher = KeyDispatcher();
     await add(dispatcher);
-    joystick = TestJoystick();
+    final joystick = TestJoystick();
     await add(joystick);
     player = _TestPlayer(joystick: joystick, keyDispatcher: dispatcher);
     await add(player);

--- a/test/player_damage_flash_test.dart
+++ b/test/player_damage_flash_test.dart
@@ -43,7 +43,7 @@ class _TestGame extends SpaceGame {
     )..state = GameState.playing;
     final keyDispatcher = KeyDispatcher();
     add(keyDispatcher);
-    joystick = JoystickComponent(
+    final joystick = JoystickComponent(
       knob: CircleComponent(radius: 1),
       background: CircleComponent(radius: 2),
     );

--- a/test/player_input_behavior_test.dart
+++ b/test/player_input_behavior_test.dart
@@ -18,8 +18,8 @@ import 'package:space_game/services/overlay_service.dart';
 import 'package:space_game/services/storage_service.dart';
 import 'package:space_game/services/audio_service.dart';
 
-import 'test_joystick.dart';
 import 'test_images.dart';
+import 'test_joystick.dart';
 
 class _TestBullet extends BulletComponent {
   @override
@@ -100,9 +100,6 @@ class _TestGame extends SpaceGame {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
     await controlManager.init();
-    controlManager.joystick.removeFromParent();
-    controlManager.joystick = TestJoystick();
-    await add(controlManager.joystick);
     player = _TestPlayer(
       joystick: controlManager.joystick,
       keyDispatcher: keyDispatcher,
@@ -139,14 +136,16 @@ class _RemountGame extends SpaceGame {
   _RemountGame({required StorageService storage, required AudioService audio})
       : super(storageService: storage, audioService: audio);
 
+  late JoystickComponent testJoystick;
+
   @override
   Future<void> onLoad() async {
     keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
     await controlManager.init();
     controlManager.joystick.removeFromParent();
-    controlManager.joystick = TestJoystick();
-    await add(controlManager.joystick);
+    testJoystick = TestJoystick();
+    await add(testJoystick);
   }
 }
 
@@ -253,12 +252,12 @@ void main() {
     await game.onLoad();
     game.onGameResize(Vector2.all(100));
     await game.ready();
-    game.controlManager.joystick.onGameResize(game.size);
+    game.testJoystick.onGameResize(game.size);
     game.update(0);
     game.update(0);
 
     final player = _RemountPlayer(
-      joystick: game.controlManager.joystick,
+      joystick: game.testJoystick,
       keyDispatcher: game.keyDispatcher,
     );
     await game.add(player);

--- a/test/player_reset_orientation_test.dart
+++ b/test/player_reset_orientation_test.dart
@@ -32,10 +32,10 @@ void main() {
     await game.ready();
     game.resumeEngine();
     game.controlManager.joystick.removeFromParent();
-    game.controlManager.joystick = TestJoystick();
-    await game.add(game.controlManager.joystick);
+    final joystick = TestJoystick();
+    await game.add(joystick);
     game.player
-      ..setJoystick(game.controlManager.joystick)
+      ..setJoystick(joystick)
       ..resetInput();
     game.update(0);
     game.update(0);
@@ -46,8 +46,8 @@ void main() {
       ..position.setValues(20, 20);
 
     // Clear input before restarting.
-    game.controlManager.joystick.delta.setZero();
-    game.controlManager.joystick.relativeDelta.setZero();
+    joystick.delta.setZero();
+    joystick.relativeDelta.setZero();
 
     // Starting a new game should reset orientation and position.
     await game.startGame();

--- a/test/player_rotation_test.dart
+++ b/test/player_rotation_test.dart
@@ -56,16 +56,18 @@ class _TestGame extends SpaceGame {
   _TestGame({required StorageService storage, required AudioService audio})
       : super(storageService: storage, audioService: audio);
 
+  late JoystickComponent testJoystick;
+
   @override
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
     await controlManager.init();
     controlManager.joystick.removeFromParent();
-    controlManager.joystick = TestJoystick();
-    await add(controlManager.joystick);
+    testJoystick = TestJoystick();
+    await add(testJoystick);
     player = _TestPlayer(
-      joystick: controlManager.joystick,
+      joystick: testJoystick,
       keyDispatcher: keyDispatcher,
     );
     await add(player);
@@ -94,8 +96,8 @@ void main() {
     game.update(0);
 
     // Move down; target angle is pi.
-    game.controlManager.joystick.delta.setValues(0, 1);
-    game.controlManager.joystick.relativeDelta.setValues(0, 1);
+    game.testJoystick.delta.setValues(0, 1);
+    game.testJoystick.relativeDelta.setValues(0, 1);
     final input = game.player.inputBehavior;
     input.update(0.05);
     final angleAfterFirstUpdate = game.player.angle;
@@ -105,8 +107,8 @@ void main() {
     expect(angleAfterFirstUpdate, lessThan(math.pi));
 
     // Change direction upward before rotation completes.
-    game.controlManager.joystick.delta.setValues(0, -1);
-    game.controlManager.joystick.relativeDelta.setValues(0, -1);
+    game.testJoystick.delta.setValues(0, -1);
+    game.testJoystick.relativeDelta.setValues(0, -1);
     input.update(0.05);
     expect(game.player.angle, lessThan(angleAfterFirstUpdate));
 

--- a/test/player_shoot_cooldown_test.dart
+++ b/test/player_shoot_cooldown_test.dart
@@ -77,6 +77,8 @@ class _TestGame extends SpaceGame {
   _TestGame({required StorageService storage, required AudioService audio})
       : super(storageService: storage, audioService: audio);
 
+  late JoystickComponent testJoystick;
+
   @override
   PoolManager createPoolManager() => _TestPoolManager(events: eventBus);
 
@@ -86,10 +88,10 @@ class _TestGame extends SpaceGame {
     await add(keyDispatcher);
     await controlManager.init();
     controlManager.joystick.removeFromParent();
-    controlManager.joystick = TestJoystick();
-    await add(controlManager.joystick);
+    testJoystick = TestJoystick();
+    await add(testJoystick);
     player = _TestPlayer(
-      joystick: controlManager.joystick,
+      joystick: testJoystick,
       keyDispatcher: keyDispatcher,
     );
     await add(player);
@@ -113,7 +115,7 @@ void main() {
       ),
     );
     await game.ready();
-    game.controlManager.joystick.onGameResize(game.size);
+    game.testJoystick.onGameResize(game.size);
     game.update(0);
     game.update(0);
 

--- a/test/tractor_aura_test.dart
+++ b/test/tractor_aura_test.dart
@@ -20,7 +20,7 @@ class _TestGame extends SpaceGame {
   Future<void> onLoad() async {
     final keyDispatcher = KeyDispatcher();
     await add(keyDispatcher);
-    joystick = JoystickComponent(
+    final joystick = JoystickComponent(
       knob: CircleComponent(radius: 1),
       background: CircleComponent(radius: 2),
     );


### PR DESCRIPTION
## Summary
- make ControlManager's joystick read-only and final
- expose joystick only through getter on SpaceGame
- update tests to inject their own joystick instances

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3c25c0ce48330b93990650b0b581d