### PR TITLE
Remove unused import from nebula layer

### DIFF
--- a/lib/components/nebula_layer.dart
+++ b/lib/components/nebula_layer.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flame/components.dart';


### PR DESCRIPTION
## Summary
- remove unused typed data import from the nebula layer component

## Testing
- scripts/flutterw analyze --no-pub

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925895456388330b9961f412bbde98f)