### PR TITLE
Fix service worker asset caching path

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -61,13 +61,12 @@ async function cacheOptionalAssets(cache) {
       ...(cachedManifest.audio || []),
       ...(cachedManifest.fonts || []),
       // Flutter compiles assets under a top-level `assets/` directory for web
-      // builds. Prefix manifest entries so cache.add fetches the actual files,
-      // but avoid double-prefixing if the entry already points inside `assets/`.
+      // builds. The manifest entries may already include an `assets/` prefix,
+      // but the actual files live under `assets/assets/`. Always prefix each
+      // manifest entry so the cached URL matches the compiled output.
     ].map((asset) => {
       const normalized = asset.startsWith("/") ? asset.slice(1) : asset;
-      return normalized.startsWith("assets/")
-        ? normalized
-        : `assets/${normalized}`;
+      return `assets/${normalized}`;
     });
     await cacheAll(cache, assetList);
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure service worker prefixes optional asset paths with `assets/` so cached URLs match Flutter web build output

## Testing
- `scripts/dartw format lib test`
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3c717fe908330bc19a0b32e008678