### PR TITLE
Fix high score persistence race

### DIFF
--- a/lib/services/score_service.dart
+++ b/lib/services/score_service.dart
@@ -48,10 +48,11 @@ class ScoreService {
   }
 
   Future<void> updateHighScoreIfNeeded() async {
-    if (score.value > highScore.value) {
-      final success = await storageService.setHighScore(score.value);
+    final currentScore = score.value;
+    if (currentScore > highScore.value) {
+      final success = await storageService.setHighScore(currentScore);
       if (success) {
-        highScore.value = score.value;
+        highScore.value = currentScore;
       }
     }
   }


### PR DESCRIPTION
## Summary
- capture current score before writing to storage
- persist consistent high score value

## Testing
- `./scripts/dartw analyze lib/services/score_service.dart`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3db674cfc83309cb000d94a1a19e8