### PR TITLE
Optimize nearest component lookup with early exit

### DIFF
--- a/lib/util/nearest_component.dart
+++ b/lib/util/nearest_component.dart
@@ -22,6 +22,10 @@ extension NearestComponent<T extends PositionComponent> on Iterable<T> {
       }
       final distanceSquared = component.position.distanceToSquared(origin);
       if (distanceSquared < closestDistanceSquared) {
+        if (distanceSquared == 0) {
+          // Can't be closer than this; exit early.
+          return component;
+        }
         closest = component;
         closestDistanceSquared = distanceSquared;
       }


### PR DESCRIPTION
## Summary
- short-circuit nearest-component search when the distance is zero
- remove unneeded zero-distance regression test

## Testing
- `scripts/dartw analyze`
- `scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d2aaa17483308fd272394a23900d