### PR TITLE
refactor: extract game flow helper

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -141,6 +141,7 @@ for context, and milestone docs (`milestone-*.md`) for detailed goals.
       - [x] Extract service setup into a dedicated `game_services.dart` or similar.
       - [x] Move world construction logic into a `world_builder.dart` module.
       - [x] Create an `OverlayCoordinator` to manage overlays and state changes.
-      - [ ] Isolate gameplay flow helpers (damage, scoring, pause/resume, reset, game over)
+      - [x] Isolate gameplay flow helpers (damage, scoring, pause/resume, reset, game over)
         into a `GameFlow` helper.
-      - [ ] Move debug toggles and lifecycle disposal into dedicated helpers or mixins.
+      - [ ] Move debug toggles into a dedicated `GameDebugHelper` mixin.
+      - [ ] Extract service disposal into a `GameDisposal` helper.

--- a/lib/game/game_flow.dart
+++ b/lib/game/game_flow.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:flame/components.dart';
+
+import '../components/explosion.dart';
+import 'space_game.dart';
+
+/// Handles high-level gameplay flow actions like scoring, damage and state
+/// transitions.
+class GameFlow {
+  GameFlow(this.game);
+
+  final SpaceGame game;
+
+  /// Handles player damage and checks for game over.
+  void hitPlayer() {
+    if (!game.stateMachine.isPlaying) {
+      return;
+    }
+    game.player.flashDamage();
+    if (game.scoreService.hitPlayer()) {
+      game.add(ExplosionComponent(position: game.player.position.clone()));
+      game.audioService.playExplosion();
+      game.player.removeFromParent();
+      game.stateMachine.gameOver();
+    }
+  }
+
+  /// Adds [value] to the current score.
+  void addScore(int value) => game.scoreService.addScore(value);
+
+  /// Adds [value] to the current mineral count.
+  void addMinerals(int value) => game.scoreService.addMinerals(value);
+
+  /// Resets the shield regeneration timer.
+  void resetHealthRegenTimer() => game.healthRegen.reset();
+
+  /// Pauses the game and shows the `PAUSED` overlay.
+  void pauseGame() => game.assetLifecycle.pauseGame();
+
+  /// Resumes the game from a paused state.
+  void resumeGame() => game.assetLifecycle.resumeGame();
+
+  /// Returns to the main menu without restarting the session.
+  void returnToMenu() => game.stateMachine.returnToMenu();
+
+  /// Begins loading assets needed for gameplay.
+  ///
+  /// Safe to call multiple times; subsequent invocations are ignored.
+  void startLoadingAssets() => game.assetLifecycle.startLoadingAssets();
+
+  /// Starts a new game session.
+  Future<void> startGame() => game.assetLifecycle.startGame();
+
+  /// Clears the saved high score.
+  ///
+  /// Returns `true` if the score was removed from storage.
+  Future<bool> resetHighScore() => game.scoreService.resetHighScore();
+
+  /// Transitions to the game over state.
+  void gameOver() => game.stateMachine.gameOver();
+}


### PR DESCRIPTION
## Summary
- isolate gameplay flow logic into new `GameFlow` helper
- delegate scoring, damage and game-state methods from `SpaceGame` to `GameFlow`
- note remaining refactor work in `TASKS.md`

## Testing
- `./scripts/dartw format lib/game/space_game.dart lib/game/game_flow.dart`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3db4d0fcc83309f19af16f405357e