### PR TITLE
Remove unused Flame import causing analysis warning

### DIFF
--- a/lib/game/game_flow.dart
+++ b/lib/game/game_flow.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:flame/components.dart';
-
 import '../components/explosion.dart';
 import 'space_game.dart';
 


### PR DESCRIPTION
## Summary
- remove unused `flame/components.dart` import from `GameFlow`

## Testing
- `./scripts/flutterw analyze --no-pub`
- `./scripts/flutterw test`


------
https://chatgpt.com/codex/tasks/task_e_68c3f4fe35d483308300afcc880fb1b3