### PR TITLE
Ensure high score updates reflect storage success

### DIFF
--- a/lib/services/score_service.dart
+++ b/lib/services/score_service.dart
@@ -40,14 +40,19 @@ class ScoreService {
   ///
   /// Returns `true` if the underlying storage was successfully updated.
   Future<bool> resetHighScore() async {
-    highScore.value = 0;
-    return storageService.resetHighScore();
+    final success = await storageService.resetHighScore();
+    if (success) {
+      highScore.value = 0;
+    }
+    return success;
   }
 
   Future<void> updateHighScoreIfNeeded() async {
     if (score.value > highScore.value) {
-      highScore.value = score.value;
-      await storageService.setHighScore(highScore.value);
+      final success = await storageService.setHighScore(score.value);
+      if (success) {
+        highScore.value = score.value;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Only reset high score after storage removal succeeds
- Write high score to storage before updating in-memory value
- Test ScoreService behavior when storage writes or resets fail

## Testing
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68c3d2aaa17483308fd272394a23900d