### PR TITLE
Tweak health heart icon alignment

### DIFF
--- a/lib/ui/health_display.dart
+++ b/lib/ui/health_display.dart
@@ -11,15 +11,26 @@ class HealthDisplay extends StatelessWidget {
   /// Reference to the running game providing health updates.
   final SpaceGame game;
 
+  /// Vertical offset applied to nudge the heart icon upward.
+  static const double _iconVerticalOffset = -2;
+
+  /// Base size used for the heart icon before scaling.
+  static const double _iconBaseSize = 22;
+
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return HudValueDisplay(
       valueListenable: game.health,
-      iconBuilder: (size) => ImageIcon(
-        AssetImage('assets/images/${Assets.healthIcon}'),
-        color: scheme.error,
-        size: size,
+      baseIconSize: _iconBaseSize,
+      iconBuilder: (size) => Transform.translate(
+        // Scale the offset with the icon size so text scaling stays balanced.
+        offset: Offset(0, _iconVerticalOffset * (size / _iconBaseSize)),
+        child: ImageIcon(
+          AssetImage('assets/images/${Assets.healthIcon}'),
+          color: scheme.error,
+          size: size,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Nudge heart icon upward and shrink base size for balanced HUD pill alignment

## Testing
- `./scripts/flutterw analyze`
- `./scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68c3c8da856c833088eb8fcf0ece53ca