### PR TITLE
Dispose superseded starfields during rebuild

### DIFF
--- a/lib/game/starfield_manager.dart
+++ b/lib/game/starfield_manager.dart
@@ -84,6 +84,16 @@ class StarfieldManager {
       gamma: settings.starfieldGamma.value,
     );
     if (buildId != null && buildId != _rebuildId) {
+      // A newer rebuild was scheduled while this one was in progress.
+      // Fade out the old component to ensure it's removed and its cache is
+      // released even though this build result will be discarded.
+      previous?.add(
+        OpacityEffect.to(
+          0,
+          EffectController(duration: _fadeDuration),
+          onComplete: () => previous.removeFromParent(),
+        ),
+      );
       return;
     }
     _starfield = sf;


### PR DESCRIPTION
## Summary
- fade out and remove previous starfield when a rebuild is superseded

## Testing
- `scripts/flutterw analyze`
- `scripts/flutterw test`

------
https://chatgpt.com/codex/tasks/task_e_68c3db5d1a708330a375ac4bbbe31089