### PR TITLE
Refine overlay toggle tests

### DIFF
--- a/test/help_overlay_test.dart
+++ b/test/help_overlay_test.dart
@@ -1,40 +1,27 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter/widgets.dart';
-
+import 'package:space_game/ui/help_overlay.dart';
 import 'package:space_game/game/space_game.dart';
-import 'package:space_game/game/game_state.dart';
 import 'package:space_game/services/audio_service.dart';
 import 'package:space_game/services/storage_service.dart';
-import 'package:space_game/ui/help_overlay.dart';
-import 'package:space_game/ui/menu_overlay.dart';
-import 'package:space_game/ui/hud_overlay.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/widgets.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('toggleHelp pauses and resumes the game', () async {
+  testWidgets('shows controls help content', (tester) async {
     SharedPreferences.setMockInitialValues({});
     final storage = await StorageService.create();
     final audio = await AudioService.create(storage);
     final game = SpaceGame(storageService: storage, audioService: audio);
-    game.overlays.addEntry(MenuOverlay.id, (_, __) => const SizedBox());
-    await game.onLoad();
-    game.overlays.addEntry(HelpOverlay.id, (_, __) => const SizedBox());
-    game.overlays.addEntry(HudOverlay.id, (_, __) => const SizedBox());
 
-    game.stateMachine.state = GameState.playing;
-    game.overlayService.showHud();
-    game.resumeEngine();
-    expect(game.overlays.isActive(HelpOverlay.id), isFalse);
-    expect(game.paused, isFalse);
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: HelpOverlay(game: game),
+    ));
 
-    game.ui.toggleHelp();
-    expect(game.overlays.isActive(HelpOverlay.id), isTrue);
-    expect(game.paused, isTrue);
-
-    game.ui.toggleHelp();
-    expect(game.overlays.isActive(HelpOverlay.id), isFalse);
-    expect(game.paused, isFalse);
+    expect(find.text('Controls'), findsOneWidget);
+    expect(find.textContaining('Move: WASD / Arrow keys'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
   });
 }

--- a/test/overlay_service_test.dart
+++ b/test/overlay_service_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flame/game.dart';
 
+import 'package:space_game/game/game_state.dart';
+import 'package:space_game/game/game_state_machine.dart';
+import 'package:space_game/game/ui_controller.dart';
 import 'package:space_game/services/overlay_service.dart';
 import 'package:space_game/ui/game_over_overlay.dart';
 import 'package:space_game/ui/help_overlay.dart';
@@ -141,5 +144,46 @@ void main() {
     expect(game.overlays.isActive(UpgradesOverlay.id), isFalse);
     expect(game.overlays.isActive(HelpOverlay.id), isFalse);
     expect(game.overlays.isActive(HudOverlay.id), isTrue);
+  });
+
+  test('toggleHelp pauses during play and resumes on close', () {
+    final game = _createGame();
+    final overlayService = OverlayService(game);
+
+    var paused = false;
+    var resumed = false;
+    var focused = false;
+    final stateMachine = GameStateMachine(
+      overlays: overlayService,
+      onStart: () {},
+      onPause: () {},
+      onResume: () {},
+      onGameOver: () {},
+      onMenu: () {},
+      onEnterUpgrades: () {},
+      onExitUpgrades: () {},
+    );
+    stateMachine.state = GameState.playing;
+
+    final controller = UiController(
+      overlayService: overlayService,
+      stateMachine: stateMachine,
+      player: () => throw UnimplementedError(),
+      miningLaser: () => null,
+      pauseEngine: () => paused = true,
+      resumeEngine: () => resumed = true,
+      focusGame: () => focused = true,
+    );
+
+    controller.toggleHelp();
+
+    expect(game.overlays.isActive(HelpOverlay.id), isTrue);
+    expect(paused, isTrue);
+
+    controller.toggleHelp();
+
+    expect(game.overlays.isActive(HelpOverlay.id), isFalse);
+    expect(resumed, isTrue);
+    expect(focused, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- add UiController-based toggleHelp coverage to overlay service tests
- simplify help overlay widget test to assert UI content instead of toggle behaviour

## Testing
- ./scripts/flutterw test test/overlay_service_test.dart test/help_overlay_test.dart


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69212b1bcabc833083679552d67dd3dd)