### PR TITLE
Disable default Flutter service worker

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -73,13 +73,21 @@
       }
     </script>
     <script src="segmenter_polyfill.js"></script>
+    <script src="flutter.js" defer></script>
     <script>
       // Disable Flutter's default service worker bootstrap since we register our
-      // own `sw.js` above. This prevents Flutter's loader from waiting four
-      // seconds for `flutter_service_worker.js`, which would otherwise log a
-      // noisy console error when it times out.
-      window.flutterConfiguration = { serviceWorker: null };
+      // own `sw.js` above. Passing `serviceWorkerSettings: null` prevents the
+      // Flutter loader from waiting for `flutter_service_worker.js`, which would
+      // otherwise log a noisy console error when it times out.
+      window.addEventListener('load', function () {
+        _flutter.loader
+          .loadEntrypoint({ serviceWorkerSettings: null })
+          .then(function (engineInitializer) {
+            engineInitializer.initializeEngine().then(function (appRunner) {
+              appRunner.runApp();
+            });
+          });
+      });
     </script>
-    <script src="flutter_bootstrap.js" async></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- disable Flutter's generated service worker by manually bootstrapping with `serviceWorkerSettings: null`

## Testing
- `./scripts/dartw format web/index.html` *(fails: The '===' operator is not supported...)*
- `./scripts/flutterw test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68c4c3d28e2083309f3a55647ef71baa)