### PR TITLE
refactor: simplify menu overlay player sizing

### DIFF
--- a/lib/ui/menu_overlay.dart
+++ b/lib/ui/menu_overlay.dart
@@ -22,9 +22,11 @@ class MenuOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return OverlayLayout(
       builder: (context, spacing, iconSize) {
-        final shortestSide = spacing / 0.02;
+        // `spacing` represents 2% of the shortest screen side (see
+        // [OverlayLayout]), so multiplying by 6 yields the same value as
+        // `shortestSide * 0.12` without recalculating the original dimension.
         final playerSize = math.min(
-          shortestSide * 0.12,
+          spacing * 6,
           Constants.playerSize *
               (Constants.spriteScale + Constants.playerScale),
         );


### PR DESCRIPTION
## Summary
- simplify player preview sizing in the menu overlay by deriving it directly from the responsive spacing

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d2aaa17483308fd272394a23900d