### PR TITLE
refactor: modularize SpaceGame setup

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -138,10 +138,9 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
 
 - [ ] Split the `SpaceGame` class into focused modules so each file stays under the
       ~300‑line guideline.
-      - Extract service setup into a dedicated `game_services.dart` or similar.
-      - Move world construction logic into a `WorldBuilder` module.
-      - Create an `OverlayCoordinator` to manage overlays and state changes.
-      - Isolate gameplay flow helpers (damage, scoring, pause/resume, reset, game over)
+      - [x] Extract service setup into a dedicated `game_services.dart` or similar.
+      - [x] Move world construction logic into a `world_builder.dart` module.
+      - [x] Create an `OverlayCoordinator` to manage overlays and state changes.
+      - [ ] Isolate gameplay flow helpers (damage, scoring, pause/resume, reset, game over)
         into a `GameFlow` helper.
-      - Move debug toggles and lifecycle disposal into dedicated helpers or mixins.
-
+      - [ ] Move debug toggles and lifecycle disposal into dedicated helpers or mixins.

--- a/lib/game/game_services.dart
+++ b/lib/game/game_services.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../services/asset_lifecycle_service.dart';
+import '../services/targeting_service.dart';
+import '../services/upgrade_service.dart';
+import 'control_manager.dart';
+import 'health_regen_system.dart';
+import 'pool_manager.dart';
+import 'starfield_manager.dart';
+import 'space_game.dart';
+
+/// Sets up game-wide services and managers.
+void initGameServices(SpaceGame game) {
+  final storedIndex = game.storageService.getPlayerSpriteIndex();
+  if (storedIndex != game.selectedPlayerIndex.value) {
+    unawaited(
+      game.storageService.setPlayerSpriteIndex(game.selectedPlayerIndex.value),
+    );
+  }
+  game.settingsService.attachStorage(game.storageService);
+  game.debugMode = kDebugMode;
+  game.pools = PoolManager(events: game.eventBus);
+  game.targetingService = TargetingService(game.eventBus);
+  game.upgradeService = UpgradeService(
+    scoreService: game.scoreService,
+    storageService: game.storageService,
+    settingsService: game.settingsService,
+  );
+  game.healthRegen = HealthRegenSystem(
+    scoreService: game.scoreService,
+    upgradeService: game.upgradeService,
+  );
+  game.starfieldManager = StarfieldManager(
+    game: game,
+    settings: game.settingsService,
+    debugMode: game.debugMode,
+  );
+  game.controlManager = ControlManager(
+    game: game,
+    settings: game.settingsService,
+    colorScheme: game.colorScheme,
+  );
+  game.assetLifecycle = AssetLifecycleService(
+    game: game,
+    audioService: game.audioService,
+  );
+}

--- a/lib/game/overlay_coordinator.dart
+++ b/lib/game/overlay_coordinator.dart
@@ -1,0 +1,70 @@
+import '../services/overlay_service.dart';
+import '../ui/help_overlay.dart';
+import 'lifecycle_manager.dart';
+import 'game_state_machine.dart';
+import 'shortcut_manager.dart' as game_shortcuts;
+import 'ui_controller.dart';
+import 'space_game.dart';
+
+/// Coordinates overlay setup and state transitions.
+class OverlayCoordinator {
+  OverlayCoordinator({required this.game});
+
+  final SpaceGame game;
+
+  late final OverlayService overlayService;
+  late final LifecycleManager lifecycle;
+  late final GameStateMachine stateMachine;
+  late final UiController ui;
+  late final game_shortcuts.ShortcutManager shortcuts;
+
+  Future<void> init() async {
+    overlayService = OverlayService(game);
+    lifecycle = LifecycleManager(game);
+    stateMachine = GameStateMachine(
+      overlays: overlayService,
+      onStart: lifecycle.onStart,
+      // Keep the engine running when paused so HUD tweaks render live.
+      onPause: () {},
+      onResume: () {},
+      onGameOver: lifecycle.onGameOver,
+      onMenu: lifecycle.onMenu,
+      onEnterUpgrades: () {
+        game.pauseEngine();
+        game.miningLaser?.stopSound();
+      },
+      onExitUpgrades: () {
+        game.resumeEngine();
+        game.focusGame();
+      },
+    );
+
+    ui = UiController(
+      overlayService: overlayService,
+      stateMachine: stateMachine,
+      player: () => game.player,
+      miningLaser: () => game.miningLaser,
+      pauseEngine: game.pauseEngine,
+      resumeEngine: game.resumeEngine,
+      focusGame: game.focusGame,
+    );
+
+    shortcuts = game_shortcuts.ShortcutManager(
+      keyDispatcher: game.keyDispatcher,
+      stateMachine: stateMachine,
+      audioService: game.audioService,
+      pauseGame: game.pauseGame,
+      resumeGame: game.resumeGame,
+      startGame: () => game.startGame(),
+      toggleHelp: ui.toggleHelp,
+      toggleUpgrades: ui.toggleUpgrades,
+      toggleDebug: game.toggleDebug,
+      toggleMinimap: ui.toggleMinimap,
+      toggleRangeRings: ui.toggleRangeRings,
+      toggleSettings: ui.toggleSettings,
+      returnToMenu: game.returnToMenu,
+      isHelpVisible: () => game.overlays.isActive(HelpOverlay.id),
+    );
+    stateMachine.returnToMenu();
+  }
+}

--- a/lib/game/world_builder.dart
+++ b/lib/game/world_builder.dart
@@ -1,0 +1,26 @@
+import '../components/player.dart';
+import '../components/mining_laser.dart';
+import '../components/enemy_spawner.dart';
+import '../components/asteroid_spawner.dart';
+import 'space_game.dart';
+
+/// Builds the initial game world and attaches core components.
+Future<void> buildWorld(SpaceGame game) async {
+  game.player = PlayerComponent(
+    joystick: game.controlManager.joystick,
+    keyDispatcher: game.keyDispatcher,
+    spritePath: game.selectedPlayerSprite,
+  );
+  await game.add(game.player);
+  game.camera.follow(game.player, snap: true);
+  final laser = MiningLaserComponent(player: game.player);
+  game.miningLaser = laser;
+  await game.add(laser);
+
+  await game.controlManager.attachPlayer(game.player);
+
+  game.enemySpawner = EnemySpawner();
+  game.asteroidSpawner = AsteroidSpawner();
+  await game.add(game.enemySpawner);
+  await game.add(game.asteroidSpawner);
+}


### PR DESCRIPTION
## Summary
- extract service initialization to `game_services.dart`
- move world construction into `world_builder.dart`
- introduce `OverlayCoordinator` and wire it into `SpaceGame`
- update refactoring checklist in `TASKS.md`

## Testing
- `./scripts/dartw analyze`
- `./scripts/flutterw test --concurrency 5`
- `./scripts/markdownlint.sh TASKS.md`


------
https://chatgpt.com/codex/tasks/task_e_68c3d47ac0d88330af0640a75ccb1da4