### PR TITLE
chore: remove deprecated service worker variable

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -78,7 +78,7 @@
       // own `sw.js` above. This prevents Flutter's loader from waiting four
       // seconds for `flutter_service_worker.js`, which would otherwise log a
       // noisy console error when it times out.
-      var serviceWorkerVersion = null;
+      window.flutterConfiguration = { serviceWorker: null };
     </script>
     <script src="flutter_bootstrap.js" async></script>
   </body>


### PR DESCRIPTION
## Summary
- remove legacy `serviceWorkerVersion` variable
- configure flutter web bootstrap to disable default service worker

## Testing
- `./scripts/flutterw test` *(interrupted after hanging at loading tests)*
- `./scripts/flutterw analyze` *(interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68c3f4f283fc8330a2cb45a536bd6301